### PR TITLE
Add FAQ structures and questions

### DIFF
--- a/FAQ/FAQ-Contribution.md
+++ b/FAQ/FAQ-Contribution.md
@@ -1,0 +1,10 @@
+# Contributions to Wasabi
+- Who is contributing to Wasabi already?
+- How can I get help and support?
+- What does the Wasabi project need help with?
+- How can I report a bug?
+- How can I request a feature?
+- How should I start contributing code?
+- Who verifies the pull requests? 
+- Is there a bounty program?
+- What is on the future roadmap of Wasabi development?

--- a/FAQ/FAQ-GeneralBitcoinPrivacy.md
+++ b/FAQ/FAQ-GeneralBitcoinPrivacy.md
@@ -1,0 +1,7 @@
+## General Bitcoin Privacy
+- I have nothing to hide, do I still need financial privacy?
+- How is Bitcoin good in terms of privacy?
+- How is Bitcoin bad in terms of privacy?
+- Why is it important to use a new address for every payment?
+- Why is it important for my privacy to run a full node?
+- How does Tor protect my network-level privacy? 

--- a/FAQ/FAQ-GeneralBitcoinPrivacy.md
+++ b/FAQ/FAQ-GeneralBitcoinPrivacy.md
@@ -1,4 +1,4 @@
-## General Bitcoin Privacy
+# General Bitcoin Privacy
 - I have nothing to hide, do I still need financial privacy?
 - How is Bitcoin good in terms of privacy?
 - How is Bitcoin bad in terms of privacy?

--- a/FAQ/FAQ-Installation.md
+++ b/FAQ/FAQ-Installation.md
@@ -6,16 +6,16 @@
 - How do I install Wasabi on iOS?
 - How do I check the current version of Wasabi?
 - How do I know about a new version of Wasabi?
-- How do I securely upgrade Wasabi?
+- [How do I securely upgrade Wasabi?](/FAQ/FAQ-Installation.md#how-do-i-securely-upgrade-wasabi)
 - How do I compile Wasabi from source?
 - How can I install Wasabi headless daemon without GUI?
 - How do I check the deterministic builds?
 - How do I install the Wasabi backend server?
-- Do I need to install Tor separately?
+- [Do I need to install Tor separately?](/FAQ/FAQ-Installation.md#do-i-need-to-install-tor-separately)
+
+### How do I securely upgrade Wasabi?
+You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion). Make sure you also download the signatures of the build and verify them for [Adam Ficsor's public key.](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) For step by step instructions, follow [this guide](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/InstallInstructions.md) or [see this video](https://youtu.be/DUc9A76rwX4).
 
 ### Do I need to install Tor separately?
 All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself. If you do already have Tor, and it is running, then Wasabi will try to use that first.  
 You can turn off Tor in the Settings. Note that in this case you are still private, except when you coinjoin and when you broadcast a transaction. In the first case, the coordinator would know the links between your inputs and outputs based on your IP address. In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
-
-### How do I securely upgrade Wasabi?
-You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion). Make sure you also download the signatures of the build and verify them for [Adam Ficsor's public key.](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) For step by step instructions, follow [this guide](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/InstallInstructions.md) or [see this video](https://youtu.be/DUc9A76rwX4).

--- a/FAQ/FAQ-Installation.md
+++ b/FAQ/FAQ-Installation.md
@@ -1,0 +1,14 @@
+## Installation of Wasabi
+- Where can I download Wasabi?
+- Why is it important to verify PGP signatures?
+- How do I install Wasabi on Linux?
+- How do I install Wasabi on Microsoft?
+- How do I install Wasabi on iOS?
+- How do I check the current version of Wasabi?
+- How do I know about a new version of Wasabi?
+- How do I securely upgrade Wasabi?
+- How do I compile Wasabi from source?
+- How can I install Wasabi headless daemon without GUI?
+- How do I check the deterministic builds?
+- How do I install the Wasabi backend server?
+- Do I need to install Tor separately?

--- a/FAQ/FAQ-Installation.md
+++ b/FAQ/FAQ-Installation.md
@@ -12,3 +12,10 @@
 - How do I check the deterministic builds?
 - How do I install the Wasabi backend server?
 - Do I need to install Tor separately?
+
+### Do I need to install Tor separately?
+All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself. If you do already have Tor, and it is running, then Wasabi will try to use that first.  
+You can turn off Tor in the Settings. Note that in this case you are still private, except when you coinjoin and when you broadcast a transaction. In the first case, the coordinator would know the links between your inputs and outputs based on your IP address. In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
+
+### How do I securely upgrade Wasabi?
+You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion). Make sure you also download the signatures of the build and verify them for [Adam Ficsor's public key.](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) For step by step instructions, follow [this guide](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/InstallInstructions.md) or [see this video](https://youtu.be/DUc9A76rwX4).

--- a/FAQ/FAQ-Installation.md
+++ b/FAQ/FAQ-Installation.md
@@ -1,4 +1,4 @@
-## Installation of Wasabi
+# Installation of Wasabi
 - Where can I download Wasabi?
 - Why is it important to verify PGP signatures?
 - How do I install Wasabi on Linux?

--- a/FAQ/FAQ-Installation.md
+++ b/FAQ/FAQ-Installation.md
@@ -13,6 +13,8 @@
 - How do I install the Wasabi backend server?
 - [Do I need to install Tor separately?](/FAQ/FAQ-Installation.md#do-i-need-to-install-tor-separately)
 
+---
+
 ### How do I securely upgrade Wasabi?
 You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion). Make sure you also download the signatures of the build and verify them for [Adam Ficsor's public key.](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) For step by step instructions, follow [this guide](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/InstallInstructions.md) or [see this video](https://youtu.be/DUc9A76rwX4).
 

--- a/FAQ/FAQ-Introduction.md
+++ b/FAQ/FAQ-Introduction.md
@@ -1,4 +1,4 @@
-## Introduction to Wasabi
+# Introduction to Wasabi
 - Explain Wasabi like I'm 5
 - What is the history of Wasabi?
 - What is a coin join?

--- a/FAQ/FAQ-Introduction.md
+++ b/FAQ/FAQ-Introduction.md
@@ -1,17 +1,17 @@
 # Introduction to Wasabi
 - Explain Wasabi like I'm 5
 - What is the history of Wasabi?
-- What is a coin join?
+- [What is a coin join?](/FAQ/FAQ-Introduction.md#what-is-a-coin-join)
 - How does Zero Link differ from other coin join implementations?
-- Do I need to trust Wasabi with my coins?
-- What is the privacy I get after mixing with Wasabi?
-- Can I hurt my privacy with Wasabi?
+- [Do I need to trust Wasabi with my coins?](/FAQ/FAQ-Introduction.md#do-i-need-to-trust-wasabi-with-my-coins)
+- [What is the privacy I get after mixing with Wasabi?](/FAQ/FAQ-Introduction.md#what-is-the-privacy-i-get-after-mixing-with-wasabi)
+- [Can I hurt my privacy with Wasabi?](/FAQ/FAQ-Introduction.md#can-i-hurt-my-privacy-with-wasabi)
 - Who can use Wasabi?
 - Who is contributing to Wasabi?
 - What are the minimal requirements to run Wasabi?
 - Why is Wasabi libre and open source software?
 - Why is Wasabi Bitcoin-only?
-- Does Wasabi have a warrant canary?
+- [Does Wasabi have a warrant canary?](/FAQ/FAQ-Introduction.md#does-wasabi-have-a-warrant-canary)
 - What do peers say about Wasabi?
 
 ### What is a coin join?

--- a/FAQ/FAQ-Introduction.md
+++ b/FAQ/FAQ-Introduction.md
@@ -13,3 +13,32 @@
 - Why is Wasabi Bitcoin-only?
 - Does Wasabi have a warrant canary?
 - What do peers say about Wasabi?
+
+### What is a coin join?
+A mechanism by which multiple participants combine their coins (or UTXOs, to be more precise) into one large transaction with multiple inputs and multiple outputs. An observer cannot determine which output belongs to which input, and neither can the participants themselves. This makes it difficult for outside parties to trace where a particular coin originated from and where it was sent to (as opposed to regular bitcoin transactions, where there is usually one sender and one receiver).  
+
+In very simple terms, coinjoin means: “when you want to make a transaction, find someone else who also wants to make a transaction and make a joint transaction together”.  
+
+See also: https://en.bitcoin.it/wiki/CoinJoin
+
+### Do I need to trust Wasabi with my coins?
+No, Wasabi's coinjoin implementation is trustless by design. The participants do not need to trust each other or any third party. Both the sending address (the coinjoin input) and the receiving address (the coinjoin output) are controlled by your own private keys. Wasabi merely coordinates the process of combining the inputs of the participants into one single transaction, but the wallet can neither steal your coins, nor figure out which outputs belong to which inputs (look up “[Chaumian Coinjoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin)” if you want to know more).
+
+### What is the privacy I get after mixing with Wasabi?
+This depends on how you handle your outputs after the coinjoin. There are some ways how you can unintentionally undo the mixing by being careless. For example, if you make a 1.8 BTC transaction into Wasabi, do the coinjoin, and then make one single outgoing transaction of 1.8 BTC, a third party observer can reasonably assume that both transactions belong to one single entity, due to both amounts being virtually the same even though if they have been through a coinjoin. In this scenario, Wasabi will barely make any improvement to your privacy, although it will still have a protective effect against unsophisticated observers.  
+
+Another deanonymizing scenario happens when you combine mixed outputs with unmixed ones when sending: a third party will be able to make the connection between them as belonging to the same sender.
+
+The practice of being careful with your post-mix outputs is commonly facilitated through coin control, which is the default way of interacting with the wallet. Find out more about coin control it [here](https://medium.com/@nopara73/coin-control-is-must-learn-if-you-care-about-your-privacy-in-bitcoin-33b9a5f224a2).
+
+### Can I hurt my privacy using Wasabi?
+No. The worst thing that can happen (through user’s negligence post-mix) is that the level of your privacy stays the same as before coinjoin. It is crucial to understand that Wasabi is not a fool-proof solution if you neglect to practice coin control after the mixing process.
+
+### Does Wasabi have a warrant canary?
+The nature of Wasabi is that you should not need to trust the developers or the Wasabi coordinating server, as you can verify that the code does not leak information to anyone. The developers have gone to great lengths in an attempt to ensure that the coordinator cannot steal funds nor harvest information (for example, the outputs sent from your Wasabi Wallet are blinded, meaning that even the Wasabi server cannot link the outputs to the inputs). 
+
+The only known possible 'malicious' actions that the server *could* perform are two sides of the same coin;
+- Blacklisted UTXO's
+Though this would not affect the users who are able to successfully mix with other 'honest/real' peers. 
+- Targeted Sybil Attack
+The follow-up concern is the inverse of the above. It is possible that the server could *only* include one 'honest/real' coin in the mix and supply the other coins themselves. This would give a false sense of security, **but it would not worsen the existing privacy of the coin**. It would also be noticaable to all users excluding the user being targeted as their coins would not be mixed. It has been argued that this 'attack' would be very costly in terms of fees because the number of coins being mixed is verifiable. Though it is true that fees would have to be paid to zkSNACKs every round, this does not matter if it is zkSNACKs that is acting maliciously (as they get the funds back). Typical rounds currently have <100 people per mix, with the minimum input being ~0.1 BTC with a fee of 0.003% per anonymity set. Taking the 'worst case' (100 people, each mixing 0.1 BTC) gives 0.03 BTC per round. This is not prohibitive and is thus a valid concern. That said, if multiple chain-analysis companies attempt to flood the zkSNACKs mix (to decrease the true anonymity set) they will hinder each other's efforts (unless they are cooperating). See [here](https://github.com/nopara73/ZeroLink/#e-sybil-attack) for more info.

--- a/FAQ/FAQ-Introduction.md
+++ b/FAQ/FAQ-Introduction.md
@@ -14,6 +14,8 @@
 - [Does Wasabi have a warrant canary?](/FAQ/FAQ-Introduction.md#does-wasabi-have-a-warrant-canary)
 - What do peers say about Wasabi?
 
+---
+
 ### What is a coin join?
 A mechanism by which multiple participants combine their coins (or UTXOs, to be more precise) into one large transaction with multiple inputs and multiple outputs. An observer cannot determine which output belongs to which input, and neither can the participants themselves. This makes it difficult for outside parties to trace where a particular coin originated from and where it was sent to (as opposed to regular bitcoin transactions, where there is usually one sender and one receiver).  
 

--- a/FAQ/FAQ-Introduction.md
+++ b/FAQ/FAQ-Introduction.md
@@ -1,0 +1,15 @@
+## Introduction to Wasabi
+- Explain Wasabi like I'm 5
+- What is the history of Wasabi?
+- What is a coin join?
+- How does Zero Link differ from other coin join implementations?
+- Do I need to trust Wasabi with my coins?
+- What is the privacy I get after mixing with Wasabi?
+- Can I hurt my privacy with Wasabi?
+- Who can use Wasabi?
+- Who is contributing to Wasabi?
+- What are the minimal requirements to run Wasabi?
+- Why is Wasabi libre and open source software?
+- Why is Wasabi Bitcoin-only?
+- Does Wasabi have a warrant canary?
+- What do peers say about Wasabi?

--- a/FAQ/FAQ-UseWasabi.md
+++ b/FAQ/FAQ-UseWasabi.md
@@ -40,6 +40,7 @@
 ## Coin Join
 - How can I select UTXOs for coin join?
 - What are the denominations created in one round?
+- Can I mix more than the round's minimum?
 - What is the anonymity set?
 - How much anonymity set do I need?
 - How many rounds should I coin join?
@@ -80,3 +81,107 @@
 - What can I do with small change?
 - Which coins can I select for coin joins?
 - How can I mix large amounts?
+
+## Wallet Manager
+
+
+## Synchronization
+
+
+## Receive
+### Why does Wasabi only use SegWit bech32 addresses?
+Wasabi generates Bech32 addresses only, also known as bc1 addresses or native SegWit addresses. These addresses start with the characters `bc1...` Some wallets/exchanges do not yet support this type of address and may give an error message (e.g. "unknown bitcoin address"). The solution is to manage your funds with a wallet which does support Bech32, [see list](https://en.bitcoin.it/wiki/Bech32_adoption).
+
+Be careful, if you send all your coins from an old wallet to a new wallet (from the table above) in one transaction then you will merge all your coins which is bad for privacy - instead, **send the coins individually** or if possible **import the seed in the new wallet**.
+
+
+## Send
+
+
+## History
+
+
+## Coin Join
+### What are the fees for the coin join?
+You currently pay a fee of 0.003% * anonymity set. If the anonymity set of a coin is 50 then you pay 0.003% * 50 (=0.15%). If you set the target anonymity set to 53 then Wasabi will continue mixing until this is reached, so you may end up with an anonymity set of say 60, and you will pay 0.003% * 60 (=0.18%).  
+There are also edge cases where you do not pay the full fee or where you pay more. For example if you're the smallest registrant to a round, you will never pay a fee. Also when you are remixing and you cannot pay the full fee with your input, then you only pay as much as you have, but if the change amount leftover would be too small, then that is also added to the fee. Currently the minimum change amount to be paid out is 0.7% of the base denomination (~0.1BTC.)  
+It is also possible that you get more back from mixing than you put in. This happens when network fees go down between the start of the round and its end. In this case, the difference is split between the active outputs of the mix.
+
+### What is the anonymity set?
+The anonymity set is effectively the size of the group you are hiding in. 
+
+If 3 people take part in a CoinJoin (with equal size inputs) and there are 3 outputs then each of those output coins has an anonymity set of 3.
+
+```
+0.1 BTC (Alice)       0.1 BTC (Anon set 3)
+0.3 BTC (Bob) 	  ->  0.1 BTC (Anon set 3)
+0.4 BTC (Charlie)     0.1 BTC (Anon set 3)
+                      0.2 BTC (Change Coin Bob)
+                      0.3 BTC (Change Coin Charlie)
+```
+
+There is no way to know which of the anon set output coins are owned by which of the input owners.
+All an observer knows is that a specific anon set output coin is owned by one of the owners of one of the input Coins i.e. 3 people - hence an anonymity set of 3.  
+Your Wasabi software has limited information on what the anonymity set should be, so the anonymity set that the software presents you is just an estimation, not an accurate value. With Wasabi we are trying to do lower estimations, rather than higher ones.
+
+### Can I mix more than the round's minimum?
+
+Yes.  
+In a round with a ~0.1 BTC minimum, you could mix ~0.3 BTC and get a ~0.1 BTC output & a ~ 0.2 BTC output.
+Similarly, with a 0.7 BTC input you would expect the following outputs: ~0.1, ~0.2, ~0.4 BTC. The possible values of equal output that can be created are 0.1 x 2^n where n is a positive integer (or zero).  [See more here](https://youtu.be/PKtxzSLPWFU) and [here](https://youtu.be/3Ezru07J674).
+
+### Why is the minimum mixing amount an odd number?
+
+The output value changes each round to ensure that you can enqueue a coin and have it remix (mix over and over again - increasing the anonymity set, improving privacy). As a result the round mixing amount will often be a specific number which generally decreases as the rounds proceed, with a reset once a lower bound is reached. 
+
+## Hardware Wallet
+
+
+## Settings
+### How do I connect my own full node to Wasabi?
+There is currently a basic implementation of connecting your full node to Wasabi. The server will still send you [BIP 158 block filters](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki), and when you realize that a block contains a transaction of yours, then you pull this block from your own full node, instead of a random P2P node, thus you can verify that this is actually a valid block including your transaction. One attack vector could be that Wasabi lies to you and give you wrong filters that exclude your transaction, thus you would see in the wallet less coins than you actually control. [BIP 157 solves this](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki).
+When your full node is on the same hardware [computer, laptop] as your Wasabi Wallet, then it will automatically recognize it and pull blocks from there. If your node is on a remote device [raspberry pi, nodl, server], then you can specify your local IP in the Settings tab, or in line 11 of the config file. [See more here](https://youtu.be/gWo2RAkIVrE).
+
+### How can I turn off Tor?
+You can turn off Tor in the Settings. Note that in this case you are still private, except when you coinjoin and when you broadcast a transaction. In the first case, the coordinator would know the links between your inputs and outputs based on your IP address. In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
+
+### How can I change the anonset target?
+In the Settings tab at the bottom you can change the three `PrivacyLevelX` values of the desired anon set of the yellow, green, and checkmark shield button in the GUI. The `MixUntilAnonymitySet` is the last selected value from previous use. 
+In the wallet GUI, go to `File`>`Open`>`Config File` and in the last 4 lines you see:
+
+```json
+"MixUntilAnonymitySet": 50,
+"PrivacyLevelSome": 2,
+"PrivacyLevelFine": 21,
+"PrivacyLevelStrong": 50
+```
+
+Remember that you pay a fee proportional to the Anonymity Set. [See more here](https://youtu.be/gWo2RAkIVrE?t=191).
+
+
+## Coin Control Best Practices 
+### Can I consolidate anonset coins?
+It is advisable to limit the recombining of mixed coins because it can only decrease the privacy of said coins. This links all the consolidated UTXOs in one transaction, creating only one output, which then clearly controls all these funds. That said, if you combine less than 1 BTC it is less likely to reveal your pre-coinjoin transaction history. The potential issue comes when you spend that coin. Depending on what you do with the coin you might reduce the privacy of the resulting change (if you send half your coin to an exchange for example, as they will know that you own the coin change). As a result it is best not to recombine ALL your mixed change, though you may wish to recombine some coins if you are planning on hodling for many years as this will reduce the fees required to spend the coins later.
+
+If you would like to dive into the details of this topic, you can [read more here](https://old.reddit.com/r/WasabiWallet/comments/avxbjy/combining_mixed_coins_privacy_megathread/) and [see more here](https://www.youtube.com/watch?v=Tk8-N1kHa4g).
+
+### How can I send my anonset coins to my hardware wallet?
+Most hardware wallets communicate with servers to provide you with your balance. This reveals your public key to the server, which damages your privacy - the hardware company can now theoretically link together all your addresses. As a result **it is not recommended** that you send your mixed coins to an address associated with your hardware wallet unless you are confident that you have set up your hardware wallet in a way that it does not communicate with a 3rd party server (see below). 
+
+You can however manage your hardware wallet with the Wasabi interface. Alternatively you can use your hardware wallet with Electrum, which connects to your Bitcoin Core full node through [Electrum Personal Server](https://github.com/chris-belcher/electrum-personal-server).
+
+### What can I do with small change?
+There are no hard and fast rules for what to do with the change. Generally try to avoid the change and use the Max button extensively at sending. The most problematic type of change is what has `anonymity set 1` (red shield.) You should treat it as a kind of toxic waste (handled with great care).
+
+**Warning**
+You want to avoid merging `anonymity set 1 coins` with `anonymity set > 1 coins` wherever possible, because this will link your `anonymity set > 1 coin` to the coin you merge it with. Note that, this is also true if you merge them in a mix, however that is slightly less problematic, because some blockchain analysis techniques become [computationally infeasible](https://www.comsys.rwth-aachen.de/fileadmin/papers/2017/2017-maurer-trustcom-coinjoin.pdf).
+
+It is also important that you do not send different coins to the same receiving address (even if performed as separate transactions) as this will also link the coins together, damaging your privacy.
+
+**Your Options**
+- If you do not care about linking the history of the coins because they are all from the same source then you could combine them in a mix (queue all the change from the same source until you reach the minimum input required to mix, currently ~ 0.1 BTC).  
+- Mix with [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver).
+- Donate them (e.g. [to the EFF](https://www.eff.org/))
+- Spend them on something that is not a particular privacy risk (eg. gift cards).
+- Open a lightning channel. 
+- The ultimate solution is to 'close the loop' i.e. spend a change coin without merging it with other coins, do not generate it in the first place by sending whole coins. 

--- a/FAQ/FAQ-UseWasabi.md
+++ b/FAQ/FAQ-UseWasabi.md
@@ -1,0 +1,82 @@
+# Use of Wasabi
+## Wallet Manager
+- How do I generate a new wallet?
+- How do I back up my mnemonic seed?
+- What password should I use?
+- Can I spend my bitcoin without the password?
+- How do I backup my wallet?
+- What's up with the Chinese characters?
+
+## Synchronization
+- What are BIP-158 block filters?
+- How does Wasabi download a relevant block?
+- How long does the initial, and a subsequent synchronization take?
+- How do I know if the synchronization is finished?
+
+## Receive
+- How do I generate a new receiving address?
+- Why do I have to label my address?
+- How can I change the label of my address?
+- Why does Wasabi only use SegWit bech32 addresses?
+- Where can I find my public key?
+- Where can I find a QR code of the address?
+- Are there privacy concerns regarding whom I send my address?
+
+## Send
+- What are coins?
+- Why is coin control so important?
+- How do I select coins for spending?
+- What is the cluster history?
+- How do I set a destination address?
+- Can I send to many addresses?
+- What fee should I select?
+- Can I see the fee in Satoshis per byte?
+- How is the tansaction broadcasted?
+
+## History
+- How can I check the history of transactions?
+- Can I export a list of transaction?
+
+## Coin Join
+- How can I select UTXOs for coin join?
+- What are the denominations created in one round?
+- What is the anonymity set?
+- How much anonymity set do I need?
+- How many rounds should I coin join?
+- What are the fees for the coin join?
+- What is happening in the input registration phase?
+- What is happening in the connection confirmation phase?
+- What is happening in the output registration phase?
+- What is happening in the signing phase phase?
+- What is happening in the broadcasting phase?
+- How does my wallet communicate with the Wasabi coordinator server?
+- Why is the denomination such an odd number?
+
+## Hardware Wallet
+- Why does Wasabi use the Hardware Wallet Interface?
+- What specific hardware wallets does Wasabi support?
+- How can I type in the PIN of my Trezor One?
+- How can I manage the passphrase of my Trezor T?
+- Can I use the passphrase of my Trezor One?
+- How can I generate a Wasabi skelton wallet file in Cold Card?
+- How can I import the Wasabi skelton wallet file?
+- How can I generate a receiving address of my hardware wallet?
+- How can I sign a transaction with a USB connected hardware wallet?
+- How can I build and export a transaction to Cold Card?
+- How can I sign a transaction on the Cold Card?
+- How can I import and broadcast a final transaction from Cold Card?
+- Can I coin join the bitcoin on my hardware wallet?
+
+## Settings
+- How can I connect to my own full node?
+- How can I change the anonset target?
+- How can I change the dust threshold?
+- How can I turn off Tor?
+- Where can I find the logs?
+
+## Coin Control Best Practices
+- Can I consolidate anonset coins?
+- How can I send my anonset coins to my hardware wallet?
+- What can I do with small change?
+- Which coins can I select for coin joins?
+- How can I mix large amounts?

--- a/FAQ/FAQ-UseWasabi.md
+++ b/FAQ/FAQ-UseWasabi.md
@@ -1,5 +1,5 @@
 # Use of Wasabi
-## Wallet Manager
+## [Wallet Manager](/FAQ/FAQ-UseWasabi.md#wallet-manager-1)
 - How do I generate a new wallet?
 - How do I back up my mnemonic seed?
 - What password should I use?
@@ -7,22 +7,22 @@
 - How do I backup my wallet?
 - What's up with the Chinese characters?
 
-## Synchronization
+## [Synchronization](/FAQ/FAQ-UseWasabi.md#synchronization-1)
 - What are BIP-158 block filters?
 - How does Wasabi download a relevant block?
 - How long does the initial, and a subsequent synchronization take?
 - How do I know if the synchronization is finished?
 
-## Receive
+## [Receive](/FAQ/FAQ-UseWasabi.md#receive-1)
 - How do I generate a new receiving address?
 - Why do I have to label my address?
 - How can I change the label of my address?
-- Why does Wasabi only use SegWit bech32 addresses?
+- [Why does Wasabi only use SegWit bech32 addresses?](/FAQ/FAQ-UseWasabi.md#why-does-wasabi-only-use-segwit-bech32-addresses)
 - Where can I find my public key?
 - Where can I find a QR code of the address?
 - Are there privacy concerns regarding whom I send my address?
 
-## Send
+## [Send](/FAQ/FAQ-UseWasabi.md#send-1)
 - What are coins?
 - Why is coin control so important?
 - How do I select coins for spending?
@@ -33,27 +33,27 @@
 - Can I see the fee in Satoshis per byte?
 - How is the tansaction broadcasted?
 
-## History
+## [History](/FAQ/FAQ-UseWasabi.md#history-1)
 - How can I check the history of transactions?
 - Can I export a list of transaction?
 
-## Coin Join
+## [Coin Join](/FAQ/FAQ-UseWasabi.md#coin-join-1)
 - How can I select UTXOs for coin join?
 - What are the denominations created in one round?
-- Can I mix more than the round's minimum?
-- What is the anonymity set?
+- [Can I mix more than the round's minimum?](/FAQ/FAQ-UseWasabi.md#can-i-mix-more-than-the-rounds-minimum)
+- [What is the anonymity set?](/FAQ/FAQ-UseWasabi.md#what-is-the-anonymity-set)
 - How much anonymity set do I need?
 - How many rounds should I coin join?
-- What are the fees for the coin join?
+- [What are the fees for the coin join?](/FAQ/FAQ-UseWasabi.md#what-are-the-fees-for-the-coin-join)
 - What is happening in the input registration phase?
 - What is happening in the connection confirmation phase?
 - What is happening in the output registration phase?
 - What is happening in the signing phase phase?
 - What is happening in the broadcasting phase?
 - How does my wallet communicate with the Wasabi coordinator server?
-- Why is the denomination such an odd number?
+- [Why is the denomination such an odd number?](/FAQ/FAQ-UseWasabi.md#why-is-the-denomination-such-an-odd-number)
 
-## Hardware Wallet
+## [Hardware Wallet](/FAQ/FAQ-UseWasabi.md#hardware-wallet-1)
 - Why does Wasabi use the Hardware Wallet Interface?
 - What specific hardware wallets does Wasabi support?
 - How can I type in the PIN of my Trezor One?
@@ -68,19 +68,21 @@
 - How can I import and broadcast a final transaction from Cold Card?
 - Can I coin join the bitcoin on my hardware wallet?
 
-## Settings
-- How can I connect to my own full node?
-- How can I change the anonset target?
+## [Settings](/FAQ/FAQ-UseWasabi.md#settings-1)
+- [How can I connect to my own full node to Wasabi?](/FAQ/FAQ-UseWasabi.md#how-can-i-connect-to-my-own-full-node-to-wasabi)
+- [How can I change the anonset target?](/FAQ/FAQ-UseWasabi.md#how-can-i-change-the-anonset-target)
 - How can I change the dust threshold?
-- How can I turn off Tor?
+- [How can I turn off Tor?](/FAQ/FAQ-UseWasabi.md#how-can-i-turn-off-tor)
 - Where can I find the logs?
 
-## Coin Control Best Practices
-- Can I consolidate anonset coins?
-- How can I send my anonset coins to my hardware wallet?
-- What can I do with small change?
+## [Coin Control Best Practices](/FAQ/FAQ-UseWasabi.md#coin-control-best-practices-1)
+- [Can I consolidate anonset coins?](/FAQ/FAQ-UseWasabi.md#can-i-consolidate-anonset-coins)
+- [How can I send my anonset coins to my hardware wallet?](/FAQ/FAQ-UseWasabi.md#how-can-i-send-my-anonset-coins-to-my-hardware-wallet)
+- [What can I do with small change?](/FAQ/FAQ-UseWasabi.md#what-can-i-do-with-small-change)
 - Which coins can I select for coin joins?
 - How can I mix large amounts?
+
+--------------------------
 
 ## Wallet Manager
 

--- a/FAQ/README.md
+++ b/FAQ/README.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions about Wasabi Wallet
 
-This document contains a list of all the questions and common issues answered in this archive. If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
+This document contains a list of all the questions and common issues answered in this archive. The hyperlinks lead to the separate files with answers to the questions.
 
 ## [General Bitcoin Privacy](/FAQ-GeneralBitcoinPrivacy.md)
 - I have nothing to hide, do I still need financial privacy?

--- a/FAQ/README.md
+++ b/FAQ/README.md
@@ -18,15 +18,25 @@ This document contains a list of all the questions and common issues answered in
 - Do I need to trust Wasabi with my coins?
 - What is the privacy I get after mixing with Wasabi?
 - Can I hurt my privacy with Wasabi?
+- Who can use Wasabi?
 - Who is contributing to Wasabi?
+- What are the minimal requirements to run Wasabi?
+- Why is Wasabi libre and open source software?
+- Why is Wasabi Bitcoin-only?
 - Does Wasabi have a warrant canary?
+- What do peers say about Wasabi?
 
 ## Installation of Wasabi
+- Where can I download Wasabi?
+- Why is it important to verify PGP signatures?
 - How do I install Wasabi on Linux?
 - How do I install Wasabi on Microsoft?
 - How do I install Wasabi on iOS?
-- How do I upgrade Wasabi?
+- How do I check the current version of Wasabi?
+- How do I know about a new version of Wasabi?
+- How do I securely upgrade Wasabi?
 - How do I compile Wasabi from source?
+- How can I install Wasabi headless daemon without GUI?
 - How do I check the deterministic builds?
 - How do I install the Wasabi backend server?
 - Do I need to install Tor separately?
@@ -39,6 +49,12 @@ This document contains a list of all the questions and common issues answered in
 - Can I spend my bitcoin without the password?
 - How do I backup my wallet?
 - What's up with the Chinese characters?
+
+### Synchronization
+- What are BIP-158 block filters?
+- How does Wasabi download a relevant block?
+- How long does the initial, and a subsequent synchronization take?
+- How do I know if the synchronization is finished?
 
 ### Receive
 - How do I generate a new receiving address?
@@ -110,9 +126,11 @@ This document contains a list of all the questions and common issues answered in
 
 ## Contributions to Wasabi
 - Who is contributing to Wasabi already?
+- How can I get help and support?
 - What does the Wasabi project need help with?
 - How can I report a bug?
 - How can I request a feature?
 - How should I start contributing code?
 - Who verifies the pull requests? 
 - Is there a bounty program?
+- What is on the future roadmap of Wasabi development?

--- a/FAQ/README.md
+++ b/FAQ/README.md
@@ -2,7 +2,7 @@
 
 This document contains a list of all the questions and common issues answered in this archive. If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
 
-## General Bitcoin privacy
+## [General Bitcoin Privacy](/FAQ-GeneralBitcoinPrivacy.md)
 - I have nothing to hide, do I still need financial privacy?
 - How is Bitcoin good in terms of privacy?
 - How is Bitcoin bad in terms of privacy?
@@ -10,7 +10,7 @@ This document contains a list of all the questions and common issues answered in
 - Why is it important for my privacy to run a full node?
 - How does Tor protect my network-level privacy? 
 
-## Introduction to Wasabi
+## [Introduction to Wasabi](/FAQ-Introduction.md)
 - Explain Wasabi like I'm 5
 - What is the history of Wasabi?
 - What is a coin join?
@@ -26,7 +26,7 @@ This document contains a list of all the questions and common issues answered in
 - Does Wasabi have a warrant canary?
 - What do peers say about Wasabi?
 
-## Installation of Wasabi
+## [Installation of Wasabi](/FAQ-Installation.md)
 - Where can I download Wasabi?
 - Why is it important to verify PGP signatures?
 - How do I install Wasabi on Linux?
@@ -41,8 +41,8 @@ This document contains a list of all the questions and common issues answered in
 - How do I install the Wasabi backend server?
 - Do I need to install Tor separately?
 
-## Use of Wasabi
-### Wallet Manager
+## [Use of Wasabi](/FAQ-UseWasabi.md)
+### [Wallet Manager](/FAQ-UseWasabi.md#wallet-manager)
 - How do I generate a new wallet?
 - How do I back up my mnemonic seed?
 - What password should I use?
@@ -50,13 +50,13 @@ This document contains a list of all the questions and common issues answered in
 - How do I backup my wallet?
 - What's up with the Chinese characters?
 
-### Synchronization
+### [Synchronization](/FAQ-UseWasabi.md#synchronization)
 - What are BIP-158 block filters?
 - How does Wasabi download a relevant block?
 - How long does the initial, and a subsequent synchronization take?
 - How do I know if the synchronization is finished?
 
-### Receive
+### [Receive](/FAQ-UseWasabi.md#receive)
 - How do I generate a new receiving address?
 - Why do I have to label my address?
 - How can I change the label of my address?
@@ -65,7 +65,7 @@ This document contains a list of all the questions and common issues answered in
 - Where can I find a QR code of the address?
 - Are there privacy concerns regarding whom I send my address?
 
-### Send
+### [Send](/FAQ-UseWasabi.md#send)
 - What are coins?
 - Why is coin control so important?
 - How do I select coins for spending?
@@ -76,11 +76,11 @@ This document contains a list of all the questions and common issues answered in
 - Can I see the fee in Satoshis per byte?
 - How is the tansaction broadcasted?
 
-### History
+### [History](/FAQ-UseWasabi.md#history)
 - How can I check the history of transactions?
 - Can I export a list of transaction?
 
-### Coin Join
+### [Coin Join](/FAQ-UseWasabi.md#coin-join)
 - How can I select UTXOs for coin join?
 - What are the denominations created in one round?
 - What is the anonymity set?
@@ -95,7 +95,7 @@ This document contains a list of all the questions and common issues answered in
 - How does my wallet communicate with the Wasabi coordinator server?
 - Why is the denomination such an odd number?
 
-### Hardware Wallet
+### [Hardware Wallet](/FAQ-UseWasabi.md#hardware-wallet)
 - Why does Wasabi use the Hardware Wallet Interface?
 - What specific hardware wallets does Wasabi support?
 - How can I type in the PIN of my Trezor One?
@@ -110,21 +110,21 @@ This document contains a list of all the questions and common issues answered in
 - How can I import and broadcast a final transaction from Cold Card?
 - Can I coin join the bitcoin on my hardware wallet?
 
-### Settings
+### [Settings](/FAQ-UseWasabi.md#settings)
 - How can I connect to my own full node?
 - How can I change the anonset target?
 - How can I change the dust threshold?
 - How can I turn off Tor?
 - Where can I find the logs?
 
-### Coin Control Best Practices
+### [Coin Control Best Practices](/FAQ-UseWasabi.md#coin-control-best-practices)
 - Can I consolidate anonset coins?
 - How can I send my anonset coins to my hardware wallet?
 - What can I do with small change?
 - Which coins can I select for coin joins?
 - How can I mix large amounts?
 
-## Contributions to Wasabi
+## [Contributions to Wasabi](/FAQ-Contributions)
 - Who is contributing to Wasabi already?
 - How can I get help and support?
 - What does the Wasabi project need help with?

--- a/FAQ/README.md
+++ b/FAQ/README.md
@@ -13,17 +13,17 @@ This document contains a list of all the questions and common issues answered in
 ## [Introduction to Wasabi](/FAQ-Introduction.md)
 - Explain Wasabi like I'm 5
 - What is the history of Wasabi?
-- What is a coin join?
+- [What is a coin join?](/FAQ/FAQ-Introduction.md#what-is-a-coin-join)
 - How does Zero Link differ from other coin join implementations?
-- Do I need to trust Wasabi with my coins?
-- What is the privacy I get after mixing with Wasabi?
-- Can I hurt my privacy with Wasabi?
+- [Do I need to trust Wasabi with my coins?](/FAQ/FAQ-Introduction.md#do-i-need-to-trust-wasabi-with-my-coins)
+- [What is the privacy I get after mixing with Wasabi?](/FAQ/FAQ-Introduction.md#what-is-the-privacy-i-get-after-mixing-with-wasabi)
+- [Can I hurt my privacy with Wasabi?](/FAQ/FAQ-Introduction.md#can-i-hurt-my-privacy-with-wasabi)
 - Who can use Wasabi?
 - Who is contributing to Wasabi?
 - What are the minimal requirements to run Wasabi?
 - Why is Wasabi libre and open source software?
 - Why is Wasabi Bitcoin-only?
-- Does Wasabi have a warrant canary?
+- [Does Wasabi have a warrant canary?](/FAQ/FAQ-Introduction.md#does-wasabi-have-a-warrant-canary)
 - What do peers say about Wasabi?
 
 ## [Installation of Wasabi](/FAQ-Installation.md)
@@ -34,12 +34,12 @@ This document contains a list of all the questions and common issues answered in
 - How do I install Wasabi on iOS?
 - How do I check the current version of Wasabi?
 - How do I know about a new version of Wasabi?
-- How do I securely upgrade Wasabi?
+- [How do I securely upgrade Wasabi?](/FAQ/FAQ-Installation.md#how-do-i-securely-upgrade-wasabi)
 - How do I compile Wasabi from source?
 - How can I install Wasabi headless daemon without GUI?
 - How do I check the deterministic builds?
 - How do I install the Wasabi backend server?
-- Do I need to install Tor separately?
+- [Do I need to install Tor separately?](/FAQ/FAQ-Installation.md#do-i-need-to-install-tor-separately)
 
 ## [Use of Wasabi](/FAQ-UseWasabi.md)
 ### [Wallet Manager](/FAQ-UseWasabi.md#wallet-manager)
@@ -60,7 +60,7 @@ This document contains a list of all the questions and common issues answered in
 - How do I generate a new receiving address?
 - Why do I have to label my address?
 - How can I change the label of my address?
-- Why does Wasabi only use SegWit bech32 addresses?
+- [Why does Wasabi only use SegWit bech32 addresses?](/FAQ/FAQ-UseWasabi.md#why-does-wasabi-only-use-segwit-bech32-addresses)
 - Where can I find my public key?
 - Where can I find a QR code of the address?
 - Are there privacy concerns regarding whom I send my address?
@@ -83,17 +83,18 @@ This document contains a list of all the questions and common issues answered in
 ### [Coin Join](/FAQ-UseWasabi.md#coin-join)
 - How can I select UTXOs for coin join?
 - What are the denominations created in one round?
-- What is the anonymity set?
+- [Can I mix more than the round's minimum?](/FAQ/FAQ-UseWasabi.md#can-i-mix-more-than-the-rounds-minimum)
+- [What is the anonymity set?](/FAQ/FAQ-UseWasabi.md#what-is-the-anonymity-set)
 - How much anonymity set do I need?
 - How many rounds should I coin join?
-- What are the fees for the coin join?
+- [What are the fees for the coin join?](/FAQ/FAQ-UseWasabi.md#what-are-the-fees-for-the-coin-join)
 - What is happening in the input registration phase?
 - What is happening in the connection confirmation phase?
 - What is happening in the output registration phase?
 - What is happening in the signing phase phase?
 - What is happening in the broadcasting phase?
 - How does my wallet communicate with the Wasabi coordinator server?
-- Why is the denomination such an odd number?
+- [Why is the denomination such an odd number?](/FAQ/FAQ-UseWasabi.md#why-is-the-denomination-such-an-odd-number)
 
 ### [Hardware Wallet](/FAQ-UseWasabi.md#hardware-wallet)
 - Why does Wasabi use the Hardware Wallet Interface?
@@ -111,16 +112,16 @@ This document contains a list of all the questions and common issues answered in
 - Can I coin join the bitcoin on my hardware wallet?
 
 ### [Settings](/FAQ-UseWasabi.md#settings)
-- How can I connect to my own full node?
-- How can I change the anonset target?
+- [How can I connect to my own full node to Wasabi?](/FAQ/FAQ-UseWasabi.md#how-can-i-connect-to-my-own-full-node-to-wasabi)
+- [How can I change the anonset target?](/FAQ/FAQ-UseWasabi.md#how-can-i-change-the-anonset-target)
 - How can I change the dust threshold?
-- How can I turn off Tor?
+- [How can I turn off Tor?](/FAQ/FAQ-UseWasabi.md#how-can-i-turn-off-tor)
 - Where can I find the logs?
 
 ### [Coin Control Best Practices](/FAQ-UseWasabi.md#coin-control-best-practices)
-- Can I consolidate anonset coins?
-- How can I send my anonset coins to my hardware wallet?
-- What can I do with small change?
+- [Can I consolidate anonset coins?](/FAQ/FAQ-UseWasabi.md#can-i-consolidate-anonset-coins)
+- [How can I send my anonset coins to my hardware wallet?](/FAQ/FAQ-UseWasabi.md#how-can-i-send-my-anonset-coins-to-my-hardware-wallet)
+- [What can I do with small change?](/FAQ/FAQ-UseWasabi.md#what-can-i-do-with-small-change)
 - Which coins can I select for coin joins?
 - How can I mix large amounts?
 

--- a/FAQ/README.md
+++ b/FAQ/README.md
@@ -12,16 +12,20 @@ This document contains a list of all the questions and common issues answered in
 
 ## Introduction to Wasabi
 - Explain Wasabi like I'm 5
+- What is the history of Wasabi?
 - What is a coin join?
+- How does Zero Link differ from other coin join implementations?
 - Do I need to trust Wasabi with my coins?
 - What is the privacy I get after mixing with Wasabi?
 - Can I hurt my privacy with Wasabi?
 - Who is contributing to Wasabi?
+- Does Wasabi have a warrant canary?
 
 ## Installation of Wasabi
-- How do I install the Wasabi Wallet on Linux?
-- How do I install the Wasabi Wallet on Microsoft?
-- How do I install the Wasabi Wallet on iOS?
+- How do I install Wasabi on Linux?
+- How do I install Wasabi on Microsoft?
+- How do I install Wasabi on iOS?
+- How do I upgrade Wasabi?
 - How do I compile Wasabi from source?
 - How do I check the deterministic builds?
 - How do I install the Wasabi backend server?
@@ -73,6 +77,7 @@ This document contains a list of all the questions and common issues answered in
 - What is happening in the signing phase phase?
 - What is happening in the broadcasting phase?
 - How does my wallet communicate with the Wasabi coordinator server?
+- Why is the denomination such an odd number?
 
 ### Hardware Wallet
 - Why does Wasabi use the Hardware Wallet Interface?
@@ -88,6 +93,20 @@ This document contains a list of all the questions and common issues answered in
 - How can I sign a transaction on the Cold Card?
 - How can I import and broadcast a final transaction from Cold Card?
 - Can I coin join the bitcoin on my hardware wallet?
+
+### Settings
+- How can I connect to my own full node?
+- How can I change the anonset target?
+- How can I change the dust threshold?
+- How can I turn off Tor?
+- Where can I find the logs?
+
+### Coin Control Best Practices
+- Can I consolidate anonset coins?
+- How can I send my anonset coins to my hardware wallet?
+- What can I do with small change?
+- Which coins can I select for coin joins?
+- How can I mix large amounts?
 
 ## Contributions to Wasabi
 - Who is contributing to Wasabi already?

--- a/FAQ/README.md
+++ b/FAQ/README.md
@@ -1,0 +1,99 @@
+# Frequently Asked Questions about Wasabi Wallet
+
+This document contains a list of all the questions and common issues answered in this archive. If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
+
+## General Bitcoin privacy
+- I have nothing to hide, do I still need financial privacy?
+- How is Bitcoin good in terms of privacy?
+- How is Bitcoin bad in terms of privacy?
+- Why is it important to use a new address for every payment?
+- Why is it important for my privacy to run a full node?
+- How does Tor protect my network-level privacy? 
+
+## Introduction to Wasabi
+- Explain Wasabi like I'm 5
+- What is a coin join?
+- Do I need to trust Wasabi with my coins?
+- What is the privacy I get after mixing with Wasabi?
+- Can I hurt my privacy with Wasabi?
+- Who is contributing to Wasabi?
+
+## Installation of Wasabi
+- How do I install the Wasabi Wallet on Linux?
+- How do I install the Wasabi Wallet on Microsoft?
+- How do I install the Wasabi Wallet on iOS?
+- How do I compile Wasabi from source?
+- How do I check the deterministic builds?
+- How do I install the Wasabi backend server?
+- Do I need to install Tor separately?
+
+## Use of Wasabi
+### Wallet Manager
+- How do I generate a new wallet?
+- How do I back up my mnemonic seed?
+- What password should I use?
+- Can I spend my bitcoin without the password?
+- How do I backup my wallet?
+- What's up with the Chinese characters?
+
+### Receive
+- How do I generate a new receiving address?
+- Why do I have to label my address?
+- How can I change the label of my address?
+- Why does Wasabi only use SegWit bech32 addresses?
+- Where can I find my public key?
+- Where can I find a QR code of the address?
+- Are there privacy concerns regarding whom I send my address?
+
+### Send
+- What are coins?
+- Why is coin control so important?
+- How do I select coins for spending?
+- What is the cluster history?
+- How do I set a destination address?
+- Can I send to many addresses?
+- What fee should I select?
+- Can I see the fee in Satoshis per byte?
+- How is the tansaction broadcasted?
+
+### History
+- How can I check the history of transactions?
+- Can I export a list of transaction?
+
+### Coin Join
+- How can I select UTXOs for coin join?
+- What are the denominations created in one round?
+- What is the anonymity set?
+- How much anonymity set do I need?
+- How many rounds should I coin join?
+- What are the fees for the coin join?
+- What is happening in the input registration phase?
+- What is happening in the connection confirmation phase?
+- What is happening in the output registration phase?
+- What is happening in the signing phase phase?
+- What is happening in the broadcasting phase?
+- How does my wallet communicate with the Wasabi coordinator server?
+
+### Hardware Wallet
+- Why does Wasabi use the Hardware Wallet Interface?
+- What specific hardware wallets does Wasabi support?
+- How can I type in the PIN of my Trezor One?
+- How can I manage the passphrase of my Trezor T?
+- Can I use the passphrase of my Trezor One?
+- How can I generate a Wasabi skelton wallet file in Cold Card?
+- How can I import the Wasabi skelton wallet file?
+- How can I generate a receiving address of my hardware wallet?
+- How can I sign a transaction with a USB connected hardware wallet?
+- How can I build and export a transaction to Cold Card?
+- How can I sign a transaction on the Cold Card?
+- How can I import and broadcast a final transaction from Cold Card?
+- Can I coin join the bitcoin on my hardware wallet?
+
+## Contributions to Wasabi
+- Who is contributing to Wasabi already?
+- What does the Wasabi project need help with?
+- How can I report a bug?
+- How can I request a feature?
+- How should I start contributing code?
+- Who verifies the pull requests? 
+- Is there a bounty program?


### PR DESCRIPTION
We have many questions, now we need the answers!! 

I suggest this rough structure `General Bitcoin privacy`, `Introduction to Wasabi`, `Installation of Wasabi`, `Use of Wasabi`- `Wallet Manager` - `Receive` - `Send` - `History` - `Coin Join` - `Hardware Wallet`, `Contributions to Wasabi`.

Of course, open for re-structuring, and changes / additions to the questions.

This addresses #3.