### PR TITLE
add gitbook necessary structure

### DIFF
--- a/docs/.gitbook.yaml
+++ b/docs/.gitbook.yaml
@@ -1,0 +1,5 @@
+root: ./docs/
+
+structure:
+  readme: ./README.md
+  summary: ./SUMMARY.md

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,11 @@
+# Summary
+
+* [README](./README.md)
+
+## Installation
+* [Installation](./InstallInstructions.md)
+
+## Contributing and Community
+* [Contributing](./CONTRIBUTING.md)
+* [Dojo](./Dojo.md)
+* [License](./LICENSE.md)


### PR DESCRIPTION
This is really just to kickstart the docs and allow GitBook to generate the site. I included 5 basic files in there, but we can easily add more or remove all but the README if you guys prefer.

Note that the files needed for GitBook to generate the website need to be in the `./docs/` directory, as this is the one we'll designate to GitBook as the "root" of the docs.