### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-# Wasabi Documentation
+![](https://i.imgur.com/4GO7nnY.png)
 
-[Wasabi](https://wasabiwallet.io) is an open-source, non-custodial, privacy focused Bitcoin wallet for desktop. It implements trustless coin shuffling: [Schnorrian CoinJoin](https://github.com/nopara73/ZeroLink/).
+# Documentation
 
-This is the open source documentation repository of Wasabi Wallet, here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself. If you would like to support the project by educating your peers, this documentation repository is the right place for your efforts! If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues). If you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls). For more details on how to contribute, see the [contribution checklist](/docs/ContributionChecklist.md)
+This is the open source documentation repository of [Wasabi Wallet](https://wasabiwallet.io)*. Developers repository can be found [here](https://github.com/zkSNACKs/WalletWasabi).
+
+From the [docs](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs) files you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself. 
+If you would like to support the project by educating your peers, this documentation repository is the right place for your efforts!
+
+Have a question that is not yet covered? Please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues).
+If you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
+For more details on how to contribute, see the [contribution checklist](/docs/ContributionChecklist.md) or [To-Do-List](https://github.com/zkSNACKs/WasabiDoc/blob/master/docs/ToDo.md).
+
+*[Wasabi Wallet](https://wasabiwallet.io) is an open-source, non-custodial, privacy focused Bitcoin wallet for desktop.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,8 @@
 # WasabiDoc
 
-[Wasabi](https://wasabiwallet.io) is an open-source, non-custodial, privacy focused Bitcoin wallet for desktop. It implements trustless coin shuffling: [Schnorrian CoinJoin](https://github.com/nopara73/ZeroLink/).
+This is the open source documentation repository of Wasabi Wallet*, here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself. If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
 
-However, "[anonymity loves company](https://www.freehaven.net/anonbib/cache/usability:weis2006.pdf)", the more participants there are, the better your privacy is, and the faster the coin join rounds are. Whether you are looking for state of the art operational security or you are philosophically aligned with the principles of freedom and privacy, now it is YOUR time to contribute. Fire up your Wasabi and help us to bootstrap the system!
-
-This is the open source documentation repository of Wasabi Wallet, here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself. If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
+*[Wasabi](https://wasabiwallet.io) is an open-source, non-custodial, privacy focused Bitcoin wallet for desktop.
 
 
 ## Basics

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,9 @@
-# WasabiDoc
+# WasabiDoc 
 
-This is the open source documentation repository of Wasabi Wallet*, here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself. If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
+From this document you will find links to information about the nuances of privacy in Bitcoin, how [Wasabi](https://wasabiwallet.io) solves these difficult problems, and how you can use these tools to defend yourself. 
+If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
 
-*[Wasabi](https://wasabiwallet.io) is an open-source, non-custodial, privacy focused Bitcoin wallet for desktop.
+Developers repository can be found [here](https://github.com/zkSNACKs/WalletWasabi).
 
 
 ## Basics
@@ -14,8 +15,6 @@ This is the open source documentation repository of Wasabi Wallet*, here you wil
   -- [Transaction Graph](BitcoinPrivacy.md#transaction-graph) </br>
   -- [Network Snooping](BitcoinPrivacy.md#network-snooping) </br>
 - Getting started
-- [Wasabi 10 Commandments](10Commandments.md)
-- Wasabi compared to other Wallets
 
 ## Installing Wasabi
 
@@ -36,24 +35,6 @@ This is the open source documentation repository of Wasabi Wallet*, here you wil
 - Seed and mnemonic
 - Password
 - [Password Finder](PasswordFinder.md)
-
-### Hardware Wallet
-- Trezor One PIN
-- Trezor One passphrase
-- Trezor passphrase
-- ColdCard </br>
--- Import skeleton wallet </br>
--- Build PSBT </br>
--- Export PSBT </br>
--- Sign PSBT </br>
--- Import PSBT </br>
--- Broadcast PSBT </br>
-
-### Load Wallet
-- [Network Level Privacy - Bitcoin Core vs Wasabi Wallet](NetworkLevelPrivacy.md)
-- Difference hot / watch only wallet
-- BIP 158 block filter
-- Download of blocks over tor & full node
 
 ### Receive
 - HD path
@@ -79,6 +60,23 @@ This is the open source documentation repository of Wasabi Wallet*, here you wil
 - Fees
 - [Pay To EndPoint](PayToEndPoint.md)
 
+### Hardware Wallet
+- Trezor One PIN
+- Trezor One passphrase
+- Trezor passphrase
+- ColdCard </br>
+-- Import skeleton wallet </br>
+-- Build PSBT </br>
+-- Export PSBT </br>
+-- Sign PSBT </br>
+-- Import PSBT </br>
+-- Broadcast PSBT </br>
+
+### Load Wallet
+- [Network Level Privacy - Bitcoin Core vs Wasabi Wallet](NetworkLevelPrivacy.md)
+- Difference hot / watch only wallet
+- BIP 158 block filter
+- Download of blocks over tor & full node
 
 ## Development
 
@@ -116,3 +114,8 @@ This is the open source documentation repository of Wasabi Wallet*, here you wil
 - [Contribution Checklist](ContributionChecklist.md)
 - [Demo Guide](DemoGuide.md)
 - [Contribution Game](ContributionGame.md)
+
+## Other
+
+- [Wasabi 10 Commandments](10Commandments.md)
+- Wasabi compared to other Wallets


### PR DESCRIPTION
Update all 3 README.md files of Wasabi to give viewers more information about the differences of these files and repositories.

Moved some of the info between files and added few comments and hyperlinks to all README.md files. 

Basic idea is this: 
WasabiDocs/readme = introduction to the Docs repo
WasabiDocs/docs/readme = manual and links to specific documents
WalletWasabi/readme = introduction to developers repo.

Haven't made a new PR to WalletWasabi yet.

PS. I'm new to github so bare with me guys.