### PR TITLE
Fix consistent "CoinJoin" spelling

### DIFF
--- a/docs/10Commandments.md
+++ b/docs/10Commandments.md
@@ -4,7 +4,7 @@
 2. [Verify the integrity of your software](10Commandments.md#2-verify-the-integrity-of-your-software)
 3. [Keep your mnemonic words and password safely stored (BOTH!)](10Commandments.md#3-keep-your-mnemonic-words-and-password-safely-stored-both)
 4. [Practice good labeling AND try to never reuse addresses](10Commandments.md#4-practice-good-labeling-and-try-to-never-reuse-addresses)
-5. [Coin join whenever possible and be patient](10Commandments.md#5-coin-join-whenever-possible-and-be-patient)
+5. [CoinJoin whenever possible and be patient](10Commandments.md#5-coinjoin-whenever-possible-and-be-patient)
 6. [Use separate profiles](10Commandments.md#6-use-separate-profiles)
 7. [Never merge mixed and unmixed coins, and avoid large merges of mixed coins](10Commandments.md#7-never-merge-mixed-and-unmixed-coins-and-avoid-large-merges-of-mixed-coins)
 8. [Avoid 3rd party servers & Buy Bitcoin P2P](10Commandments.md#8-avoid-3rd-party-servers--buy-bitcoin-p2p)
@@ -47,9 +47,9 @@ Address #1
 
 Lastly, if you must use an exchange, try to ask for a new deposit address on each deposit. In the same way that you should never receive Bitcoin to the same address twice, you should try to avoiding sending Bitcoin to the same address twice.
 
-## 5. Coin join whenever possible and be patient!
+## 5. CoinJoin whenever possible and be patient!
 
-The process of engaging in a coin join is as simple as selecting a coin or coins to en-queue and entering your password. Once coins have en-queued for coin joining, you must keep your computer online and awake, as the coin join process is interactive. As a coin join is really just many users (up to 100) en-queuing coins at the same time, it may take up to two hours for you to successfully participate in a coin join and clean outputs should only be spent once the coin join transaction is confirmed. For context, Wasabi currently does 18 coin joins a day, or roughly one every 1 hour and 20 minutes. As more users join the network, the frequency of these coin joins will go up. Lastly, if you are able and patient enough to re-mix your coins, please do so. Re-mixing coins is nearly free and greatly encouraged!
+The process of engaging in a CoinJoin is as simple as selecting a coin or coins to en-queue and entering your password. Once coins have en-queued for CoinJoining, you must keep your computer online and awake, as the coin join process is interactive. As a coin join is really just many users (up to 100) en-queuing coins at the same time, it may take up to two hours for you to successfully participate in a CoinJoin and clean outputs should only be spent once the coin join transaction is confirmed. For context, Wasabi currently does 18 CoinJoins a day, or roughly one every 1 hour and 20 minutes. As more users join the network, the frequency of these CoinJoins will go up. Lastly, if you are able and patient enough to re-mix your coins, please do so. Re-mixing coins is nearly free and greatly encouraged!
 
 ## 6. Use separate profiles
 
@@ -57,7 +57,7 @@ When you put a label on an address, or ask a question on this Reddit or send coi
 
 ## 7. Never merge mixed and unmixed coins, and avoid large merges of mixed coins!
 
-The first part should be somewhat intuitive - coins in your wallet have shields (red, yellow, green and green +) and it is at a minimum important to never send non-red coins (coins with anonset > 1) with red coins (coins with anonset == 1). By merging your tainted coins with your mixed coins, you undo the privacy benefits of coin joins! Further, when sending mixed coins to your cold storage, make sure to send your coins in parallel. Don't merge all of your Bitcoin (more than 0.8 BTC) in a single transaction! Instead, take your time and send coins to multiple addresses belong to your cold storage over a few hours or days. If you are sending coins to an exchange, you can get the same result by requesting a brand new address to receive coins.
+The first part should be somewhat intuitive - coins in your wallet have shields (red, yellow, green and green +) and it is at a minimum important to never send non-red coins (coins with anonset > 1) with red coins (coins with anonset == 1). By merging your tainted coins with your mixed coins, you undo the privacy benefits of CoinJoins! Further, when sending mixed coins to your cold storage, make sure to send your coins in parallel. Don't merge all of your Bitcoin (more than 0.8 BTC) in a single transaction! Instead, take your time and send coins to multiple addresses belong to your cold storage over a few hours or days. If you are sending coins to an exchange, you can get the same result by requesting a brand new address to receive coins.
 
 For more information, please see the discussions [here](https://www.reddit.com/r/WasabiWallet/comments/avxbjy/combining_mixed_coins_privacy_megathread/).
 
@@ -83,7 +83,7 @@ Wasabi will work just fine without a local full node on your device, however, if
 
 ## 10. Use Lightning
 
-Wasabi is an ideal wallet for many things, but trade-offs exist with everything. If you have small amounts of un-mixed change from previous coin joins and you are unable to meet the requirements to engage in a coin join, consider using that coin to open a lightning channel. Lightning is still a project in its' early days, but the privacy topology of lightning payments is much more ideal over on-chain payments if you have the choice. Routing large amounts can be uncertain, but for small amounts the network is becoming steadily more reliable. Currently Wasabi does not support in-wallet lightning features, but it is on the road-map.
+Wasabi is an ideal wallet for many things, but trade-offs exist with everything. If you have small amounts of un-mixed change from previous CoinJoins and you are unable to meet the requirements to engage in a CoinJoin, consider using that coin to open a lightning channel. Lightning is still a project in its' early days, but the privacy topology of lightning payments is much more ideal over on-chain payments if you have the choice. Routing large amounts can be uncertain, but for small amounts the network is becoming steadily more reliable. Currently Wasabi does not support in-wallet lightning features, but it is on the road-map.
 
 ## Credits
 

--- a/docs/BitcoinPrivacy.md
+++ b/docs/BitcoinPrivacy.md
@@ -63,11 +63,11 @@ Because of the input and output model of Bitcoin, there is a chain of digital si
 
 ### Wasabi's Solution
 
-_**Zero Link coin joins**_
+_**Zero Link CoinJoins**_
 
-In order to obfuscate the link between outputs and inputs, Wasabi uses the [Zero Link](https://github.com/nopara73/zerolink) coin join protocol. The Wasabi central coordinator cannot steal and cannot spy, he simple helps many peers to build a huge transaction, with many inputs, and many outputs. The non-private inputs can be linked to their previous transaction history. However, the equal value coin join outputs with an anonymity set can not be tied to the inputs.
+In order to obfuscate the link between outputs and inputs, Wasabi uses the [Zero Link](https://github.com/nopara73/zerolink) CoinJoin protocol. The Wasabi central coordinator cannot steal and cannot spy, he simple helps many peers to build a huge transaction, with many inputs, and many outputs. The non-private inputs can be linked to their previous transaction history. However, the equal value CoinJoin outputs with an anonymity set can not be tied to the inputs.
 
-This means that when sending an anonset coin, the receiver does not know about the transaction history before the coin join. And when the receiver does a coin join himself, then the sender cannot spy on the later spending patterns. An outside observer can only guess the correct link at a rate of 1 in the anonset, for example 1-in-100, or 1%.
+This means that when sending an anonset coin, the receiver does not know about the transaction history before the CoinJoin. And when the receiver does a CoinJoin himself, then the sender cannot spy on the later spending patterns. An outside observer can only guess the correct link at a rate of 1 in the anonset, for example 1-in-100, or 1%.
 
 
 ## Network snooping

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -21,4 +21,4 @@ You can download the software build for the different operating systems on the m
 ### Do I need to install Tor separately?
 All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself. If you do already have Tor, and it is running, then Wasabi will try to use that first.  
 
-You can turn off Tor in the Settings. Note that in this case you are still private, except when you coinjoin and when you broadcast a transaction. In the first case, the coordinator would know the links between your inputs and outputs based on your IP address. In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
+You can turn off Tor in the Settings. Note that in this case you are still private, except when you CoinJoin and when you broadcast a transaction. In the first case, the coordinator would know the links between your inputs and outputs based on your IP address. In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.

--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -1,8 +1,8 @@
 # Introduction to Wasabi
 - Explain Wasabi like I'm 5
 - What is the history of Wasabi?
-- [What is a coin join?](FAQ-Introduction.md#what-is-a-coin-join)
-- How does Zero Link differ from other coin join implementations?
+- [What is a CoinJoin?](FAQ-Introduction.md#what-is-a-coinjoin)
+- How does Zero Link differ from other CoinJoin implementations?
 - [Do I need to trust Wasabi with my coins?](FAQ-Introduction.md#do-i-need-to-trust-wasabi-with-my-coins)
 - [What is the privacy I get after mixing with Wasabi?](FAQ-Introduction.md#what-is-the-privacy-i-get-after-mixing-with-wasabi)
 - [Can I hurt my privacy with Wasabi?](FAQ-Introduction.md#can-i-hurt-my-privacy-with-wasabi)
@@ -16,25 +16,25 @@
 
 ---
 
-### What is a coin join?
+### What is a CoinJoin?
 A mechanism by which multiple participants combine their coins (or UTXOs, to be more precise) into one large transaction with multiple inputs and multiple outputs. An observer cannot determine which output belongs to which input, and neither can the participants themselves. This makes it difficult for outside parties to trace where a particular coin originated from and where it was sent to (as opposed to regular bitcoin transactions, where there is usually one sender and one receiver).  
 
-In very simple terms, coinjoin means: “when you want to make a transaction, find someone else who also wants to make a transaction and make a joint transaction together”.  
+In very simple terms, CoinJoin means: “when you want to make a transaction, find someone else who also wants to make a transaction and make a joint transaction together”.  
 
 See also: https://en.bitcoin.it/wiki/CoinJoin
 
 ### Do I need to trust Wasabi with my coins?
-No, Wasabi's coinjoin implementation is trustless by design. The participants do not need to trust each other or any third party. Both the sending address (the coinjoin input) and the receiving address (the coinjoin output) are controlled by your own private keys. Wasabi merely coordinates the process of combining the inputs of the participants into one single transaction, but the wallet can neither steal your coins, nor figure out which outputs belong to which inputs (look up “[Chaumian Coinjoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin)” if you want to know more).
+No, Wasabi's CoinJoin implementation is trustless by design. The participants do not need to trust each other or any third party. Both the sending address (the CoinJoin input) and the receiving address (the CoinJoin output) are controlled by your own private keys. Wasabi merely coordinates the process of combining the inputs of the participants into one single transaction, but the wallet can neither steal your coins, nor figure out which outputs belong to which inputs (look up “[Chaumian CoinJoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin)” if you want to know more).
 
 ### What is the privacy I get after mixing with Wasabi?
-This depends on how you handle your outputs after the coinjoin. There are some ways how you can unintentionally undo the mixing by being careless. For example, if you make a 1.8 BTC transaction into Wasabi, do the coinjoin, and then make one single outgoing transaction of 1.8 BTC, a third party observer can reasonably assume that both transactions belong to one single entity, due to both amounts being virtually the same even though they have been through a coinjoin. In this scenario, Wasabi will barely make any improvement to your privacy, although it will still have a protective effect against unsophisticated observers.  
+This depends on how you handle your outputs after the CoinJoin. There are some ways how you can unintentionally undo the mixing by being careless. For example, if you make a 1.8 BTC transaction into Wasabi, do the CoinJoin, and then make one single outgoing transaction of 1.8 BTC, a third party observer can reasonably assume that both transactions belong to one single entity, due to both amounts being virtually the same even though they have been through a CoinJoin. In this scenario, Wasabi will barely make any improvement to your privacy, although it will still have a protective effect against unsophisticated observers.  
 
 Another deanonymizing scenario happens when you combine mixed outputs with unmixed ones when sending: a third party will be able to make the connection between them as belonging to the same sender.
 
 The practice of being careful with your post-mix outputs is commonly facilitated through coin control, which is the default way of interacting with the wallet. Find out more about coin control it [here](https://medium.com/@nopara73/coin-control-is-must-learn-if-you-care-about-your-privacy-in-bitcoin-33b9a5f224a2).
 
 ### Can I hurt my privacy using Wasabi?
-No. The worst thing that can happen (through user’s negligence post-mix) is that the level of your privacy stays the same as before coinjoin. It is crucial to understand that Wasabi is not a fool-proof solution if you neglect to practice coin control after the mixing process.
+No. The worst thing that can happen (through user’s negligence post-mix) is that the level of your privacy stays the same as before CoinJoin. It is crucial to understand that Wasabi is not a fool-proof solution if you neglect to practice coin control after the mixing process.
 
 ### Does Wasabi have a warrant canary?
 The nature of Wasabi is that you should not need to trust the developers or the Wasabi coordinating server, as you can verify that the code does not leak information to anyone. The developers have gone to great lengths in an attempt to ensure that the coordinator cannot steal funds nor harvest information (for example, the outputs sent from your Wasabi Wallet are blinded, meaning that even the Wasabi server cannot link the outputs to the inputs). 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -39,14 +39,14 @@
 - How can I check the history of transactions?
 - Can I export a list of transaction?
 
-## [Coin Join](FAQ-UseWasabi.md#coin-join-1)
-- How can I select UTXOs for coin join?
+## [CoinJoin](FAQ-UseWasabi.md#coinjoin-1)
+- How can I select UTXOs for CoinJoin?
 - What are the denominations created in one round?
 - [Can I mix more than the round's minimum?](FAQ-UseWasabi.md#can-i-mix-more-than-the-rounds-minimum)
 - [What is the anonymity set?](FAQ-UseWasabi.md#what-is-the-anonymity-set)
 - How much anonymity set do I need?
-- How many rounds should I coin join?
-- [What are the fees for the coin join?](FAQ-UseWasabi.md#what-are-the-fees-for-the-coin-join)
+- How many rounds should I CoinJoin?
+- [What are the fees for the CoinJoin?](FAQ-UseWasabi.md#what-are-the-fees-for-the-coinjoin)
 - What is happening in the input registration phase?
 - What is happening in the connection confirmation phase?
 - What is happening in the output registration phase?
@@ -68,7 +68,7 @@
 - How can I build and export a transaction to Cold Card?
 - How can I sign a transaction on the Cold Card?
 - How can I import and broadcast a final transaction from Cold Card?
-- Can I coin join the bitcoin on my hardware wallet?
+- Can I CoinJoin the bitcoin on my hardware wallet?
 
 ## [Settings](FAQ-UseWasabi.md#settings-1)
 - [How can I connect to my own full node to Wasabi?](FAQ-UseWasabi.md#how-can-i-connect-to-my-own-full-node-to-wasabi)
@@ -81,7 +81,7 @@
 - [Can I consolidate anonset coins?](FAQ-UseWasabi.md#can-i-consolidate-anonset-coins)
 - [How can I send my anonset coins to my hardware wallet?](FAQ-UseWasabi.md#how-can-i-send-my-anonset-coins-to-my-hardware-wallet)
 - [What can I do with small change?](FAQ-UseWasabi.md#what-can-i-do-with-small-change)
-- Which coins can I select for coin joins?
+- Which coins can I select for CoinJoins?
 - How can I mix large amounts?
 
 --------------------------
@@ -120,8 +120,8 @@ So to fix this Wasabi broadcasts your transactions to a random node, and message
 ## History
 
 
-## Coin Join
-### What are the fees for the coin join?
+## CoinJoin
+### What are the fees for the CoinJoin?
 You currently pay a fee of 0.003% * anonymity set. If the anonymity set of a coin is 50 then you pay 0.003% * 50 (=0.15%). If you set the target anonymity set to 53 then Wasabi will continue mixing until this is reached, so you may end up with an anonymity set of say 60, and you will pay 0.003% * 60 (=0.18%).  
 
 There are also edge cases where you do not pay the full fee or where you pay more. For example if you're the smallest registrant to a round, you will never pay a fee. Also when you are remixing and you cannot pay the full fee with your input, then you only pay as much as you have, but if the change amount leftover would be too small, then that is also added to the fee. Currently the minimum change amount to be paid out is 0.7% of the base denomination (~0.1BTC.)  
@@ -169,7 +169,7 @@ There is currently a basic implementation of connecting your full node to Wasabi
 When your full node is on the same hardware [computer, laptop] as your Wasabi Wallet, then it will automatically recognize it and pull blocks from there. If your node is on a remote device [raspberry pi, nodl, server], then you can specify your local IP in the Settings tab, or in line 11 of the config file. [See more here](https://youtu.be/gWo2RAkIVrE).
 
 ### How can I turn off Tor?
-You can turn off Tor in the Settings. Note that in this case you are still private, except when you coinjoin and when you broadcast a transaction. In the first case, the coordinator would know the links between your inputs and outputs based on your IP address. In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
+You can turn off Tor in the Settings. Note that in this case you are still private, except when you CoinJoin and when you broadcast a transaction. In the first case, the coordinator would know the links between your inputs and outputs based on your IP address. In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
 
 ### How can I change the anonset target?
 In the Settings tab at the bottom you can change the three `PrivacyLevelX` values of the desired anon set of the yellow, green, and checkmark shield button in the GUI. The `MixUntilAnonymitySet` is the last selected value from previous use. 
@@ -188,7 +188,7 @@ Remember that you pay a fee proportional to the Anonymity Set. [See more here](h
 
 ## Coin Control Best Practices 
 ### Can I consolidate anonset coins?
-It is advisable to limit the recombining of mixed coins because it can only decrease the privacy of said coins. This links all the consolidated UTXOs in one transaction, creating only one output, which then clearly controls all these funds. That said, if you combine less than 1 BTC it is less likely to reveal your pre-coinjoin transaction history. The potential issue comes when you spend that coin. Depending on what you do with the coin you might reduce the privacy of the resulting change (if you send half your coin to an exchange for example, as they will know that you own the coin change). As a result it is best not to recombine ALL your mixed change, though you may wish to recombine some coins if you are planning on hodling for many years as this will reduce the fees required to spend the coins later.
+It is advisable to limit the recombining of mixed coins because it can only decrease the privacy of said coins. This links all the consolidated UTXOs in one transaction, creating only one output, which then clearly controls all these funds. That said, if you combine less than 1 BTC it is less likely to reveal your pre-CoinJoin transaction history. The potential issue comes when you spend that coin. Depending on what you do with the coin you might reduce the privacy of the resulting change (if you send half your coin to an exchange for example, as they will know that you own the coin change). As a result it is best not to recombine ALL your mixed change, though you may wish to recombine some coins if you are planning on hodling for many years as this will reduce the fees required to spend the coins later.
 
 If you would like to dive into the details of this topic, you can [read more here](https://old.reddit.com/r/WasabiWallet/comments/avxbjy/combining_mixed_coins_privacy_megathread/) and [see more here](https://www.youtube.com/watch?v=Tk8-N1kHa4g).
 
@@ -208,11 +208,11 @@ It is also important that you do not send different coins to the same receiving 
 
 There are two different types of zero link change:
 
-When you have a KYC coin with red anonset 1 and you register it for coin join, then you get one anonset 100 green coin and one red anonset 1 change. This change is very clearly tied to your KYC input coin, but the coin join output is pretty good with anonset 100. If you combine that red coin with the green, then it's clear that both of them belong to you, and thus the anonset of the output in this transactioin becomes the lowest common denominator, in this case anonset 1.
+When you have a KYC coin with red anonset 1 and you register it for CoinJoin, then you get one anonset 100 green coin and one red anonset 1 change. This change is very clearly tied to your KYC input coin, but the CoinJoin output is pretty good with anonset 100. If you combine that red coin with the green, then it's clear that both of them belong to you, and thus the anonset of the output in this transactioin becomes the lowest common denominator, in this case anonset 1.
 
-When you take a 100 anonset coin, and you register it again for coin join, then you get one coin with anonset 200, and one change with anonset 100. This change has anonset 100 because it can be linked to the input of the second coin join, but this coin has anonset 100 already. So, although this change can still reveal pre-mix history, because the pr-mix history is another coin join, you cannot go farther back. So, it might be ok to send this second change output to some place, or even consolidate it, because it still has anonset.
+When you take a 100 anonset coin, and you register it again for CoinJoin, then you get one coin with anonset 200, and one change with anonset 100. This change has anonset 100 because it can be linked to the input of the second CoinJoin, but this coin has anonset 100 already. So, although this change can still reveal pre-mix history, because the pr-mix history is another CoinJoin, you cannot go farther back. So, it might be ok to send this second change output to some place, or even consolidate it, because it still has anonset.
 
-When you consolidate several small change coins in a regular transaction, then every outside observer knows that they belong to the same cluster. However, you can consolidate within a coin join by simply selecting all these coins in the coin join tab. Because the Wasabi coin join transaction shuffles inputs, for an outside observer it is not clear which inputs belong to the same Alice. However, the coordinator gets the input proof of **ALL** the coins that Alice has provided during the input registration phase. Thus the coordinator knows that this is a consolidation transaction. It is wise to assume that every one knows what the coordinator knows. So consolidating in a coin join is better, but it might still reveal the common ownership of the coins.
+When you consolidate several small change coins in a regular transaction, then every outside observer knows that they belong to the same cluster. However, you can consolidate within a CoinJoin by simply selecting all these coins in the CoinJoin tab. Because the Wasabi CoinJoin transaction shuffles inputs, for an outside observer it is not clear which inputs belong to the same Alice. However, the coordinator gets the input proof of **ALL** the coins that Alice has provided during the input registration phase. Thus the coordinator knows that this is a consolidation transaction. It is wise to assume that every one knows what the coordinator knows. So consolidating in a CoinJoin is better, but it might still reveal the common ownership of the coins.
 
 **Your Options**
 - If you do not care about linking the history of the coins because they are all from the same source then you could combine them in a mix (queue all the change from the same source until you reach the minimum input required to mix, currently ~ 0.1 BTC).  

--- a/docs/FAQ/README.md
+++ b/docs/FAQ/README.md
@@ -13,8 +13,8 @@ This document contains a list of all the questions and common issues answered in
 ## [Introduction to Wasabi](FAQ-Introduction.md)
 - Explain Wasabi like I'm 5
 - What is the history of Wasabi?
-- [What is a coin join?](FAQ-Introduction.md#what-is-a-coin-join)
-- How does Zero Link differ from other coin join implementations?
+- [What is a CoinJoin?](FAQ-Introduction.md#what-is-a-coinjoin)
+- How does Zero Link differ from other CoinJoin implementations?
 - [Do I need to trust Wasabi with my coins?](FAQ-Introduction.md#do-i-need-to-trust-wasabi-with-my-coins)
 - [What is the privacy I get after mixing with Wasabi?](FAQ-Introduction.md#what-is-the-privacy-i-get-after-mixing-with-wasabi)
 - [Can I hurt my privacy with Wasabi?](FAQ-Introduction.md#can-i-hurt-my-privacy-using-wasabi)
@@ -81,14 +81,14 @@ This document contains a list of all the questions and common issues answered in
 - How can I check the history of transactions?
 - Can I export a list of transaction?
 
-### [Coin Join](/FAQ-UseWasabi.md#coin-join)
-- How can I select UTXOs for coin join?
+### [CoinJoin](/FAQ-UseWasabi.md#coinjoin)
+- How can I select UTXOs for CoinJoin?
 - What are the denominations created in one round?
 - [Can I mix more than the round's minimum?](FAQ-UseWasabi.md#can-i-mix-more-than-the-rounds-minimum)
 - [What is the anonymity set?](FAQ-UseWasabi.md#what-is-the-anonymity-set)
 - How much anonymity set do I need?
-- How many rounds should I coin join?
-- [What are the fees for the coin join?](FAQ-UseWasabi.md#what-are-the-fees-for-the-coin-join)
+- How many rounds should I CoinJoin?
+- [What are the fees for the CoinJoin?](FAQ-UseWasabi.md#what-are-the-fees-for-the-coinjoin)
 - What is happening in the input registration phase?
 - What is happening in the connection confirmation phase?
 - What is happening in the output registration phase?
@@ -110,7 +110,7 @@ This document contains a list of all the questions and common issues answered in
 - How can I build and export a transaction to Cold Card?
 - How can I sign a transaction on the Cold Card?
 - How can I import and broadcast a final transaction from Cold Card?
-- Can I coin join the bitcoin on my hardware wallet?
+- Can I CoinJoin the bitcoin on my hardware wallet?
 
 ### [Settings](FAQ-UseWasabi.md#settings)
 - [How can I connect to my own full node to Wasabi?](FAQ-UseWasabi.md#how-do-i-connect-my-own-full-node-to-wasabi)
@@ -123,7 +123,7 @@ This document contains a list of all the questions and common issues answered in
 - [Can I consolidate anonset coins?](FAQ-UseWasabi.md#can-i-consolidate-anonset-coins)
 - [How can I send my anonset coins to my hardware wallet?](FAQ-UseWasabi.md#how-can-i-send-my-anonset-coins-to-my-hardware-wallet)
 - [What can I do with small change?](FAQ-UseWasabi.md#what-can-i-do-with-small-change)
-- Which coins can I select for coin joins?
+- Which coins can I select for CoinJoins?
 - How can I mix large amounts?
 
 ## [Contributions to Wasabi](FAQ-Contribution.md)

--- a/docs/PayToEndPoint.md
+++ b/docs/PayToEndPoint.md
@@ -4,19 +4,19 @@
 - [The Basics](PayToEndPoint.md#the-basics) </br>
   -- [Pay to IP](PayToEndPoint.md#p2ip) </br>
   -- [Bulletproofs](PayToEndPoint.md#bulletproofs) </br>
-  -- [Coin Join](PayToEndPoint.md#coin-join) </br>
+  -- [CoinJoin](PayToEndPoint.md#coinjoin) </br>
   -- [Blockchain Heuristics](PayToEndPoint.md#blockchain-heuristics) </br>
   -- [Clusterfuck Wallet](PayToEndPoint.md#clusterfuck-wallet) </br>
 - [The Protocol](PayToEndPoint.md#the-protocol) </br>
   -- [Part 1: End-To-End Connection Establishment](PayToEndPoint.md#part-1-end-to-end-connection-establishment) </br>
-  -- [Part 2: Sender-Receiver Coin Join](PayToEndPoint.md#part-2-sender-receiver-coin-join) </br>
+  -- [Part 2: Sender-Receiver CoinJoin](PayToEndPoint.md#part-2-sender-receiver-coinjoin) </br>
   -- [Extensions](PayToEndPoint.md#extensions) </br>
 - [The Novelty of Sender-Receiver Scheme](PayToEndPoint.md#the-novelty-of-sender-receiver-scheme)
 - [Conclusion](PayToEndPoint.md#conclusion)
 
 ---
 
-> Satoshi's Vision + Coin Join + Bulletproofs = Sad Blockchain Analysts
+> Satoshi's Vision + CoinJoin + Bulletproofs = Sad Blockchain Analysts
 
 I attended a brainstorming event on Bitcoin privacy. In this article, I will assume all participants of this meeting would like to remain anonymous, unless she or he explicitly asks me to properly credit her or him.
 To keep this post coherent, I will refer to specific participants as Jessie, James and Meowth in an interchangeable, (not pseudonymous) way, hence Team Rocket.
@@ -48,9 +48,9 @@ Bulletproofs (BP) is a zero-knowledge proof system, often cited together with Co
 
 It is also worth noting, that our scheme does not require any soft or hard fork.
 
-### Coin Join
+### CoinJoin
 
-My regular readers are probably sick of me repeatedly explaining coin join, (CJ) so feel free to skip this two sentences here. CJ stands for joining multiple users’ inputs into one transaction. It is also worth pointing out that most CJ scheme uses equal sized outputs. If it does not, then it provides zero privacy. But that is just an oversimplification, I often say. No matter how unintuitive it may seem, there are CJs with unequal sized outputs those still provide privacy, because the adversary have to recognize this was a CJ transaction in the first place. I will expand upon it later.
+My regular readers are probably sick of me repeatedly explaining CoinJoin, (CJ) so feel free to skip this two sentences here. CJ stands for joining multiple users’ inputs into one transaction. It is also worth pointing out that most CJ scheme uses equal sized outputs. If it does not, then it provides zero privacy. But that is just an oversimplification, I often say. No matter how unintuitive it may seem, there are CJs with unequal sized outputs those still provide privacy, because the adversary have to recognize this was a CJ transaction in the first place. I will expand upon it later.
 
 ### Blockchain Heuristics
 
@@ -69,7 +69,7 @@ This heuristics can be applied to CJ transactions, (and all mixing technique in 
 It is evident, but it is worth pointing out. If Blockchain Analysis sees a transaction on the Blockchain that theoretically can be interpreted in many different ways, but in practice only one way of interpretation is implemented at that point in time, then that interpretation is what Blockchain Analysis assumes. This is why it is really easy to be anonymous with Bitcoin today. Just get familiar with some Blockchain Analysis heuristics, break them manually and they will interpret your transaction in the wrong way with 99% accuracy, because you are the only person who builds such transaction in the world and they are not aware of them.
 To denounce the evils of Blockchain Analytics!
 
-To go to town with heuristics, see Adam Gibson’s [Building on Bitcoin talk](https://www.youtube.com/watch?v=XORDEX-RrAI&feature=youtu.be&t=23359), Kristov Atlas’s [Coin Join Sudoku](https://www.coinjoinsudoku.com), where he broke Blockchain info’s now discontinued SharedCoin feature and [Nick Jonas’s 2016 talk](https://www.youtube.com/watch?v=HScK4pkDNds) in a Zurich Meetup.
+To go to town with heuristics, see Adam Gibson’s [Building on Bitcoin talk](https://www.youtube.com/watch?v=XORDEX-RrAI&feature=youtu.be&t=23359), Kristov Atlas’s [CoinJoin Sudoku](https://www.coinjoinsudoku.com), where he broke Blockchain info’s now discontinued SharedCoin feature and [Nick Jonas’s 2016 talk](https://www.youtube.com/watch?v=HScK4pkDNds) in a Zurich Meetup.
 
 ### Clusterfuck Wallet
 
@@ -98,7 +98,7 @@ In this case, UX would stay the same: the receiver gives a Bitcoin address to th
 The impracticality of James’s idea is that we would need either our own anonymity network to achieve this, like a fork of Tor or we would have to convince an existing anonymity network to incorporate our scheme.
 Nevertheless, the idea is novel and worth keeping in mind.
 
-### Part 2: Sender-Receiver Coin Join
+### Part 2: Sender-Receiver CoinJoin
 
 It may seem like I do not even have to say more, because negotiating a transaction where the sender and the recipient both participates is not that hard, especially that they usually trust each other, right? Wrong. Their was a point where Team Rocket gave up on this scheme, because they thought they encountered an unsolvable issue.
 
@@ -112,7 +112,7 @@ And finally Jessie came up with something elegant: **The Bulletproofs Method**. 
 
 ### Extensions
 
-Before I explain the novelty of Part 2: Sender-Receiver coin join protocol, I would like to point out that, Part 1: End-To-End Connection Establishment protocol has a side effect, namely it can be used to facilitate many things, I described in the Clusterfuck Wallet post. One thing this can easily facilitate is merge avoidance. If the sender would want to join multiple coins together, it could ask for multiple Bitcoin addresses from the receiver and send the coins one by one. It could also establish a future cooperation with the receiver. For example, the receiver, if online could participate in later transactions of the sender, thus breaking Heuristics 1 and Meta. But really, if this P2EP would get adopted, the limit of the number of strange schemes, all breaking Blockchain Analysis assumptions is just the developer’s imagination.
+Before I explain the novelty of Part 2: Sender-Receiver CoinJoin protocol, I would like to point out that, Part 1: End-To-End Connection Establishment protocol has a side effect, namely it can be used to facilitate many things, I described in the Clusterfuck Wallet post. One thing this can easily facilitate is merge avoidance. If the sender would want to join multiple coins together, it could ask for multiple Bitcoin addresses from the receiver and send the coins one by one. It could also establish a future cooperation with the receiver. For example, the receiver, if online could participate in later transactions of the sender, thus breaking Heuristics 1 and Meta. But really, if this P2EP would get adopted, the limit of the number of strange schemes, all breaking Blockchain Analysis assumptions is just the developer’s imagination.
 
 ## The Novelty of Sender-Receiver Scheme
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 [Wasabi](https://wasabiwallet.io) is an open-source, non-custodial, privacy focused Bitcoin wallet for desktop. It implements trustless coin shuffling: [Schnorrian CoinJoin](https://github.com/nopara73/ZeroLink/).
 
-However, "[anonymity loves company](https://www.freehaven.net/anonbib/cache/usability:weis2006.pdf)", the more participants there are, the better your privacy is, and the faster the coin join rounds are. Whether you are looking for state of the art operational security or you are philosophically aligned with the principles of freedom and privacy, now it is YOUR time to contribute. Fire up your Wasabi and help us to bootstrap the system!
+However, "[anonymity loves company](https://www.freehaven.net/anonbib/cache/usability:weis2006.pdf)", the more participants there are, the better your privacy is, and the faster the CoinJoin rounds are. Whether you are looking for state of the art operational security or you are philosophically aligned with the principles of freedom and privacy, now it is YOUR time to contribute. Fire up your Wasabi and help us to bootstrap the system!
 
 This is the open source documentation repository of Wasabi Wallet, here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself. If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
 
@@ -68,7 +68,7 @@ This is the open source documentation repository of Wasabi Wallet, here you will
 - Transaction fee
 - Password
 
-### Coin Join
+### CoinJoin
 - Zero Link </br>
 -- Input registration </br>
 -- Connection confirmation </br>
@@ -104,7 +104,7 @@ This is the open source documentation repository of Wasabi Wallet, here you will
   -- [Receive](/docs/FAQ/FAQ-UseWasabi.md#receive) </br>
   -- [Send](/docs/FAQ/FAQ-UseWasabi.md#send) </br>
   -- [History](/docs/FAQ/FAQ-UseWasabi.md#history) </br>
-  -- [Coin Join](/docs/FAQ/FAQ-UseWasabi.md#coin-join) </br>
+  -- [CoinJoin](/docs/FAQ/FAQ-UseWasabi.md#coinjoin) </br>
   -- [Hardware Wallet](/docs/FAQ/FAQ-UseWasabi.md#hardware-wallet) </br>
   -- [Settings](/docs/FAQ/FAQ-UseWasabi.md#settings) </br>
   -- [Coin Control Best Practices](/docs/FAQ/FAQ-UseWasabi.md#coin-control-best-practices) </br>

--- a/docs/TechnicalOverview.md
+++ b/docs/TechnicalOverview.md
@@ -45,15 +45,15 @@ After setting up Wasabi and generating a wallet, Wasabi welcomes the user with a
 
 Wasabi has a status bar that shows meta information about the state of the wallet. To better understand the architecture of the wallet it is helpful to go through them.
 
-The "Tor" label shows the status of the Tor daemon. Tor is an anonymity network which Wasabi ships with by default and runs in the background. The user can also opt to use their own Tor instance. All Internet traffic goes through Tor and by deafault all this traffic stays inside the onion network. Exit nodes are only involved in fallback scenarios. For example if the Tor hidden service of the backend becomes unavaiable for the user, the wallet falls back communicating with the backend's clearnet endpoint, still over Tor. Wasabi also frequently utilizes multiple Tor streams where applicable. For example, registration of coinjoin inputs and outputs is done through different Tor streams to avoid linking.
+The "Tor" label shows the status of the Tor daemon. Tor is an anonymity network which Wasabi ships with by default and runs in the background. The user can also opt to use their own Tor instance. All Internet traffic goes through Tor and by deafault all this traffic stays inside the onion network. Exit nodes are only involved in fallback scenarios. For example if the Tor hidden service of the backend becomes unavaiable for the user, the wallet falls back communicating with the backend's clearnet endpoint, still over Tor. Wasabi also frequently utilizes multiple Tor streams where applicable. For example, registration of CoinJoin inputs and outputs is done through different Tor streams to avoid linking.
 
 ![](https://i.imgur.com/054zvbY.png)
 
-Wasabi's backend is used to facilitate [Chaumian CoinJoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin) coordination between the mixing participants and to serve Golomb-Rice filters to the clients, similarly to [BIP158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki). More information will be provided about the difference soon. Before that, it is worth pointing out that the design choice of building a light wallet was made because such a wallet can attract orders of magnitude more users compared to a wallet on top of a full node, and more users means larger and faster coinjoins. Historically, all light wallets were vulnerable to some kind of network observer due to unprivate utxo fetching. A few years ago, the only type of wallet that wasn't vulnerable was a full node, like Bitcoin Core. The first iteration of Wasabi was [HiddenWallet](https://github.com/zkSNACKs/WalletWasabi/tree/hiddenwallet-v0.6), which was a full-block SPV wallet that aimed to leverage usability without compromising privacy through the omission of initial blockchain downloading compared to a full node. In theory, it was a light wallet. In practice, it was hard to compete with Bitcoin Core's micro-optimizations and it was still painful to wait for wallet synchronization every time the wallet was opened. [Read more about network level Bitcoin wallet privacy here.](https://medium.com/@nopara73/bitcoin-core-vs-wasabi-wallet-network-level-privacy-bdca1d501387)
+Wasabi's backend is used to facilitate [Chaumian CoinJoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin) coordination between the mixing participants and to serve Golomb-Rice filters to the clients, similarly to [BIP158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki). More information will be provided about the difference soon. Before that, it is worth pointing out that the design choice of building a light wallet was made because such a wallet can attract orders of magnitude more users compared to a wallet on top of a full node, and more users means larger and faster CoinJoins. Historically, all light wallets were vulnerable to some kind of network observer due to unprivate utxo fetching. A few years ago, the only type of wallet that wasn't vulnerable was a full node, like Bitcoin Core. The first iteration of Wasabi was [HiddenWallet](https://github.com/zkSNACKs/WalletWasabi/tree/hiddenwallet-v0.6), which was a full-block SPV wallet that aimed to leverage usability without compromising privacy through the omission of initial blockchain downloading compared to a full node. In theory, it was a light wallet. In practice, it was hard to compete with Bitcoin Core's micro-optimizations and it was still painful to wait for wallet synchronization every time the wallet was opened. [Read more about network level Bitcoin wallet privacy here.](https://medium.com/@nopara73/bitcoin-core-vs-wasabi-wallet-network-level-privacy-bdca1d501387)
 
 ![](https://i.imgur.com/lSXrOpJ.png)
 
-Back to Wasabi. After loading the wallet, the user can generate a receive address. Some important design choices were made here. First, Wasabi had to be a Segregated Witness only wallet, so the registration of unconfirmed coinjoin outputs into a new coinjoin round is done to prevent malleability attacks. However, the developers of Wasabi decided to make the wallet native segwit (bech32) only, not supporting wrapped segwit. This way, the backend server can leverage this and only generate filters regarding bech32 addresses. This makes Wasabi's filter size a few megabytes today, instead of >4GB. At first glance, this may be seen as hazardous to privacy, however Wasabi user utxos can be identified as Wasabi utxos by the huge coinjoins that only Wasabi does anyway, so minimal to no additional privacy loss happens there. In the future, as more and more wallets adopt bech32, Wasabi developers will have to look at how to scale the performance and network usage of the wallet. Failing that, Wasabi's initial sync will slow down.
+Back to Wasabi. After loading the wallet, the user can generate a receive address. Some important design choices were made here. First, Wasabi had to be a Segregated Witness only wallet, so the registration of unconfirmed CoinJoin outputs into a new CoinJoin round is done to prevent malleability attacks. However, the developers of Wasabi decided to make the wallet native segwit (bech32) only, not supporting wrapped segwit. This way, the backend server can leverage this and only generate filters regarding bech32 addresses. This makes Wasabi's filter size a few megabytes today, instead of >4GB. At first glance, this may be seen as hazardous to privacy, however Wasabi user utxos can be identified as Wasabi utxos by the huge CoinJoins that only Wasabi does anyway, so minimal to no additional privacy loss happens there. In the future, as more and more wallets adopt bech32, Wasabi developers will have to look at how to scale the performance and network usage of the wallet. Failing that, Wasabi's initial sync will slow down.
 
 This page shows the wallets that can be used to send to and receive from Wasabi: https://en.bitcoin.it/wiki/Bech32_adoption#Software_Wallets
 
@@ -91,7 +91,7 @@ Coins in Wasabi have Privacy and History properties. The anonymity set is just a
 
 ![](https://i.imgur.com/4vUiSWr.png)
 
-Wasabi has a CoinJoin tab as well, its use is straightforward. The user queues their coins for coinjoin and waits for others to join the mix.
+Wasabi has a CoinJoin tab as well, its use is straightforward. The user queues their coins for CoinJoin and waits for others to join the mix.
 
 ![](https://i.imgur.com/8wFd88C.png)
 
@@ -105,7 +105,7 @@ After a mix has successfully executed, the resulting CoinJoin transaction will l
 
 Wasabi also has a Tor website where one can see real time statistics about the mixes: http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/
 
-To this day, Wasabi's coinjoins have created >22941 BTC outputs with equal value.
+To this day, Wasabi's CoinJoins have created >22941 BTC outputs with equal value.
 
 ## II. Stability, Performance, UX, Code Quality
 
@@ -123,7 +123,7 @@ While education, content creation and marketing have little place in a technical
 
 At the Blockchain level Wasabi currently helps its users achieve the desired level of privacy in three main ways: mixing, coin control and intra-wallet clustering.  
 
-Coin mixing happens through Chaumian CoinJoin, as described in the [ZeroLink](https://github.com/nopara73/ZeroLink/) protocol. In a nutshell, Wasabi users register their transaction inputs and desired outputs with a coordinator, and the cooperation of these users results in a large coinjoin transaction. The coordinator cannot steal from, nor deanonymize the users. However, with ZeroLink, in order to statistically avoid post-mix deanonymization, coins must not be joined together. This, however, is unfeasible in practice.  
+Coin mixing happens through Chaumian CoinJoin, as described in the [ZeroLink](https://github.com/nopara73/ZeroLink/) protocol. In a nutshell, Wasabi users register their transaction inputs and desired outputs with a coordinator, and the cooperation of these users results in a large CoinJoin transaction. The coordinator cannot steal from, nor deanonymize the users. However, with ZeroLink, in order to statistically avoid post-mix deanonymization, coins must not be joined together. This, however, is unfeasible in practice.  
 Thus, various strategies are needed to mitigate this deanonymization risk.  
 
 One such strategy is Wasabi's current compulsory coin control feature. It helps the users to not join coins together and spend whole coins, but it does not force them, so it is not perfect.  
@@ -223,7 +223,7 @@ The question of a web-wallet is also something to think about. However, it may n
 
 ### Hardware Wallet
 
-Wasabi has hardware wallet integration however in this mode coinjoining is not possible: https://github.com/zkSNACKs/WalletWasabi/pull/1341
+Wasabi has hardware wallet integration however in this mode CoinJoining is not possible: https://github.com/zkSNACKs/WalletWasabi/pull/1341
 
 ### Bitcoin Core
 
@@ -231,7 +231,7 @@ Some of the users use full nodes, mainly Bitcoin Core as their personal wallet, 
 
 ### Daemon/API
 
-Another way to improve the software is to let developers play with it through a daemon (RPC?) process. This however may lead to enterprise adoption, which is good for liquidity, but there is a risk of centralization and thus Sybil attacks. May become more likely. For example an exchange could decide to add coinjoins and if they acquire 50% of liquidity in Wasabi, this way many of the wallet assumptions about anonymity sets would become less accurate. https://github.com/zkSNACKs/Meta/issues/12
+Another way to improve the software is to let developers play with it through a daemon (RPC?) process. This however may lead to enterprise adoption, which is good for liquidity, but there is a risk of centralization and thus Sybil attacks. May become more likely. For example an exchange could decide to add CoinJoins and if they acquire 50% of liquidity in Wasabi, this way many of the wallet assumptions about anonymity sets would become less accurate. https://github.com/zkSNACKs/Meta/issues/12
 Wasabi already has a public web API. However developers should not build wallets on top of it, since breakin changes must be expected. Misc things like Twitter bots are fine: http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/swagger/index.html (https://wasabiwallet.io/swagger/index.html)
 
 ### .NET Ecosystem

--- a/docs/ToDo.md
+++ b/docs/ToDo.md
@@ -12,7 +12,7 @@ This document is for providing a one place stop for anyone interested in the sho
 - Guide user to not consolidate [#1958](https://github.com/zkSNACKs/WalletWasabi/issues/1958) [#1983](https://github.com/zkSNACKs/WalletWasabi/issues/1983)
 - Improve PSBT ColdCard workflow [#2015](https://github.com/zkSNACKs/WalletWasabi/issues/2015)
 - [Separate documentation repository](https://github.com/zkSNACKs/WalletWasabi/issues/1820)
-- User choise for coin join denomination [#1900](https://github.com/zkSNACKs/WalletWasabi/issues/1900) [#1904](https://github.com/zkSNACKs/WalletWasabi/issues/1904)
+- User choise for CoinJoin denomination [#1900](https://github.com/zkSNACKs/WalletWasabi/issues/1900) [#1904](https://github.com/zkSNACKs/WalletWasabi/issues/1904)
 - [Improve cluster history](https://github.com/zkSNACKs/WalletWasabi/issues/612)
 - [Replace by fee integration](https://github.com/zkSNACKs/WalletWasabi/issues/1543)
 - [Add encryption manager BIP 322](https://github.com/zkSNACKs/WalletWasabi/issues/1121)
@@ -25,8 +25,8 @@ This document is for providing a one place stop for anyone interested in the sho
 - Proper bitcoind integration
 - Pay to EndPoint integration
 - Join Market integration
-- [SNICKER integration: Simple Non-Interactive Coinjoin with Keys for Encryption Reused](https://github.com/zkSNACKs/Meta/issues/67)
+- [SNICKER integration: Simple Non-Interactive CoinJoin with Keys for Encryption Reused](https://github.com/zkSNACKs/Meta/issues/67)
 - Lightning network integration 
-- Coin join statistics database and website
+- CoinJoin statistics database and website
 - SegWit v1 Schnorr / Taproot
 - [SigNet integration](https://github.com/zkSNACKs/Meta/issues/66)


### PR DESCRIPTION
This PR changes all the different spelling variants to `CoinJoin`, as was the [original vision of GMax](https://bitcointalk.org/index.php?topic=279249.0).

There are a bunch of links including `coin-join` and I think I fixed them all to `coinjoin` - but I might have missed some, then they are broken.

Closes #27.