### PR TITLE
More on how to build website locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ If you are looking for the developers repository, it can be found here [WalletWa
 
 </br>
 
+## Contribute to the Documentation
+
+Just like the Wasabi wallet software, this documentation is libre and open source under the [MIT license](LICENSE). Not only do we appreciate the contributoin of peers, but we desperately need it! If you have a question, [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues) and if you know the answer, then [make a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
+
+The documentation has three main pillars, each of them have a separate folder for proper structure: [Why Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/why-wasabi), [Using Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/using-wasabi), and [Building Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/building-wasabi), as well as an independent [Frequently Asked Question](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/FAQ). Please consider this repsoitory structure for hyperlinks, and use relative links whenever possible, for example `[What is a CoinJoin?](FAQ-Introduction.md#what-is-a-coinjoin)`.
+
+The graphical documentation is built with [VuePress](https://v1.vuepress.vuejs.org/), and the sidebar navigation can be [edited here](https://github.com/zkSNACKs/WasabiDoc/blob/master/docs/.vuepress/config.toml).
+
+If you have front end skills and would like to help improve the theme/look of the website, we welcome your input! Check out the [VuePress documentation](https://v1.vuepress.vuejs.org/) for details on how it works.
+
+On the other hand, if you'd like to contribute to the content of the site, know that you do not need to understand/deal with VuePress at all! You can make PRs pertaining to the markdown files in the `/docs/` directory, and if accepted, the merged changes will automatically be integrated into the documentation website by VuePress.
+
+<br>
+
 ## Build the Documentation Locally
 The Wasabi documentation website is built using an open source static site generator called VuePress. It is extrememly customizable and offers great defaults out-of-the-box. Check out the [VuePress documentation](https://v1.vuepress.vuejs.org/) for details on how to use it powerfully.
 
@@ -61,18 +75,9 @@ yarn global add vuepress
 vuepress dev docs
 ```
 
-## Contribute to the Documentation
+<br>
 
-Just like the Wasabi wallet software, this documentation is libre and open source under the [MIT license](LICENSE). Not only do we appreciate the contributoin of peers, but we desperately need it! If you have a question, [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues) and if you know the answer, then [make a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
-
-The documentation has three main pillars, each of them have a separate folder for proper structure: [Why Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/why-wasabi), [Using Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/using-wasabi), and [Building Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/building-wasabi), as well as an independent [Frequently Asked Question](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/FAQ). Please consider this repsoitory structure for hyperlinks, and use relative links whenever possible, for example `[What is a CoinJoin?](FAQ-Introduction.md#what-is-a-coinjoin)`.
-
-The graphical documentation is built with [VuePress](https://v1.vuepress.vuejs.org/), and the sidebar navigation can be [edited here](https://github.com/zkSNACKs/WasabiDoc/blob/master/docs/.vuepress/config.toml).
-
-If you have front end skills and would like to help improve the theme/look of the website, we welcome your input! Check out the [VuePress documentation](https://v1.vuepress.vuejs.org/) for details on how it works.
-
-On the other hand, if you'd like to contribute to the content of the site, know that you do not need to understand/deal with VuePress at all! You can make PRs pertaining to the markdown files in the `/docs/` directory, and if accepted, the merged changes will automatically be integrated into the documentation website by VuePress.
-
+---
 ### Spelling Conventions 
 
 - Wasabi [capitalized]

--- a/README.md
+++ b/README.md
@@ -56,23 +56,15 @@ On the other hand, if you'd like to contribute to the content of the site, know 
 ## Build the Documentation Locally
 The Wasabi documentation website is built using an open source static site generator called VuePress. It is extrememly customizable and offers great defaults out-of-the-box. Check out the [VuePress documentation](https://v1.vuepress.vuejs.org/) for details on how to use it powerfully.
 
-In order to build the website locally, you'll need [Node.js](https://nodejs.org/en/download/) and either [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/en/docs/install).
+In order to build the website locally, you'll need [Node.js](https://nodejs.org/en/download/).
 
-### Serve locally using npm
-1. Install VuePress
+### Serve locally
+1. Install dependencies
 2. Serve locally (by default on port 8080)
 
 ```bash
-npm install -g vuepress # alternatively: npm install
-vuepress dev docs       # alternatively: npm start
-```
-### Serve locally using yarn
-1. Install VuePress
-2. Serve locally
-
-```bash
-yarn global add vuepress
-vuepress dev docs
+npm install
+npm start
 ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -39,40 +39,26 @@ If you are looking for the developers repository, it can be found here [WalletWa
 
 </br>
 
-## Build the Documentation
+## Build the Documentation Locally
+The Wasabi documentation website is built using an open source static site generator called VuePress. It is extrememly customizable and offers great defaults out-of-the-box. Check out the [VuePress documentation](https://v1.vuepress.vuejs.org/) for details on how to use it powerfully.
 
-### Setup
+In order to build the website locally, you'll need [Node.js](https://nodejs.org/en/download/) and either [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/en/docs/install).
 
-Prerequisite: [Node.js](https://nodejs.org/en/download/)
-
-Install the dependencies:
+### Serve locally using npm
+1. Install VuePress
+2. Serve locally (by default on port 8080)
 
 ```bash
-npm install
+npm install -g vuepress # alternatively: npm install
+vuepress dev docs       # alternatively: npm start
 ```
-
-### Development
-
-Start the local build:
-
-```bash
-npm start
-```
-
-### Deployment
-
-Deploy the site manually:
+### Serve locally using yarn
+1. Install VuePress
+2. Serve locally
 
 ```bash
-npm run deploy
-```
-
-The command above creates a production build and pushes it to the GitHub Pages branch.
-
-To just create the production build you can use this command:
-
-```bash
-npm run build
+yarn global add vuepress
+vuepress dev docs
 ```
 
 ## Contribute to the Documentation
@@ -81,7 +67,11 @@ Just like the Wasabi wallet software, this documentation is libre and open sourc
 
 The documentation has three main pillars, each of them have a separate folder for proper structure: [Why Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/why-wasabi), [Using Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/using-wasabi), and [Building Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/building-wasabi), as well as an independent [Frequently Asked Question](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/FAQ). Please consider this repsoitory structure for hyperlinks, and use relative links whenever possible, for example `[What is a CoinJoin?](FAQ-Introduction.md#what-is-a-coinjoin)`.
 
-The graphical documentation is built with [VuePress](https://vuepress.vuejs.org/), the sidebar navigation can be [edited here](https://github.com/zkSNACKs/WasabiDoc/blob/master/docs/.vuepress/config.toml).
+The graphical documentation is built with [VuePress](https://v1.vuepress.vuejs.org/), and the sidebar navigation can be [edited here](https://github.com/zkSNACKs/WasabiDoc/blob/master/docs/.vuepress/config.toml).
+
+If you have front end skills and would like to help improve the theme/look of the website, we welcome your input! Check out the [VuePress documentation](https://v1.vuepress.vuejs.org/) for details on how it works.
+
+On the other hand, if you'd like to contribute to the content of the site, know that you do not need to understand/deal with VuePress at all! You can make PRs pertaining to the markdown files in the `/docs/` directory, and if accepted, the merged changes will automatically be integrated into the documentation website by VuePress.
 
 ### Spelling Conventions 
 


### PR DESCRIPTION
This PR basically adds to the section on how to build the site locally for development in the root `README.md` file. I also pushed the section at the bottom, below "how to contribute".

One message I wanted to get across is that contributors do not need to know how to use VuePress to contribute to the contents of the docs at all; they can simply PR changes to the markdown files and the website will be updated automatically. On the other hand, frontend devs who would like to help with the look should know how and where to go, and so I referred them to the vuepress documentation. (Note that there is a 1.x version of the vuepress docs and a 0.x version, and for the first 2 weeks I was working with the wrong docs, which caused me a lot of grief; if you are working with the vuepress docs, make sure you use the 1.0 version!)

Let me know if my explanations are clear. This is a bit more of a finesse section, and I am not sure if I hit the nail on the head just yet.