### PR TITLE
add sidebarDepth = 2 to config

### DIFF
--- a/docs/.vuepress/config.toml
+++ b/docs/.vuepress/config.toml
@@ -10,10 +10,11 @@ editLinks = true
     # why Wasabi sidebar
     # ----------------------------------------
     [[themeConfig.sidebar."/why-wasabi/"]]
-    title = ""
+    title = "Why Wasabi"
     collapsable = false
+    sidebarDepth = 2
     children = [
-        "/why-wasabi/",
+#        "/why-wasabi/",
 	"/why-wasabi/WhyPrivacyImportant.md",
 	"/why-wasabi/BitcoinPrivacy.md",
 	"/why-wasabi/10Commandments.md",
@@ -23,10 +24,11 @@ editLinks = true
     # using Wasabi sidebar
     # ----------------------------------------
     [[themeConfig.sidebar."/using-wasabi/"]]
-    title = ""
+    title = "Using Wasabi"
     collapsable = false
+    sidebarDepth = 2
     children = [
-        "/using-wasabi/",
+#        "/using-wasabi/",
         "/using-wasabi/InstallPackage.md",
         "/using-wasabi/BuildSource.md",
         "/using-wasabi/DeterministicBuild.md",
@@ -40,10 +42,11 @@ editLinks = true
     # building Wasabi sidebar
     # ----------------------------------------
     [[themeConfig.sidebar."/building-wasabi/"]]
-    title = ""
+    title = "Building Wasabi"
     collapsable = false
+    sidebarDepth = 2
     children = [
-        "/building-wasabi/",
+#        "/building-wasabi/",
         "/building-wasabi/TechnicalOverview.md",
         "/building-wasabi/ContributionChecklist.md",
         "/building-wasabi/Dojo.md",
@@ -63,10 +66,11 @@ editLinks = true
     # FAQ Wasabi sidebar
     # ----------------------------------------
     [[themeConfig.sidebar."/FAQ/"]]
-    title = ""
+    title = "FAQ"
     collapsable = false
+    sidebarDepth = 2
     children = [
-        "/FAQ/",
+#        "/FAQ/",
         "/FAQ/FAQ-Introduction.md",
         "/FAQ/FAQ-Installation.md",
         "/FAQ/FAQ-UseWasabi.md",


### PR DESCRIPTION
This closes #39 and adds a sidebar depth of 2, meaning that it shows all headers up to `###` in the left sidebar.

Thing missing that might be included in this PR
- [ ] Why does it not work for `FAQ-Introduction.md` and `FAQ-Installation.md`?
- [ ] Should we use the build-in table of content to clean up the sidebar? #41 
- [ ] What to do with the branch `README.md` files? Right now they can be accessed in the navbar, but the sidebar does not have a hyperlink to them.