### PR TITLE
New Writing Convention: Each sentence new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,5 @@ npm start
 
 - Wasabi [capitalized]
 - CoinJoin [capitalized, one word]
+- Every sentense must start a new line.
+- For a paragraph, add an `empty line` or `</br>` in the markdown.

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -5,12 +5,18 @@
 ---
 
 ### How do I securely upgrade Wasabi?
-You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion). Make sure you also download the signatures of the build and verify them for [Adam Ficsor's public key.](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) For step by step instructions, follow [this guide](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/InstallInstructions.md) or [see this video](https://youtu.be/DUc9A76rwX4).
+You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
+Make sure you also download the signatures of the build and verify them for [Adam Ficsor's public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+For step by step instructions, follow [this guide](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/InstallInstructions.md) or [see this video](https://youtu.be/DUc9A76rwX4).
 
 ### Do I need to install Tor separately?
-All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself. If you do already have Tor, and it is running, then Wasabi will try to use that first.  
+All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself.
+If you do already have Tor, and it is running, then Wasabi will try to use that first.
 
-You can turn off Tor in the Settings. Note that in this case you are still private, except when you CoinJoin and when you broadcast a transaction. In the first case, the coordinator would know the links between your inputs and outputs based on your IP address. In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
+You can turn off Tor in the Settings.
+Note that in this case you are still private, except when you CoinJoin and when you broadcast a transaction.
+In the first case, the coordinator would know the links between your inputs and outputs based on your IP address.
+In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
 
 ---
 

--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -5,33 +5,54 @@
 ---
 
 ### What is a CoinJoin?
-A mechanism by which multiple participants combine their coins (or UTXOs, to be more precise) into one large transaction with multiple inputs and multiple outputs. An observer cannot determine which output belongs to which input, and neither can the participants themselves. This makes it difficult for outside parties to trace where a particular coin originated from and where it was sent to (as opposed to regular bitcoin transactions, where there is usually one sender and one receiver).  
+A mechanism by which multiple participants combine their coins (or UTXOs, to be more precise) into one large transaction with multiple inputs and multiple outputs.
+An observer cannot determine which output belongs to which input, and neither can the participants themselves.
+This makes it difficult for outside parties to trace where a particular coin originated from and where it was sent to (as opposed to regular bitcoin transactions, where there is usually one sender and one receiver).
 
-In very simple terms, CoinJoin means: “when you want to make a transaction, find someone else who also wants to make a transaction and make a joint transaction together”.  
+In very simple terms, CoinJoin means: “when you want to make a transaction, find someone else who also wants to make a transaction and make a joint transaction together”.
 
 See also: https://en.bitcoin.it/wiki/CoinJoin
 
 ### Do I need to trust Wasabi with my coins?
-No, Wasabi's CoinJoin implementation is trustless by design. The participants do not need to trust each other or any third party. Both the sending address (the CoinJoin input) and the receiving address (the CoinJoin output) are controlled by your own private keys. Wasabi merely coordinates the process of combining the inputs of the participants into one single transaction, but the wallet can neither steal your coins, nor figure out which outputs belong to which inputs (look up “[Chaumian CoinJoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin)” if you want to know more).
+No, Wasabi's CoinJoin implementation is trustless by design.
+The participants do not need to trust each other or any third party. Both the sending address (the CoinJoin input) and the receiving address (the CoinJoin output) are controlled by your own private keys.
+Wasabi merely coordinates the process of combining the inputs of the participants into one single transaction, but the wallet can neither steal your coins, nor figure out which outputs belong to which inputs (look up “[Chaumian CoinJoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin)” if you want to know more).
 
 ### What is the privacy I get after mixing with Wasabi?
-This depends on how you handle your outputs after the CoinJoin. There are some ways how you can unintentionally undo the mixing by being careless. For example, if you make a 1.8 BTC transaction into Wasabi, do the CoinJoin, and then make one single outgoing transaction of 1.8 BTC, a third party observer can reasonably assume that both transactions belong to one single entity, due to both amounts being virtually the same even though they have been through a CoinJoin. In this scenario, Wasabi will barely make any improvement to your privacy, although it will still have a protective effect against unsophisticated observers.  
+This depends on how you handle your outputs after the CoinJoin.
+There are some ways how you can unintentionally undo the mixing by being careless.
+For example, if you make a 1.8 BTC transaction into Wasabi, do the CoinJoin, and then make one single outgoing transaction of 1.8 BTC, a third party observer can reasonably assume that both transactions belong to one single entity, due to both amounts being virtually the same even though they have been through a CoinJoin.
+In this scenario, Wasabi will barely make any improvement to your privacy, although it will still have a protective effect against unsophisticated observers.
 
 Another deanonymizing scenario happens when you combine mixed outputs with unmixed ones when sending: a third party will be able to make the connection between them as belonging to the same sender.
 
-The practice of being careful with your post-mix outputs is commonly facilitated through coin control, which is the default way of interacting with the wallet. Find out more about coin control it [here](https://medium.com/@nopara73/coin-control-is-must-learn-if-you-care-about-your-privacy-in-bitcoin-33b9a5f224a2).
+The practice of being careful with your post-mix outputs is commonly facilitated through coin control, which is the default way of interacting with the wallet.
+Find out more about coin control it [here](https://medium.com/@nopara73/coin-control-is-must-learn-if-you-care-about-your-privacy-in-bitcoin-33b9a5f224a2).
 
 ### Can I hurt my privacy using Wasabi?
-No. The worst thing that can happen (through user’s negligence post-mix) is that the level of your privacy stays the same as before CoinJoin. It is crucial to understand that Wasabi is not a fool-proof solution if you neglect to practice coin control after the mixing process.
+No.
+The worst thing that can happen (through user’s negligence post-mix) is that the level of your privacy stays the same as before CoinJoin.
+It is crucial to understand that Wasabi is not a fool-proof solution if you neglect to practice coin control after the mixing process.
 
 ### Does Wasabi have a warrant canary?
-The nature of Wasabi is that you should not need to trust the developers or the Wasabi coordinating server, as you can verify that the code does not leak information to anyone. The developers have gone to great lengths in an attempt to ensure that the coordinator cannot steal funds nor harvest information (for example, the outputs sent from your Wasabi Wallet are blinded, meaning that even the Wasabi server cannot link the outputs to the inputs). 
+The nature of Wasabi is that you should not need to trust the developers or the Wasabi coordinating server, as you can verify that the code does not leak information to anyone.
+The developers have gone to great lengths in an attempt to ensure that the coordinator cannot steal funds nor harvest information (for example, the outputs sent from your Wasabi Wallet are blinded, meaning that even the Wasabi server cannot link the outputs to the inputs). 
 
 The only known possible 'malicious' actions that the server *could* perform are two sides of the same coin;
 - **Blacklisted UTXO's**:
 Though this would not affect the users who are able to successfully mix with other 'honest/real' peers. 
 - **Targeted Sybil Attack**:
-The follow-up concern is the inverse of the above. It is possible that the server could *only* include one 'honest/real' coin in the mix and supply the other coins themselves. This would give a false sense of security, **but it would not worsen the existing privacy of the coin**. It would also be noticaable to all users excluding the user being targeted as their coins would not be mixed. It has been argued that this 'attack' would be very costly in terms of fees because the number of coins being mixed is verifiable. Though it is true that fees would have to be paid to zkSNACKs every round, this does not matter if it is zkSNACKs that is acting maliciously (as they get the funds back). Typical rounds currently have <100 people per mix, with the minimum input being ~0.1 BTC with a fee of 0.003% per anonymity set. Taking the 'worst case' (100 people, each mixing 0.1 BTC) gives 0.03 BTC per round. This is not prohibitive and is thus a valid concern. That said, if multiple chain-analysis companies attempt to flood the zkSNACKs mix (to decrease the true anonymity set) they will hinder each other's efforts (unless they are cooperating). See [here](https://github.com/nopara73/ZeroLink/#e-sybil-attack) for more info.
+The follow-up concern is the inverse of the above.
+It is possible that the server could *only* include one 'honest/real' coin in the mix and supply the other coins themselves.
+This would give a false sense of security, **but it would not worsen the existing privacy of the coin**.
+It would also be noticaable to all users excluding the user being targeted as their coins would not be mixed.
+It has been argued that this 'attack' would be very costly in terms of fees because the number of coins being mixed is verifiable.
+Though it is true that fees would have to be paid to zkSNACKs every round, this does not matter if it is zkSNACKs that is acting maliciously (as they get the funds back).
+Typical rounds currently have <100 people per mix, with the minimum input being ~0.1 BTC with a fee of 0.003% per anonymity set.
+Taking the 'worst case' (100 people, each mixing 0.1 BTC) gives 0.03 BTC per round.
+This is not prohibitive and is thus a valid concern.
+That said, if multiple chain-analysis companies attempt to flood the zkSNACKs mix (to decrease the true anonymity set) they will hinder each other's efforts (unless they are cooperating).
+See [here](https://github.com/nopara73/ZeroLink/#e-sybil-attack) for more info.
 
 ---
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -12,16 +12,25 @@
 
 ## Receive
 ### Why is it bad to re-use addresses?
-Bitcoin is designed so that for every payment you can use a new address that is not tied to any of your previous addresses. When you use a new address for every coin, then it becomes much much more difficult to find out that these coins are from you. However, when you use the same address for every coin, then everyone knows that they all can be spend by one individual who has knowledge of the private key - you! Thus, when someone finds out that you have that address, maybe you published it in your social media profile for donations, or you send a coin to another peer who knows you, then they know also how many bitcoin you have in the other coins with that same address. Take good care to whom you tell your addresses, and every time, tell someone a different address.
+Bitcoin is designed so that for every payment you can use a new address that is not tied to any of your previous addresses.
+When you use a new address for every coin, then it becomes much much more difficult to find out that these coins are from you.
+However, when you use the same address for every coin, then everyone knows that they all can be spend by one individual who has knowledge of the private key - you!
+Thus, when someone finds out that you have that address, maybe you published it in your social media profile for donations, or you send a coin to another peer who knows you, then they know also how many bitcoin you have in the other coins with that same address.
+Take good care to whom you tell your addresses, and every time, tell someone a different address.
 
-Because you have all the private keys, for all these addresses, you can produce a valid signature for any of them. So you can proof that these are your bitcoin, without relying on reputation that you have any other coins. You can easily generate and store many billions of private keys and addresses in a convenient [BIP 44 multi-account hierarchy for deterministic wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) so that you can backup everything in your 12 word mnemonic phrase. 
+Because you have all the private keys, for all these addresses, you can produce a valid signature for any of them.
+So you can proof that these are your bitcoin, without relying on reputation that you have any other coins.
+You can easily generate and store many billions of private keys and addresses in a convenient [BIP 44 multi-account hierarchy for deterministic wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) so that you can backup everything in your 12 word mnemonic phrase. 
 
-This is what is used in Wasabi, you have on mnemonic backup, and unlimited numbers of new addresses. Everytime you a coin is received, then the address is removed from the GUI so that you are not tempted to use it again.
+This is what is used in Wasabi, you have on mnemonic backup, and unlimited numbers of new addresses.
+Everytime you a coin is received, then the address is removed from the GUI so that you are not tempted to use it again.
 
 Remember: ***NEVER RE-USE ADDRESSES***
 
 ### Why does Wasabi only use SegWit bech32 addresses?
-Wasabi generates Bech32 addresses only, also known as bc1 addresses or native SegWit addresses. These addresses start with the characters `bc1...` Some wallets/exchanges do not yet support this type of address and may give an error message (e.g. "unknown bitcoin address"). The solution is to manage your funds with a wallet which does support Bech32, [see list](https://en.bitcoin.it/wiki/Bech32_adoption).
+Wasabi generates Bech32 addresses only, also known as bc1 addresses or native SegWit addresses.
+These addresses start with the characters `bc1...` Some wallets/exchanges do not yet support this type of address and may give an error message (e.g. "unknown bitcoin address").
+The solution is to manage your funds with a wallet which does support Bech32, [see list](https://en.bitcoin.it/wiki/Bech32_adoption).
 
 Be careful, if you send all your coins from an old wallet to a new wallet (from the table above) in one transaction then you will merge all your coins which is bad for privacy - instead, **send the coins individually** or if possible **import the seed in the new wallet**.
 
@@ -30,9 +39,14 @@ Be careful, if you send all your coins from an old wallet to a new wallet (from 
 
 ### Why does Wasabi choose a new random node every time I send a transaction?
 
-When you broadcast a transaction from a full node, that transaction is flooded into the network. Essentially, all nearby nodes are passed your transaction, and those nodes will pass to all of their nearby nodes, etc. However, if a malicious adversary were to get enough relay nodes in the network, they could pretty easily connect the initial location of a transaction by simply observing from which node the transaction appeared first. For this reason, broadcasting transaction through your own node may reveal your IP address.
+When you broadcast a transaction from a full node, that transaction is flooded into the network.
+Essentially, all nearby nodes are passed your transaction, and those nodes will pass to all of their nearby nodes, etc.
+However, if a malicious adversary were to get enough relay nodes in the network, they could pretty easily connect the initial location of a transaction by simply observing from which node the transaction appeared first.
+For this reason, broadcasting transaction through your own node may reveal your IP address.
 
-So to fix this Wasabi broadcasts your transactions to a random node, and messages that node through TOR, so the node cannot detect your IP address. When you want to subsequently send another transaction on the network, Wasabi destroys the original TOR bridge and connection to the node and established a new TOR bridge and connection with a brand new node. This reduces the risk of a passive bystander being able to link two transactions together that appear from the same location.
+So to fix this Wasabi broadcasts your transactions to a random node, and messages that node through TOR, so the node cannot detect your IP address.
+When you want to subsequently send another transaction on the network, Wasabi destroys the original TOR bridge and connection to the node and established a new TOR bridge and connection with a brand new node.
+This reduces the risk of a passive bystander being able to link two transactions together that appear from the same location.
 
 
 ## History
@@ -40,11 +54,18 @@ So to fix this Wasabi broadcasts your transactions to a random node, and message
 
 ## CoinJoin
 ### What are the fees for the CoinJoin?
-You currently pay a fee of 0.003% * anonymity set. If the anonymity set of a coin is 50 then you pay 0.003% * 50 (=0.15%). If you set the target anonymity set to 53 then Wasabi will continue mixing until this is reached, so you may end up with an anonymity set of say 60, and you will pay 0.003% * 60 (=0.18%).  
+You currently pay a fee of 0.003% * anonymity set.
+If the anonymity set of a coin is 50 then you pay 0.003% * 50 (=0.15%).
+If you set the target anonymity set to 53 then Wasabi will continue mixing until this is reached, so you may end up with an anonymity set of say 60, and you will pay 0.003% * 60 (=0.18%).
 
-There are also edge cases where you do not pay the full fee or where you pay more. For example if you're the smallest registrant to a round, you will never pay a fee. Also when you are remixing and you cannot pay the full fee with your input, then you only pay as much as you have, but if the change amount leftover would be too small, then that is also added to the fee. Currently the minimum change amount to be paid out is 0.7% of the base denomination (~0.1BTC.)  
+There are also edge cases where you do not pay the full fee or where you pay more.
+For example if you're the smallest registrant to a round, you will never pay a fee.
+Also when you are remixing and you cannot pay the full fee with your input, then you only pay as much as you have, but if the change amount leftover would be too small, then that is also added to the fee.
+Currently the minimum change amount to be paid out is 0.7% of the base denomination (~0.1BTC.)
 
-It is also possible that you get more back from mixing than you put in. This happens when network fees go down between the start of the round and its end. In this case, the difference is split between the active outputs of the mix.
+It is also possible that you get more back from mixing than you put in.
+This happens when network fees go down between the start of the round and its end.
+In this case, the difference is split between the active outputs of the mix.
 
 ### What is the anonymity set?
 The anonymity set is effectively the size of the group you are hiding in. 
@@ -61,21 +82,24 @@ If 3 people take part in a CoinJoin (with equal size inputs) and there are 3 out
 
 There is no way to know which of the anon set output coins are owned by which of the input owners.
 
-All an observer knows is that a specific anon set output coin is owned by one of the owners of one of the input Coins i.e. 3 people - hence an anonymity set of 3.  
+All an observer knows is that a specific anon set output coin is owned by one of the owners of one of the input Coins i.e. 3 people - hence an anonymity set of 3.
 
-Your Wasabi software has limited information on what the anonymity set should be, so the anonymity set that the software presents you is just an estimation, not an accurate value. With Wasabi we are trying to do lower estimations, rather than higher ones.
+Your Wasabi software has limited information on what the anonymity set should be, so the anonymity set that the software presents you is just an estimation, not an accurate value.
+With Wasabi we are trying to do lower estimations, rather than higher ones.
 
 ### Can I mix more than the round's minimum?
 
-Yes.  
+Yes.
 
 In a round with a ~0.1 BTC minimum, you could mix ~0.3 BTC and get a ~0.1 BTC output & a ~ 0.2 BTC output.
 
-Similarly, with a 0.7 BTC input you would expect the following outputs: ~0.1, ~0.2, ~0.4 BTC. The possible values of equal output that can be created are 0.1 x 2^n where n is a positive integer (or zero).  [See more here](https://youtu.be/PKtxzSLPWFU) and [here](https://youtu.be/3Ezru07J674).
+Similarly, with a 0.7 BTC input you would expect the following outputs: ~0.1, ~0.2, ~0.4 BTC.
+The possible values of equal output that can be created are 0.1 x 2^n where n is a positive integer (or zero).  [See more here](https://youtu.be/PKtxzSLPWFU) and [here](https://youtu.be/3Ezru07J674).
 
 ### Why are the denominations such an odd number?
 
-The output value changes each round to ensure that you can enqueue a coin and have it remix (mix over and over again - increasing the anonymity set, improving privacy). As a result the round mixing amount will often be a specific number which generally decreases as the rounds proceed, with a reset once a lower bound is reached. 
+The output value changes each round to ensure that you can enqueue a coin and have it remix (mix over and over again - increasing the anonymity set, improving privacy).
+As a result the round mixing amount will often be a specific number which generally decreases as the rounds proceed, with a reset once a lower bound is reached. 
 
 ## Hardware Wallet
 ### How can I generate a Wasabi skeleton wallet file in ColdCard?
@@ -83,37 +107,54 @@ On the ColdCard (Mk2, firmware 2.1.1 and up) you go to ```>Advanced>MicrcoSD Car
 
 ### How can I import the Wasabi skeleton wallet file?
 Take the MicroSD card from the ColdCard and plug it in the computer with the Wasabi Wallet software.
-In Wasabi Wallet go to the Wallet Manager, select Hardware Wallet option and in the bottom right corner click ```Import Coldcard```. Now select the Wasabi skeleton json-file from the MicroSD card, if this fails you can manually enter the file location in Wasabi Wallet window and load the file.
+In Wasabi Wallet go to the Wallet Manager, select Hardware Wallet option and in the bottom right corner click ```Import Coldcard```.
+Now select the Wasabi skeleton json-file from the MicroSD card, if this fails you can manually enter the file location in Wasabi Wallet window and load the file.
 
 ### How can I generate a receiving address of my hardware wallet?
-In Wasabi Wallet you load your previously imported wallet (from Wasabi skeleton, or USB detection) and go to the ```Receive``` tab, here you enter a label for the incoming transaction and click ```Generate Receive Address```. In the tab below the newly generated receive address can be viewd/copied.
+In Wasabi Wallet you load your previously imported wallet (from Wasabi skeleton, or USB detection) and go to the ```Receive``` tab, here you enter a label for the incoming transaction and click ```Generate Receive Address```.
+In the tab below the newly generated receive address can be viewd/copied.
 
 ### How can I sign a transaction with a USB connected hardware wallet?
-To send a transaction you will need to connect your Hardware wallet and unlock the device (using PIN or password), in Wasabi Wallet you go to the ```Send``` tab where you can specify the address to send to, amount of bitcoin to send and which coins to use as input (only use green/private coins here!). After filling in all transaction details you click ```Send Transaction``` to sign it with the connected hardware wallet and broadcast on the network.
+To send a transaction you will need to connect your Hardware wallet and unlock the device (using PIN or password), in Wasabi Wallet you go to the ```Send``` tab where you can specify the address to send to, amount of bitcoin to send and which coins to use as input (only use green/private coins here!).
+After filling in all transaction details you click ```Send Transaction``` to sign it with the connected hardware wallet and broadcast on the network.
 
 ### How can I build and export a transaction to ColdCard?
-In the Wallet Explorer on the right side of the GUI, select ```YourWallet>Advanced>Build Transaction```. This brings up the ```Build Transaction``` tab where you can specify the address, amount of bitcoin and coins to use. Then by clicking ```Build Transaction``` a new tab will open containing the raw transaction data, here you click ```Export Binary PSBT``` to save the partially signed bitcoin transaction (PSBT) to a file. This file should be moved to the MicroSD card that you can then insert in the ColdCard for manual verification and signing.
+In the Wallet Explorer on the right side of the GUI, select ```YourWallet>Advanced>Build Transaction```.
+This brings up the ```Build Transaction``` tab where you can specify the address, amount of bitcoin and coins to use.
+Then by clicking ```Build Transaction``` a new tab will open containing the raw transaction data, here you click ```Export Binary PSBT``` to save the partially signed bitcoin transaction (PSBT) to a file.
+This file should be moved to the MicroSD card that you can then insert in the ColdCard for manual verification and signing.
 
 ### How can I sign a transaction on the ColdCard?
-On the ColdCard (Mk2, firmware 2.1.1 and up) you enter the PIN code to unlock the hardware wallet and press ```>Ready To Sign``` with the MicroSD card containing the previously generated transaction or PSBT-file. Verify the address and amount and the ColdCard will then create a signed.psbt and final.txn file on the MicroSD card. The finalized transaction (xxx-final.txn) can now be broadcasted by Wasabi Wallet or even a radio or satelite dish if someone is listening!
+On the ColdCard (Mk2, firmware 2.1.1 and up) you enter the PIN code to unlock the hardware wallet and press ```>Ready To Sign``` with the MicroSD card containing the previously generated transaction or PSBT-file.
+Verify the address and amount and the ColdCard will then create a signed.psbt and final.txn file on the MicroSD card.
+The finalized transaction (xxx-final.txn) can now be broadcasted by Wasabi Wallet or even a radio or satelite dish if someone is listening!
 
 ### How can I import and broadcast a final transaction from ColdCard?
-In the Wallet Explorer you go to ```YourWallet>Advanced>Broadcast Transaction``` and click ```Import Transaction```, now you can select the previously finalized (and signed) transaction file from the MicroSD card. If this fails you can manually type the path to this file in Wasabi Wallet to load the transaction. Now click ```Broadcast Transaction``` to send it off over Tor to a random Bitcoin node so it can flood over to the miners for confirmation in a block. 
+In the Wallet Explorer you go to ```YourWallet>Advanced>Broadcast Transaction``` and click ```Import Transaction```, now you can select the previously finalized (and signed) transaction file from the MicroSD card.
+If this fails you can manually type the path to this file in Wasabi Wallet to load the transaction.
+Now click ```Broadcast Transaction``` to send it off over Tor to a random Bitcoin node so it can flood over to the miners for confirmation in a block. 
 
 ### Can I CoinJoin the bitcoin on my hardware wallet?
 You can't do that directly, so send them (in small portions >0.1BTC if needed) to a ''hot'' Wasabi Wallet for CoinJoin and then send them back to a new address on the Hardware wallet for cold-storage. 
 
 ## Settings
 ### How do I connect my own full node to Wasabi?
-There is currently a basic implementation of connecting your full node to Wasabi. The server will still send you [BIP 158 block filters](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki), and when you realize that a block contains a transaction of yours, then you pull this block from your own full node, instead of a random P2P node, thus you can verify that this is actually a valid block including your transaction. One attack vector could be that Wasabi lies to you and gives you wrong filters that exclude your transaction, thus you would see in the wallet less coins than you actually control. [BIP 157 solves this](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki).
+There is currently a basic implementation of connecting your full node to Wasabi.
+The server will still send you [BIP 158 block filters](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki), and when you realize that a block contains a transaction of yours, then you pull this block from your own full node, instead of a random P2P node, thus you can verify that this is actually a valid block including your transaction.
+One attack vector could be that Wasabi lies to you and gives you wrong filters that exclude your transaction, thus you would see in the wallet less coins than you actually control. [BIP 157 solves this](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki).
 
-When your full node is on the same hardware [computer, laptop] as your Wasabi Wallet, then it will automatically recognize it and pull blocks from there. If your node is on a remote device [raspberry pi, nodl, server], then you can specify your local IP in the Settings tab, or in line 11 of the config file. [See more here](https://youtu.be/gWo2RAkIVrE).
+When your full node is on the same hardware [computer, laptop] as your Wasabi Wallet, then it will automatically recognize it and pull blocks from there.
+If your node is on a remote device [raspberry pi, nodl, server], then you can specify your local IP in the Settings tab, or in line 11 of the config file. [See more here](https://youtu.be/gWo2RAkIVrE).
 
 ### How can I turn off Tor?
-You can turn off Tor in the Settings. Note that in this case you are still private, except when you CoinJoin and when you broadcast a transaction. In the first case, the coordinator would know the links between your inputs and outputs based on your IP address. In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
+You can turn off Tor in the Settings.
+Note that in this case you are still private, except when you CoinJoin and when you broadcast a transaction.
+In the first case, the coordinator would know the links between your inputs and outputs based on your IP address.
+In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
 
 ### How can I change the anonset target?
-In the Settings tab at the bottom you can change the three `PrivacyLevelX` values of the desired anon set of the yellow, green, and checkmark shield button in the GUI. The `MixUntilAnonymitySet` is the last selected value from previous use. 
+In the Settings tab at the bottom you can change the three `PrivacyLevelX` values of the desired anon set of the yellow, green, and checkmark shield button in the GUI.
+The `MixUntilAnonymitySet` is the last selected value from previous use. 
 
 In the wallet GUI, go to `File`>`Open`>`Config File` and in the last 4 lines you see:
 
@@ -124,39 +165,61 @@ In the wallet GUI, go to `File`>`Open`>`Config File` and in the last 4 lines you
 "PrivacyLevelStrong": 50
 ```
 
-Remember that you pay a fee proportional to the Anonymity Set. [See more here](https://youtu.be/gWo2RAkIVrE?t=191).
+Remember that you pay a fee proportional to the Anonymity Set.
+[See more here](https://youtu.be/gWo2RAkIVrE?t=191).
 
 
 ## Coin Control Best Practices 
 ### Can I consolidate anonset coins?
-It is advisable to limit the recombining of mixed coins because it can only decrease the privacy of said coins. This links all the consolidated UTXOs in one transaction, creating only one output, which then clearly controls all these funds. That said, if you combine less than 1 BTC it is less likely to reveal your pre-CoinJoin transaction history. The potential issue comes when you spend that coin. Depending on what you do with the coin you might reduce the privacy of the resulting change (if you send half your coin to an exchange for example, as they will know that you own the coin change). As a result it is best not to recombine ALL your mixed change, though you may wish to recombine some coins if you are planning on hodling for many years as this will reduce the fees required to spend the coins later.
+It is advisable to limit the recombining of mixed coins because it can only decrease the privacy of said coins.
+This links all the consolidated UTXOs in one transaction, creating only one output, which then clearly controls all these funds.
+That said, if you combine less than 1 BTC it is less likely to reveal your pre-CoinJoin transaction history.
+The potential issue comes when you spend that coin. Depending on what you do with the coin you might reduce the privacy of the resulting change (if you send half your coin to an exchange for example, as they will know that you own the coin change).
+As a result it is best not to recombine ALL your mixed change, though you may wish to recombine some coins if you are planning on hodling for many years as this will reduce the fees required to spend the coins later.
 
 If you would like to dive into the details of this topic, you can [read more here](https://old.reddit.com/r/WasabiWallet/comments/avxbjy/combining_mixed_coins_privacy_megathread/) and [see more here](https://www.youtube.com/watch?v=Tk8-N1kHa4g).
 
 ### How can I send my anonset coins to my hardware wallet?
-Most hardware wallets communicate with servers to provide you with your balance. This reveals your public key to the server, which damages your privacy - the hardware company can now theoretically link together all your addresses. As a result **it is not recommended** that you send your mixed coins to an address associated with your hardware wallet unless you are confident that you have set up your hardware wallet in a way that it does not communicate with a 3rd party server (see below). 
+Most hardware wallets communicate with servers to provide you with your balance.
+This reveals your public key to the server, which damages your privacy - the hardware company can now theoretically link together all your addresses.
+As a result **it is not recommended** that you send your mixed coins to an address associated with your hardware wallet unless you are confident that you have set up your hardware wallet in a way that it does not communicate with a 3rd party server (see below). 
 
-You can, however, manage your hardware wallet with the Wasabi interface. Alternatively, you can use your hardware wallet with Electrum, which connects to your Bitcoin Core full node through [Electrum Personal Server](https://github.com/chris-belcher/electrum-personal-server).
+You can, however, manage your hardware wallet with the Wasabi interface.
+Alternatively, you can use your hardware wallet with Electrum, which connects to your Bitcoin Core full node through [Electrum Personal Server](https://github.com/chris-belcher/electrum-personal-server).
 
 ### What can I do with small change?
-There are no hard and fast rules for what to do with the change. Generally try to avoid the change and use the `Max` button extensively to send whole coins. The most problematic type of change is what has `anonymity set 1` (red shield.) You should treat it as a kind of toxic waste (handled with great care).
+There are no hard and fast rules for what to do with the change.
+Generally try to avoid the change and use the `Max` button extensively to send whole coins.
+The most problematic type of change is what has `anonymity set 1` [red shield] You should treat it as a kind of toxic waste [handled with great care].
 
 **Warning**
 
-You want to avoid merging `anonymity set 1 coins` with `anonymity set > 1 coins` wherever possible, because this will link your `anonymity set > 1 coin` to the coin you merge it with. Note that, this is also true if you merge them in a mix, however that is slightly less problematic, because some blockchain analysis techniques become [computationally infeasible](https://www.comsys.rwth-aachen.de/fileadmin/papers/2017/2017-maurer-trustcom-coinjoin.pdf).
+You want to avoid merging `anonymity set 1 coins` with `anonymity set > 1 coins` wherever possible, because this will link your `anonymity set > 1 coin` to the coin you merge it with.
+Note that, this is also true if you merge them in a mix, however that is slightly less problematic, because some blockchain analysis techniques become [computationally infeasible](https://www.comsys.rwth-aachen.de/fileadmin/papers/2017/2017-maurer-trustcom-coinjoin.pdf).
 
 It is also important that you do not send different coins to the same receiving address (even if performed as separate transactions) as this will also link the coins together, damaging your privacy.
 
 There are two different types of zero link change:
 
-When you have a KYC coin with red anonset 1 and you register it for CoinJoin, then you get one anonset 100 green coin and one red anonset 1 change. This change is very clearly tied to your KYC input coin, but the CoinJoin output is pretty good with anonset 100. If you combine that red coin with the green, then it's clear that both of them belong to you, and thus the anonset of the output in this transactioin becomes the lowest common denominator, in this case anonset 1.
+When you have a KYC coin with red anonset 1 and you register it for CoinJoin, then you get one anonset 100 green coin and one red anonset 1 change.
+This change is very clearly tied to your KYC input coin, but the CoinJoin output is pretty good with anonset 100.
+If you combine that red coin with the green, then it's clear that both of them belong to you, and thus the anonset of the output in this transactioin becomes the lowest common denominator, in this case anonset 1.
 
-When you take a 100 anonset coin, and you register it again for CoinJoin, then you get one coin with anonset 200, and one change with anonset 100. This change has anonset 100 because it can be linked to the input of the second CoinJoin, but this coin has anonset 100 already. So, although this change can still reveal pre-mix history, because the pr-mix history is another CoinJoin, you cannot go farther back. So, it might be ok to send this second change output to some place, or even consolidate it, because it still has anonset.
+When you take a 100 anonset coin, and you register it again for CoinJoin, then you get one coin with anonset 200, and one change with anonset 100.
+This change has anonset 100 because it can be linked to the input of the second CoinJoin, but this coin has anonset 100 already.
+So, although this change can still reveal pre-mix history, because the pr-mix history is another CoinJoin, you cannot go farther back.
+So, it might be ok to send this second change output to some place, or even consolidate it, because it still has anonset.
 
-When you consolidate several small change coins in a regular transaction, then every outside observer knows that they belong to the same cluster. However, you can consolidate within a CoinJoin by simply selecting all these coins in the CoinJoin tab. Because the Wasabi CoinJoin transaction shuffles inputs, for an outside observer it is not clear which inputs belong to the same Alice. However, the coordinator gets the input proof of **ALL** the coins that Alice has provided during the input registration phase. Thus the coordinator knows that this is a consolidation transaction. It is wise to assume that every one knows what the coordinator knows. So consolidating in a CoinJoin is better, but it might still reveal the common ownership of the coins.
+When you consolidate several small change coins in a regular transaction, then every outside observer knows that they belong to the same cluster.
+However, you can consolidate within a CoinJoin by simply selecting all these coins in the CoinJoin tab.
+Because the Wasabi CoinJoin transaction shuffles inputs, for an outside observer it is not clear which inputs belong to the same Alice.
+However, the coordinator gets the input proof of **ALL** the coins that Alice has provided during the input registration phase.
+Thus the coordinator knows that this is a consolidation transaction.
+It is wise to assume that every one knows what the coordinator knows.
+So consolidating in a CoinJoin is better, but it might still reveal the common ownership of the coins.
 
 **Your Options**
-- If you do not care about linking the history of the coins because they are all from the same source then you could combine them in a mix (queue all the change from the same source until you reach the minimum input required to mix, currently ~ 0.1 BTC).  
+- If you do not care about linking the history of the coins because they are all from the same source then you could combine them in a mix (queue all the change from the same source until you reach the minimum input required to mix, currently ~ 0.1 BTC).
 - Mix with [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver).
 - Donate them (e.g. [to the EFF](https://www.eff.org/))
 - Spend them on something that is not a particular privacy risk (eg. gift cards).

--- a/docs/FAQ/README.md
+++ b/docs/FAQ/README.md
@@ -4,7 +4,8 @@ title : Frequently Asked Questions
 
 # Frequently Asked Questions about Wasabi Wallet
 
-This document contains a list of all the questions and common issues answered in this archive. The hyperlinks lead to the separate files with answers to the questions.
+This document contains a list of all the questions and common issues answered in this archive.
+The hyperlinks lead to the separate files with answers to the questions.
 
 ## [General Bitcoin Privacy](FAQ-GeneralBitcoinPrivacy.md)
 - I have nothing to hide, do I still need financial privacy?

--- a/docs/IntroWasabi.md
+++ b/docs/IntroWasabi.md
@@ -1,13 +1,17 @@
 
-This is the open source documentation repository of Wasabi Wallet, here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself. If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
+This is the open source documentation repository of Wasabi Wallet, here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself.
+If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
 
 # WasabiDoc
 
 [Wasabi](https://wasabiwallet.io) is an open-source, non-custodial, privacy focused Bitcoin wallet for desktop. It implements trustless coin shuffling: [Schnorrian CoinJoin](https://github.com/nopara73/ZeroLink/).
 
-However, "[anonymity loves company](https://www.freehaven.net/anonbib/cache/usability:weis2006.pdf)", the more participants there are, the better your privacy is, and the faster the CoinJoin rounds are. Whether you are looking for state of the art operational security or you are philosophically aligned with the principles of freedom and privacy, now it is YOUR time to contribute. Fire up your Wasabi and help us to bootstrap the system!
+However, "[anonymity loves company](https://www.freehaven.net/anonbib/cache/usability:weis2006.pdf)", the more participants there are, the better your privacy is, and the faster the CoinJoin rounds are.
+Whether you are looking for state of the art operational security or you are philosophically aligned with the principles of freedom and privacy, now it is YOUR time to contribute.
+Fire up your Wasabi and help us to bootstrap the system!
 
-This is the open source documentation repository of Wasabi Wallet, here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself. If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
+This is the open source documentation repository of Wasabi Wallet, here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself.
+If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
 
 
 ## Basics

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,4 +14,5 @@ features:
 
 -----
 
-This is the open source documentation repository of [Wasabi Wallet](https://wasabiwallet.io), here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself. If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
+This is the open source documentation repository of [Wasabi Wallet](https://wasabiwallet.io), here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves these difficult problems, and how you can use these tools to defend yourself.
+If you have a question that is not yet covered, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues), if you have a good answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).

--- a/docs/building-wasabi/CodeCoverage.md
+++ b/docs/building-wasabi/CodeCoverage.md
@@ -1,7 +1,6 @@
 # Code coverage (How to)
 
-Wasabi Wallet is built using dotnet core. Given there is no cross-platform Profiling API like the one available on Windows, we
-use [AltCover](https://github.com/SteveGilham/altcover) package for instrumenting the assemblies and recording the execution
+Wasabi Wallet is built using dotnet core. Given there is no cross-platform Profiling API like the one available on Windows, we use [AltCover](https://github.com/SteveGilham/altcover) package for instrumenting the assemblies and recording the execution
 coverage.
 
 So, first of all we need to install the package in the `WalletWasabi.Tests` project as follow:
@@ -17,7 +16,8 @@ Next, run:
 dotnet test /p:AltCover=true /p:AltCoverLcovReport=lcov.info
 ```
 
-As a result we get a `lcov.info` file containing the covered lines. In order to be able to see what lines
+As a result we get a `lcov.info` file containing the covered lines.
+In order to be able to see what lines
 are covered we need to install a `vscode extension` called  [Coverage Gutters](https://github.com/ryanluker/vscode-coverage-gutters).
 
 Run vscode and click on "Watch":

--- a/docs/building-wasabi/CodingConventions.md
+++ b/docs/building-wasabi/CodingConventions.md
@@ -6,18 +6,23 @@
 
 ## CodeMaid
 
-**DO** use [CodeMaid](http://www.codemaid.net/),  a Visual Studio extension to automatically clean up your code on saving the file.
+**DO** use [CodeMaid](http://www.codemaid.net/), a Visual Studio extension to automatically clean up your code on saving the file.
 
-CodeMaid is a non-intrusive code cleanup tool. Wasabi's CodeMaid settings [can be found in the root of the repository](https://github.com/zkSNACKs/WalletWasabi/blob/master/CodeMaid.config), and are automatically picked up by Visual Studio when you open the project, assuming the CodeMaid extension is installed. Unfortunately CodeMaid has no Visual Studio Code extension yet. You can check out the progress on this [under this GitHub issue](https://github.com/codecadwallader/codemaid/issues/273).
+CodeMaid is a non-intrusive code cleanup tool.
+Wasabi's CodeMaid settings [can be found in the root of the repository](https://github.com/zkSNACKs/WalletWasabi/blob/master/CodeMaid.config), and are automatically picked up by Visual Studio when you open the project, assuming the CodeMaid extension is installed.
+Unfortunately CodeMaid has no Visual Studio Code extension yet.
+You can check out the progress on this [under this GitHub issue](https://github.com/codecadwallader/codemaid/issues/273).
 
 ## .editorconfig
 
-Not only CodeMaid, but Visual Studio also enforces certain code style through [`.editorconfig`](https://github.com/zkSNACKs/WalletWasabi/blob/master/.editorconfig) file.  
+Not only CodeMaid, but Visual Studio also enforces certain code style through [`.editorconfig`](https://github.com/zkSNACKs/WalletWasabi/blob/master/.editorconfig) file.
+
 If you are using Visual Studio code, please **DO** install the [editorconfig extension](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) for it to make sure your coding style will resemble to ours.
 
 ## Refactoring
 
-If you are a new contributor **DO** keep refactoring pull requests short, uncomplex and easy to verify. It requires a certain level of experience to know where the code belongs to and to understand the full ramification (including rebase effort of open pull requests) - [source](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#refactoring).
+If you are a new contributor **DO** keep refactoring pull requests short, uncomplex and easy to verify.
+It requires a certain level of experience to know where the code belongs to and to understand the full ramification (including rebase effort of open pull requests) - [source](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#refactoring).
 
 ## Comments
 
@@ -62,7 +67,8 @@ using (AsyncLock.Lock())
 
 ## Null Check
 
-**DO** use `is null` instead of `== null`. It was a performance consideration in the past but from C# 7.0 it does not matter anymore, today we use this convention to keep our code consistent.
+**DO** use `is null` instead of `== null`.
+It was a performance consideration in the past but from C# 7.0 it does not matter anymore, today we use this convention to keep our code consistent.
 
 ```cs
 	if (foo is null) return;
@@ -70,7 +76,8 @@ using (AsyncLock.Lock())
 
 ## Blocking
 
-**DO NOT** block with `.Result, .Wait(), .GetAwaiter().GetResult()`. Never.
+**DO NOT** block with `.Result, .Wait(), .GetAwaiter().GetResult()`.
+Never.
 
 ```cs
 // BAD
@@ -79,7 +86,8 @@ IoHelpers.DeleteRecursivelyWithMagicDustAsync(Folder).GetAwaiter().GetResult();
 
 ## `async void`
 
-**DO NOT** `async void`, except for event subscriptions. `async Task` instead.
+**DO NOT** `async void`, except for event subscriptions.
+`async Task` instead.
 **DO** `try catch` in `async void`, otherwise the software can crash.
 
 ```cs
@@ -105,7 +113,8 @@ private async void Synchronizer_ResponseArrivedAsync(object sender, EventArgs e)
 
 **DO** follow [ReactiveUI's Subscription Disposing Conventions](https://reactiveui.net/docs/guidelines/framework/dispose-your-subscriptions).
 
-**DO** dispose your subscription if you are referencing another object. **DO** use the `.DisposeWith()` method.
+**DO** dispose your subscription if you are referencing another object.
+**DO** use the `.DisposeWith()` method.
 
 ```cs
 Observable.FromEventPattern(...)
@@ -114,7 +123,10 @@ Observable.FromEventPattern(...)
 	.DisposeWith(Disposables);
 ```
 
-**DO NOT** dispose your subscription if a component exposes an event and also subscribes to it itself. That's because the subscription is manifested as the component having a reference to itself. Same is true with Rx. If you're a VM and you e.g. WhenAnyValue against your own property, there's no need to clean that up because that is manifested as the VM having a reference to itself.
+**DO NOT** dispose your subscription if a component exposes an event and also subscribes to it itself.
+That's because the subscription is manifested as the component having a reference to itself.
+Same is true with Rx.
+If you're a VM and you e.g. WhenAnyValue against your own property, there's no need to clean that up because that is manifested as the VM having a reference to itself.
 
 ```cs
 this.WhenAnyValue(...)

--- a/docs/building-wasabi/ContributionChecklist.md
+++ b/docs/building-wasabi/ContributionChecklist.md
@@ -4,25 +4,32 @@
 
 ---
 
-So you're interested in contributing go Wasabi - welcome! This checklist will get you plugged in and productive as quickly as possible.
+So you're interested in contributing go Wasabi - welcome!
+This checklist will get you plugged in and productive as quickly as possible.
 
 ### Who is a contributor?
 :::tip
-Wasabi is free and open source software, but contributing is **not** just about writing code. **A contributor is any individual who works to improve and add value to Wasabi and its users.**
+Wasabi is free and open source software, but contributing is **not** just about writing code.
+**A contributor is any individual who works to improve and add value to Wasabi and its users.**
 
-This can mean anything from fixing typos in documentation, to answering questions of fellow Wasabikas, to implementing new Wasabi features and everything in-between. All such contributions are very welcomed and greatly appreciated.
+This can mean anything from fixing typos in documentation, to answering questions of fellow Wasabikas, to implementing new Wasabi features and everything in-between.
+All such contributions are very welcomed and greatly appreciated.
 :::
 
 ## Say hello and get started
 - Join our [Slack](https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2NzQ1ODI0LWIzOTg5YTM3YmNkOTg1NjZmZTQ3NmM1OTAzYmQyYzk1M2M0MTdlZDk2OTQwNzFiNTg1ZmExNzM0NjgzY2M0Yzg), [Telegram](https://t.me/WasabiWallet) or [Sub-Reddit](https://www.reddit.com/r/WasabiWallet/), and check out the [GitHub](https://github.com/zkSnacks/WalletWasabi)
-- Introduce yourself, say a bit about your skills and interests. This will help others point you in the right direction.
-- Explore the communication channels and find out what the peers are tinkering on, learn about the project and who is contributing in what way. This will help you to find the interesting challenges you can work on.
+- Introduce yourself, say a bit about your skills and interests.
+This will help others point you in the right direction.
+- Explore the communication channels and find out what the peers are tinkering on, learn about the project and who is contributing in what way.
+This will help you to find the interesting challenges you can work on.
 
 ## Learn how we work
 - To understand how Wasabi coin joins work, read [Zero Link: The Bitcoin Fungibility Framework](https://github.com/nopara73/zerolink) and explore the [Documentation](README.md).
-- Familiarize yourself with [C4: The Collective Code Construction Contract](https://rfc.unprotocols.org/spec:1/C4/). It’s a simple set of collaboration rules based on GitHub’s fork+pull request model, and a foundational part of how we work together.
+- Familiarize yourself with [C4: The Collective Code Construction Contract](https://rfc.unprotocols.org/spec:1/C4/).
+It’s a simple set of collaboration rules based on GitHub’s fork+pull request model, and a foundational part of how we work together.
 
-`This is the place for the philosophy that we want to see in the project. Open for many additions!`
+`This is the place for the philosophy that we want to see in the project.
+Open for many additions!`
 
 ## Get connected
 - Subscribe to the [Wasabi YouTube channel](https://www.youtube.com/channel/UCobsrSexTuVkL39mbrQ35VQ) and watch the last clips of the developer calls.
@@ -31,17 +38,23 @@ This can mean anything from fixing typos in documentation, to answering question
 
 ## Do valuable work
 Ok. You’re all set up and ready to work. Here’s what to do next.
-1. **Find a problem somewhere in Wasabi-land** that (a) needs fixing and (b) is a match for your skills and interests. Browse [open issues](https://github.com/zksnacks/walletwasabi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) and [ToDo's](ToDo.md), ask around about what other contributors think needs fixing. Because while you don’t need anybody’s permission and you can work on whatever you want, you’ll want to know up front whether anybody else is going to care about the work you do.
+1. **Find a problem somewhere in Wasabi-land** that (a) needs fixing and (b) is a match for your skills and interests.
+Browse [open issues](https://github.com/zksnacks/walletwasabi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) and [ToDo's](ToDo.md), ask around about what other contributors think needs fixing.
+Because while you don’t need anybody’s permission and you can work on whatever you want, you’ll want to know up front whether anybody else is going to care about the work you do.
 2. **Do work to fix that problem.** Submit your fix for review with a pull request (for [code](https://github.com/zkSNACKs/WalletWasabi/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) and [documentation](https://github.com/zkSNACKs/WasabiDoc/pulls) changes) or with a GitHub [issue](https://github.com/zksnacks/walletwasabi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) (for everything else).
-3. **Request that others review your work.** The best way to do this is by writing good commit comments and pull request/issue descriptions that clearly explain the problem your work is intended to solve, why it’s important, and why you fixed it the way you did. Make it as easy as possible for others to review your work. Make it a *pleasure* for others to review your work.
+3. **Request that others review your work.** The best way to do this is by writing good commit comments and pull request/issue descriptions that clearly explain the problem your work is intended to solve, why it’s important, and why you fixed it the way you did.
+Make it as easy as possible for others to review your work. Make it a *pleasure* for others to review your work.
 4. **Incorporate review feedback** you get until your fix gets merged or is otherwise accepted.
 5. Repeat steps 1–4.
 
 
 ## What to work on
-It is not required to work on an existing issue to contribute to Wasabi, and no one is here to tell you what to do. Contributors who have their own ideas are free to work in their own forks on whatever they wish, however they wish, and without any permission from anyone.
+It is not required to work on an existing issue to contribute to Wasabi, and no one is here to tell you what to do.
+Contributors who have their own ideas are free to work in their own forks on whatever they wish, however they wish, and without any permission from anyone.
 
-With that said, it's a good idea to consult with other Wasabikas via Slack, GitHub, or other communication channels before setting out on any serious contribution effort. Also check the [ToDo list](ToDo.md) for the short and long term priorities. Do this in order to ensure your contribution is:
+With that said, it's a good idea to consult with other Wasabikas via Slack, GitHub, or other communication channels before setting out on any serious contribution effort.
+Also check the [ToDo list](ToDo.md) for the short and long term priorities.
+Do this in order to ensure your contribution is:
 
 - something that the relevant maintainer(s) would be likely to merge;
 - subjected to as much feedback as possible while still an idea and thus cheap to change or abort;

--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -10,11 +10,13 @@ In PR https://github.com/zkSNACKs/WalletWasabi/pull/1850 nopara73 implemented @N
 
 ## Update (2019-06-28)
 
-PR https://github.com/zkSNACKs/WalletWasabi/pull/1661 moved around large files. 49+154+50 lines have been removed and added, so 506 lines will come down from @jmacato's score.
+PR https://github.com/zkSNACKs/WalletWasabi/pull/1661 moved around large files.
+49+154+50 lines have been removed and added, so 506 lines will come down from @jmacato's score.
 
 ## Update (2019-06-28)
 
-- The originally posted links on additions and deletions do not work, due to a GitHub bug. It seems like the timeframe specified is lagging behind 5 days, so it may appear that nobody contributed, yet it is 28 already and there were many contributions, so the adjusted links are:
+- The originally posted links on additions and deletions do not work, due to a GitHub bug.
+It seems like the timeframe specified is lagging behind 5 days, so it may appear that nobody contributed, yet it is 28 already and there were many contributions, so the adjusted links are:
 - For additions: https://github.com/zkSNACKs/WalletWasabi/graphs/contributors?from=2019-06-20&to=2019-07-20&type=a
 - For deletions: https://github.com/zkSNACKs/WalletWasabi/graphs/contributors?from=2019-06-20&to=2019-07-20&type=d
 - nopara73 is disqualified from this game.

--- a/docs/building-wasabi/DemoGuide.md
+++ b/docs/building-wasabi/DemoGuide.md
@@ -18,10 +18,10 @@
 1. Get Git: https://git-scm.com/downloads
 2. Get .NET Core 2.2 SDK: https://www.microsoft.com/net/download
 3. [OSX] Get Brew: https://stackoverflow.com/a/20381183/2061103
-4. Get Tor:  
-  [Windows] Install the Tor Expert Bundle: https://www.torproject.org/download/  
-  [Linux] `apt-get install tor`  
-  [OSX] `brew install tor`  
+4. Get Tor: </br>
+  [Windows] Install the Tor Expert Bundle: https://www.torproject.org/download/ </br>
+  [Linux] `apt-get install tor` </br>
+  [OSX] `brew install tor` </br>
   
 ## Get Wasabi
 
@@ -37,9 +37,9 @@ dotnet restore && dotnet build
 
 ## Run Wasabi
 
-1. Run Tor:  
-  [Windows] Run `tor.exe`.  
-  [Linux&OSX] Type `tor` in terminal.  
+1. Run Tor: </br>
+  [Windows] Run `tor.exe`. </br>
+  [Linux&OSX] Type `tor` in terminal. </br>
 2. Run Wasabi with `dotnet run` from the `WalletWasabi.Gui` folder.
 
 

--- a/docs/building-wasabi/Dojo.md
+++ b/docs/building-wasabi/Dojo.md
@@ -8,7 +8,12 @@
 
 White -> Blue -> Yellow -> Green -> Brown -> Black
 
-You can only be promoted by someone two belts above you. Consequently you can promote anyone two belts below you. For example if you are a Blue belt you can promote anyone to be a White belt. It is advised that you only promote someone if he or she deserves it. Promotion happens through Pull Requests to this page. Osu!
+You can only be promoted by someone two belts above you.
+Consequently you can promote anyone two belts below you.
+For example if you are a Blue belt you can promote anyone to be a White belt.
+It is advised that you only promote someone if he or she deserves it.
+Promotion happens through Pull Requests to this page.
+Osu!
 
 ## Wasabikas
 

--- a/docs/building-wasabi/HardwareWalletTestingGuide.md
+++ b/docs/building-wasabi/HardwareWalletTestingGuide.md
@@ -58,8 +58,10 @@ More info here: https://github.com/zkSNACKs/WalletWasabi/blob/master/README.md
 
 ## Step 3: Report Results
 
-Report results on GitHub or Reddit.  
-On GitHub by commenting under this pull request: https://github.com/zkSNACKs/WalletWasabi/pull/1341  
+Report results on GitHub or Reddit.
+
+On GitHub by commenting under this pull request: https://github.com/zkSNACKs/WalletWasabi/pull/1341
+
 On Reddit by commenting under this thread: https://old.reddit.com/r/WasabiWallet/comments/bdyz84/wasabi_wallet_hardware_wallet_integration_testing/
 
 Please include your OS version and your hardware wallet type.

--- a/docs/building-wasabi/HowToDebug.md
+++ b/docs/building-wasabi/HowToDebug.md
@@ -4,7 +4,8 @@
 
 ---
 
-This guide is for giving detailed instructions about how to debug Wasabi Wallet components to those developers who want to contribute to the project. We will focus on how to achieve this with `vscode` first because that is the cross-platform IDE used by some of the developer team members.
+This guide is for giving detailed instructions about how to debug Wasabi Wallet components to those developers who want to contribute to the project.
+We will focus on how to achieve this with `vscode` first because that is the cross-platform IDE used by some of the developer team members.
 
 ## Before to start
 We assume the reader has already read the project [README](https://github.com/zkSNACKs/WalletWasabi/blob/master/README.md) file  and has installed the .NET Core SDK, knows how to clone the repository and build the Wasabi solution.
@@ -12,27 +13,33 @@ We assume the reader has already read the project [README](https://github.com/zk
 
 ## Install VS Code and extensions
 ### 1: Get Visual Studio Code
-Install Visual Studio Code (VSC). Pick the latest VSC version from here: https://code.visualstudio.com/download
+Install Visual Studio Code (VSC).
+Pick the latest VSC version from here: https://code.visualstudio.com/download
 
 
 ### 2: Install C# Extension
-Open the command palette in VS Code (press <kbd>F1</kbd>) and type `ext install C#` to trigger the installation of the extension. VS Code will show a message that the extension has been installed and it will restart. Installing this extension can take a while.
+Open the command palette in VS Code (press <kbd>F1</kbd>) and type `ext install C#` to trigger the installation of the extension.
+VS Code will show a message that the extension has been installed and it will restart.
+Installing this extension can take a while.
 
 
 ### 3: Open the WalletWasabi directory in VS Code
-Go to `File->Open Folder` and open the WalletWasabi directory in Visual Studio Code. The Wasabi vscode settings forces to download the latest omnisharp versions every time the folder is opened and this can take a while.
+Go to `File->Open Folder` and open the WalletWasabi directory in Visual Studio Code.
+The Wasabi vscode settings forces to download the latest omnisharp versions every time the folder is opened and this can take a while.
 
 After this step we are ready to start configuring the build tasks and the launches.
 
 ## Understanding the Wasabi components
 
-Wasabi Wallet is a client/server system where the client part is the Wasabi Wallet that users download and install on their machines and the server part is the Wasabi backend that runs on the zkSNACKs servers.  Additionally the solution contains other components like the Packager used to prepare Wasabi client to be distributed, integration tests project and others.
+Wasabi Wallet is a client/server system where the client part is the Wasabi Wallet that users download and install on their machines and the server part is the Wasabi backend that runs on the zkSNACKs servers.
+Additionally the solution contains other components like the Packager used to prepare Wasabi client to be distributed, integration tests project and others.
 
 Here we are going to focus on how to debug the client component first and the backend component after.
 
 ### Wasabi Client
 
-Let us start by creating the launcher (it goes into the `.vscode/launch.json` file). This file contains the list of projects that can be launched, how to do it, what tasks have to be executed before the launching, etc.
+Let us start by creating the launcher (it goes into the `.vscode/launch.json` file).
+This file contains the list of projects that can be launched, how to do it, what tasks have to be executed before the launching, etc.
 
 ```json
 {
@@ -51,7 +58,8 @@ Let us start by creating the launcher (it goes into the `.vscode/launch.json` fi
 }
 ```
 
-It is important to see that this launcher requires the execution of a `build-client` task. that is defined in the tasks file (it goes into `.vscode/tasks.json` file).
+It is important to see that this launcher requires the execution of a `build-client` task.
+That is defined in the tasks file (it goes into `.vscode/tasks.json` file).
 
 ```json
 {
@@ -69,11 +77,14 @@ It is important to see that this launcher requires the execution of a `build-cli
 }
 ```
 
-After these two files are created press (CTRL+SHIFT+D) to go to the debugger, set a couple of breakpoints, select the `Wasabi GUI .NET Core` launcher (it should be the only one available) and press the play button. That is all.
+After these two files are created press (CTRL+SHIFT+D) to go to the debugger, set a couple of breakpoints, select the `Wasabi GUI .NET Core` launcher (it should be the only one available) and press the play button.
+That is all.
 
 ### Wasabi Backend
 
-In the same way we did with the client part, we need to create a launcher and a task for running and debugging the server-side component. Let us start with the launcher. Add the following launcher to the array of `configurations` in the `.vscode/launch.json` file.
+In the same way we did with the client part, we need to create a launcher and a task for running and debugging the server-side component.
+Let us start with the launcher.
+Add the following launcher to the array of `configurations` in the `.vscode/launch.json` file.
 
 ```json
 {
@@ -108,7 +119,8 @@ In the same way we did with the client part, we need to create a launcher and a 
    }
 }
 ```
-As before, we need to create a task for compiling the backend project before executing the code, and this is done again in the `.vscode/tasks.jon` file. Add the following task to the array of tasks:
+As before, we need to create a task for compiling the backend project before executing the code, and this is done again in the `.vscode/tasks.jon` file.
+Add the following task to the array of tasks:
 
 ```json
 {
@@ -123,5 +135,6 @@ As before, we need to create a task for compiling the backend project before exe
 }
 ```
 
-And that is all. Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugger, set a couple of breakpoints, select the `Wasabi Backend .NET Core` launcher and press the play button to start debugging.
+And that is all.
+Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugger, set a couple of breakpoints, select the `Wasabi Backend .NET Core` launcher and press the play button to start debugging.
 

--- a/docs/building-wasabi/ManualTesting.md
+++ b/docs/building-wasabi/ManualTesting.md
@@ -30,7 +30,8 @@ git checkout yourbranchname
 
 #### Updating a pull request
 
-If someone made a change to the pull request and you want to go through the tests again, first checkout the master branch `git checkout master` then continue with the same procedure described in the "How to checkout a pull request?" part. It will update your branch.
+If someone made a change to the pull request and you want to go through the tests again, first checkout the master branch `git checkout master` then continue with the same procedure described in the "How to checkout a pull request?" part.
+It will update your branch.
 
 ### DataFolder location?
 
@@ -38,12 +39,17 @@ Open Wasabi and go to Main Menu / File / Open / Data Folder.
 
 ### How to check for errors?
 
-Standard procedure: look at the terminal. If there is something saying ERROR or WARNING, that is probably an error.
+Standard procedure: look at the terminal.
+If there is something saying ERROR or WARNING, that is probably an error.
 Special case: always defined at the specific test case.
 
 ### How to determine if the application has exited?
 
-Look at the terminal. Wait until log messages stop and the blinking cursor reappears. If nothing happens, try to press enter. If the application hanged, you can also check it in process manager. If it is still running, there might be an endless loop: an error which does not let the application close.
+Look at the terminal.
+Wait until log messages stop and the blinking cursor reappears.
+If nothing happens, try to press enter.
+If the application hanged, you can also check it in process manager.
+If it is still running, there might be an endless loop: an error which does not let the application close.
 
 # Workflow
 
@@ -90,8 +96,10 @@ Look at the terminal. Wait until log messages stop and the blinking cursor reapp
   * Load one of your wallets. 
   * Go to the "Receive" tab.
   * If you do not have any addresses, then generate a couple.
-  * Select an address by right clicking on it. Make sure that the context menu pops up, and the address is highlighted.
-  * Select another address by right clicking on it. Make sure again that the context menu pops up, and the address is highlighted.
+  * Select an address by right clicking on it.
+Make sure that the context menu pops up, and the address is highlighted.
+  * Select another address by right clicking on it.
+Make sure again that the context menu pops up, and the address is highlighted.
  
 
 # Checklist

--- a/docs/building-wasabi/Security.md
+++ b/docs/building-wasabi/Security.md
@@ -1,4 +1,6 @@
 # Security Policy
 
-Feel free to report a vulnerability as a GitHub issue only if the vulnerability you found does not compromise users' privacy or security.  
-If it does, then pay great care to responsible disclosure. Send an email to adam.ficsor73@gmail.com, preferably using PGP encryption: https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt
+Feel free to report a vulnerability as a GitHub issue only if the vulnerability you found does not compromise users' privacy or security.
+
+If it does, then pay great care to responsible disclosure.
+Send an email to adam.ficsor73@gmail.com, preferably using PGP encryption: [21D7 CA45 565D BCCE BE45 115D B4B7 2266 C47E 075E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt)

--- a/docs/building-wasabi/TechnicalOverview.md
+++ b/docs/building-wasabi/TechnicalOverview.md
@@ -2,7 +2,12 @@
 
 ## Abstract
 
-Wasabi Wallet is a privacy focused Bitcoin wallet that is based on the [ZeroLink Fungibility Framework](https://github.com/nopara73/ZeroLink/). While statistical privacy can be achieved today with it, the cost, convenience, intuitiveness and strength of this privacy can be greatly improved. Wasabi must also improve its accessibility and its general Bitcoin wallet features. Furthermore Wasabi should look into ways of extending the scope of its privacy protection to other, not closely Bitcoin related fields, such as end-to-end encrypted messaging. Finally, Wasabi also needs to concentrate on its stability, performance, UX and code quality. This document aims to outline a starting plan to progress towards these objectives.
+Wasabi Wallet is a privacy focused Bitcoin wallet that is based on the [ZeroLink Fungibility Framework](https://github.com/nopara73/ZeroLink/).
+While statistical privacy can be achieved today with it, the cost, convenience, intuitiveness and strength of this privacy can be greatly improved.
+Wasabi must also improve its accessibility and its general Bitcoin wallet features.
+Furthermore Wasabi should look into ways of extending the scope of its privacy protection to other, not closely Bitcoin related fields, such as end-to-end encrypted messaging.
+Finally, Wasabi also needs to concentrate on its stability, performance, UX and code quality.
+This document aims to outline a starting plan to progress towards these objectives.
 
 ## Table Of Contents
 
@@ -12,60 +17,103 @@ Wasabi Wallet is a privacy focused Bitcoin wallet that is based on the [ZeroLink
 
 ## I. Introduction
 
-Wasabi's main focuses are Bitcoin and privacy, thus section [IV. Bitcoin Privacy Improvements](#iv-bitcoin-privacy-improvements). However, a loss of privacy in fields that are traditionally considered to be outside the scope of a Bitcoin wallet, such as sharing addresses through unsecure chat clients or checking transactions in a block explorer through the clearnet also pose privacy threats, ergo Wasabi cannot consider them entirely out of its scope, thus section [VII. Extending the Scope of Privacy](#vii-extending-the-scope-of-privacy).
+Wasabi's main focuses are Bitcoin and privacy, thus section [IV. Bitcoin Privacy Improvements](#iv-bitcoin-privacy-improvements).
+However, a loss of privacy in fields that are traditionally considered to be outside the scope of a Bitcoin wallet, such as sharing addresses through unsecure chat clients or checking transactions in a block explorer through the clearnet also pose privacy threats, ergo Wasabi cannot consider them entirely out of its scope, thus section [VII. Extending the Scope of Privacy](#vii-extending-the-scope-of-privacy).
 In the paper [Anonymity Loves Company: Usability and the Network Effect](https://www.freehaven.net/anonbib/cache/usability:weis2006.pdf) the authors note: 
 
 > We show that in anonymizing networks, even if you were smart enough and had enough time to use every system perfectly, you would nevertheless be right to choose your system based in part on its usability for other users.
 
 Therefore Wasabi should also pay attention to fields that help to increase the number of Wasabi users, bringing greater privacy for everyone, thus sections [III. Education](#iii-education) and [VI. Accessibility](#vi-accessibility).
 
-Furthermore, Wasabi is software, therefore it must not neglect general software quality issues, thus section [II. Stability, Performance, UX, Code Quality](#ii-stability-performance-ux-code-quality). The better software Wasabi is, the more users it will retain.
+Furthermore, Wasabi is software, therefore it must not neglect general software quality issues, thus section [II. Stability, Performance, UX, Code Quality](#ii-stability-performance-ux-code-quality).
+The better software Wasabi is, the more users it will retain.
 
 Wasabi is also a Bitcoin wallet, therefore it must improve general Bitcoin wallet related features as well, thus section [V. General Wallet Features](#v-general-wallet-features).
 
 Finally, there are development opportunities, where the developers of Wasabi recognize that they could easily add some unique wallet features that no other wallets have, like in-wallet multi-wallet support or copypaste malware defense, thus section [VIII. Unique Wallet Features](#viii-unique-wallet-features).
 
-Note that the developers of Wasabi are currently occupied by section [II. Stability, Performance, UX, Code Quality](#ii-stability-performance-ux-code-quality). This enjoys the highest priority. New issues will constantly come up as new users try to use the software. At this point it is unclear if Wasabi will ever have the resources to tackle other sections in this document.
+Note that the developers of Wasabi are currently occupied by section [II. Stability, Performance, UX, Code Quality](#ii-stability-performance-ux-code-quality).
+This enjoys the highest priority. New issues will constantly come up as new users try to use the software.
+At this point it is unclear if Wasabi will ever have the resources to tackle other sections in this document.
 
 ### Wasabi Wallet Under the Hood
 
-Wasabi is an [open-source](https://github.com/zkSNACKs/WalletWasabi/), desktop Bitcoin wallet, working on Windows, Linux and OSX, written in [.NET Core](https://en.wikipedia.org/wiki/.NET_Core) (C#), which is cross platform and open source .NET. Wasabi uses [NBitcoin](https://github.com/MetacoSA/NBitcoin/) as its Bitcoin library, to which Wasabi developers are frequent contributors: [@lontivero](https://github.com/lontivero), [@nopara73](https://github.com/nopara73). Wasabi uses [Avalonia](https://github.com/AvaloniaUI/Avalonia/) library as its UI framework where Wasabi developer [@danwalmsley](https://github.com/danwalmsley) is a maintainer.
+Wasabi is an [open-source](https://github.com/zkSNACKs/WalletWasabi/), desktop Bitcoin wallet, working on Windows, Linux and OSX, written in [.NET Core](https://en.wikipedia.org/wiki/.NET_Core) (C#), which is cross platform and open source .NET.
+Wasabi uses [NBitcoin](https://github.com/MetacoSA/NBitcoin/) as its Bitcoin library, to which Wasabi developers are frequent contributors: [@lontivero](https://github.com/lontivero), [@nopara73](https://github.com/nopara73).
+Wasabi uses [Avalonia](https://github.com/AvaloniaUI/Avalonia/) library as its UI framework where Wasabi developer [@danwalmsley](https://github.com/danwalmsley) is a maintainer.
 Wasabi does not support and does not plan to support other currencies in the future.
 
 Let's look at what is going on under the hood for Wasabi, what design decisions and tradeoffs the developers made, so we can later understand where it can be improved.
 
-After setting up Wasabi and generating a wallet, Wasabi welcomes the user with a load wallet screen. Unlike other wallets, Wasabi has a convenient way to use multiple wallets. Privacy centric users may be already used to achieve coin separation this way. However Wasabi provides a convenient in-wallet coin separation interface too, more information will be provided about that later on. Since coin separation can be easily achieved without multiple wallet files, initially the developers did not plan for such a wallet management system, our UX design choices naturally lead us down this road.
+After setting up Wasabi and generating a wallet, Wasabi welcomes the user with a load wallet screen.
+Unlike other wallets, Wasabi has a convenient way to use multiple wallets.
+Privacy centric users may be already used to achieve coin separation this way.
+However Wasabi provides a convenient in-wallet coin separation interface too, more information will be provided about that later on.
+Since coin separation can be easily achieved without multiple wallet files, initially the developers did not plan for such a wallet management system, our UX design choices naturally lead us down this road.
 
 ![](/WalletManagerLoadWallet.png)
 
-Wasabi has a status bar that shows meta information about the state of the wallet. To better understand the architecture of the wallet it is helpful to go through them.
+Wasabi has a status bar that shows meta information about the state of the wallet.
+To better understand the architecture of the wallet it is helpful to go through them.
 
-The "Tor" label shows the status of the Tor daemon. Tor is an anonymity network which Wasabi ships with by default and runs in the background. The user can also opt to use their own Tor instance. All Internet traffic goes through Tor and by deafault all this traffic stays inside the onion network. Exit nodes are only involved in fallback scenarios. For example if the Tor hidden service of the backend becomes unavaiable for the user, the wallet falls back communicating with the backend's clearnet endpoint, still over Tor. Wasabi also frequently utilizes multiple Tor streams where applicable. For example, registration of CoinJoin inputs and outputs is done through different Tor streams to avoid linking.
+The "Tor" label shows the status of the Tor daemon.
+Tor is an anonymity network which Wasabi ships with by default and runs in the background.
+The user can also opt to use their own Tor instance. All Internet traffic goes through Tor and by deafault all this traffic stays inside the onion network.
+Exit nodes are only involved in fallback scenarios.
+For example if the Tor hidden service of the backend becomes unavaiable for the user, the wallet falls back communicating with the backend's clearnet endpoint, still over Tor.
+Wasabi also frequently utilizes multiple Tor streams where applicable.
+For example, registration of CoinJoin inputs and outputs is done through different Tor streams to avoid linking.
 
 ![](/StatusBarTorRunning.png)
 
-Wasabi's backend is used to facilitate [Chaumian CoinJoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin) coordination between the mixing participants and to serve Golomb-Rice filters to the clients, similarly to [BIP158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki). More information will be provided about the difference soon. Before that, it is worth pointing out that the design choice of building a light wallet was made because such a wallet can attract orders of magnitude more users compared to a wallet on top of a full node, and more users means larger and faster CoinJoins. Historically, all light wallets were vulnerable to some kind of network observer due to unprivate utxo fetching. A few years ago, the only type of wallet that wasn't vulnerable was a full node, like Bitcoin Core. The first iteration of Wasabi was [HiddenWallet](https://github.com/zkSNACKs/WalletWasabi/tree/hiddenwallet-v0.6), which was a full-block SPV wallet that aimed to leverage usability without compromising privacy through the omission of initial blockchain downloading compared to a full node. In theory, it was a light wallet. In practice, it was hard to compete with Bitcoin Core's micro-optimizations and it was still painful to wait for wallet synchronization every time the wallet was opened. [Read more about network level Bitcoin wallet privacy here.](https://medium.com/@nopara73/bitcoin-core-vs-wasabi-wallet-network-level-privacy-bdca1d501387)
+Wasabi's backend is used to facilitate [Chaumian CoinJoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin) coordination between the mixing participants and to serve Golomb-Rice filters to the clients, similarly to [BIP158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki).
+More information will be provided about the difference soon.
+Before that, it is worth pointing out that the design choice of building a light wallet was made because such a wallet can attract orders of magnitude more users compared to a wallet on top of a full node, and more users means larger and faster CoinJoins.
+Historically, all light wallets were vulnerable to some kind of network observer due to unprivate utxo fetching.
+A few years ago, the only type of wallet that wasn't vulnerable was a full node, like Bitcoin Core.
+The first iteration of Wasabi was [HiddenWallet](https://github.com/zkSNACKs/WalletWasabi/tree/hiddenwallet-v0.6), which was a full-block SPV wallet that aimed to leverage usability without compromising privacy through the omission of initial blockchain downloading compared to a full node.
+In theory, it was a light wallet.
+In practice, it was hard to compete with Bitcoin Core's micro-optimizations and it was still painful to wait for wallet synchronization every time the wallet was opened.
+[Read more about network level Bitcoin wallet privacy here.](https://medium.com/@nopara73/bitcoin-core-vs-wasabi-wallet-network-level-privacy-bdca1d501387)
 
 ![](/StatusBarBackendConnected.png)
 
-Back to Wasabi. After loading the wallet, the user can generate a receive address. Some important design choices were made here. First, Wasabi had to be a Segregated Witness only wallet, so the registration of unconfirmed CoinJoin outputs into a new CoinJoin round is done to prevent malleability attacks. However, the developers of Wasabi decided to make the wallet native segwit (bech32) only, not supporting wrapped segwit. This way, the backend server can leverage this and only generate filters regarding bech32 addresses. This makes Wasabi's filter size a few megabytes today, instead of >4GB. At first glance, this may be seen as hazardous to privacy, however Wasabi user utxos can be identified as Wasabi utxos by the huge CoinJoins that only Wasabi does anyway, so minimal to no additional privacy loss happens there. In the future, as more and more wallets adopt bech32, Wasabi developers will have to look at how to scale the performance and network usage of the wallet. Failing that, Wasabi's initial sync will slow down.
+Back to Wasabi.
+After loading the wallet, the user can generate a receive address.
+Some important design choices were made here.
+First, Wasabi had to be a Segregated Witness only wallet, so the registration of unconfirmed CoinJoin outputs into a new CoinJoin round is done to prevent malleability attacks.
+However, the developers of Wasabi decided to make the wallet native segwit (bech32) only, not supporting wrapped segwit.
+This way, the backend server can leverage this and only generate filters regarding bech32 addresses.
+This makes Wasabi's filter size a few megabytes today, instead of >4GB.
+At first glance, this may be seen as hazardous to privacy, however Wasabi user utxos can be identified as Wasabi utxos by the huge CoinJoins that only Wasabi does anyway, so minimal to no additional privacy loss happens there.
+In the future, as more and more wallets adopt bech32, Wasabi developers will have to look at how to scale the performance and network usage of the wallet.
+Failing that, Wasabi's initial sync will slow down.
 
 This page shows the wallets that can be used to send to and receive from Wasabi: https://en.bitcoin.it/wiki/Bech32_adoption#Software_Wallets
 
 ![](/Receive.png)
 
-Wasabi also maintains a connection to the Bitcoin P2P network over Tor. After Wasabi receives the filters from the backend, it can download the required blocks (there are false positives, too) one block from one peer. Wasabi then stores the block in its entirety on disk so it won't fetch it again. Storing blocks on the disk may take up too much space when the wallet is used extensively. There is room for improvement there as well.
-Wasabi only connects to onion peers, which faciliates end to end encryption, and it connects to them on a different Tor streams. After every block download Wasabi disconnects the peer.
+Wasabi also maintains a connection to the Bitcoin P2P network over Tor.
+After Wasabi receives the filters from the backend, it can download the required blocks (there are false positives, too) one block from one peer.
+Wasabi then stores the block in its entirety on disk so it won't fetch it again.
+Storing blocks on the disk may take up too much space when the wallet is used extensively.
+There is room for improvement there as well.
+Wasabi only connects to onion peers, which faciliates end to end encryption, and it connects to them on a different Tor streams.
+After every block download Wasabi disconnects the peer.
 
 Furthermore, if you have a full node running in the background Wasabi won't download blocks from peers, but rather will use the full node to fetch the block from instead.
 
 ![](/StatusBarPeers.png)
 
-Wasabi receives incoming transactions from the nodes it is connected to. This is, while privacy preserving, a relatively insecure way of handling this, and should be improved in the future. Generally, unconfirmed transactions are considered to be insecure regardless.
+Wasabi receives incoming transactions from the nodes it is connected to.
+This is, while privacy preserving, a relatively insecure way of handling this, and should be improved in the future.
+Generally, unconfirmed transactions are considered to be insecure regardless.
 
 ![](/StatusBarMempool.png)
 
-Unlike in other Bitcoin wallets, generating a label for each Bitcoin address is not optional, but required. That is because Wasabi has an intra-wallet blockchain analysis tool built into it, which tries to cluster utxos (Wasabi calls them coins). Based on these clusters, the user can make an educated decision on which coins to merge.
+Unlike in other Bitcoin wallets, generating a label for each Bitcoin address is not optional, but required.
+That is because Wasabi has an intra-wallet blockchain analysis tool built into it, which tries to cluster utxos (Wasabi calls them coins).
+Based on these clusters, the user can make an educated decision on which coins to merge.
 
 ![](/ReceiveLabelingRequired.png)
 
@@ -73,20 +121,27 @@ Wasabi also has a History tab like any other Bitcoin wallet.
 
 ![](/History.png)
 
-Unlike other Bitcoin wallets, the user cannot spend from Wasabi without selecting coins, since ["Coin Control Is Must Learn If You Care About Your Privacy In Bitcoin"](https://medium.com/@nopara73/coin-control-is-must-learn-if-you-care-about-your-privacy-in-bitcoin-33b9a5f224a2), at least for today. The label field of the Send tab is also compulsory.
+Unlike other Bitcoin wallets, the user cannot spend from Wasabi without selecting coins, since ["Coin Control Is Must Learn If You Care About Your Privacy In Bitcoin"](https://medium.com/@nopara73/coin-control-is-must-learn-if-you-care-about-your-privacy-in-bitcoin-33b9a5f224a2), at least for today.
+The label field of the Send tab is also compulsory.
 
 ![](/Send.png)
 
-By clicking on the Max button, one can spend all selected coins. Spending whole coins is beneficial to privacy.  
-The Bitcoin fee rates are fetched from the backend server, the source of these fees are Bitcoin Core's `estimatesmartfee`'s `CONSERVATIVE` output. Every fee query happens over Tor with a new Tor identity. When clicking send, the wallet will broadcast the transaction to a random peer, then disconnects the peer. This is currently [the optimal way to broadcast transactions from a privacy point of view,](https://medium.com/@nopara73/bitcoin-core-vs-wasabi-wallet-network-level-privacy-bdca1d501387) but a more ideal way would be to implement the [Dandelion](https://github.com/gfanti/bips/blob/master/bip-dandelion.mediawiki) protocol for transaction broadcasting when the Bitcoin network adopts it.
+By clicking on the Max button, one can spend all selected coins. Spending whole coins is beneficial to privacy.
+The Bitcoin fee rates are fetched from the backend server, the source of these fees are Bitcoin Core's `estimatesmartfee`'s `CONSERVATIVE` output.
+Every fee query happens over Tor with a new Tor identity.
+When clicking send, the wallet will broadcast the transaction to a random peer, then disconnects the peer.
+This is currently [the optimal way to broadcast transactions from a privacy point of view,](https://medium.com/@nopara73/bitcoin-core-vs-wasabi-wallet-network-level-privacy-bdca1d501387) but a more ideal way would be to implement the [Dandelion](https://github.com/gfanti/bips/blob/master/bip-dandelion.mediawiki) protocol for transaction broadcasting when the Bitcoin network adopts it.
 
 ![](/SendAmountFeePassword.png)
 
-Coins in Wasabi have Privacy and History properties. The anonymity set is just a momentary estimation, however, by examining the mixes and other people's transactions we will be able to show accurate values. The History is the calculated clusters from the labels based on typical Blockchain analysis heuristics. For example, if the user joins together a "foo" labeled coin with a "bar" labeled coin at sending, then the change coin history will show "change of (foo), change of (bar)". From this, users are able to make educated decisions as to which coins not to join together at any cost. Human input is invaluable.
+Coins in Wasabi have Privacy and History properties.
+The anonymity set is just a momentary estimation, however, by examining the mixes and other people's transactions we will be able to show accurate values.
+The History is the calculated clusters from the labels based on typical Blockchain analysis heuristics. For example, if the user joins together a "foo" labeled coin with a "bar" labeled coin at sending, then the change coin history will show "change of (foo), change of (bar)". From this, users are able to make educated decisions as to which coins not to join together at any cost. Human input is invaluable.
 
 ![](/SendAnonset.png)
 
-Wasabi has a CoinJoin tab as well, its use is straightforward. The user queues their coins for CoinJoin and waits for others to join the mix.
+Wasabi has a CoinJoin tab as well, its use is straightforward.
+The user queues their coins for CoinJoin and waits for others to join the mix.
 
 ![](/CoinJoin.png)
 
@@ -104,28 +159,53 @@ To this day, Wasabi's CoinJoins have created >22941 BTC outputs with equal value
 
 ## II. Stability, Performance, UX, Code Quality
 
-As was discussed above, the main priority of Wasabi developers is currently the stability, performance, code quality and user experience of Wasabi. Great care must be taken here because the more users a network reliant privacy software has, the better privacy it offers. The more users there are, the better the software is. In Wasabi, this is most apparent during CoinJoins. The more users participating in a round, the higher the anonymity set the CoinJoin achieves and the more frequent the rounds will be. In our calculations, if Wasabi would acquire the volume of the most popular Bitcoin mixers, Wasabi could provide a 100 anonymity set round with the denomination of 0.1 BTC every 3 to 5 minutes.  
-This section consists of many small issues, waiting to be solved one-by-one. Since solving these issues is often more effective than discussing them, they won't be discussed in this document.
+As was discussed above, the main priority of Wasabi developers is currently the stability, performance, code quality and user experience of Wasabi.
+Great care must be taken here because the more users a network reliant privacy software has, the better privacy it offers.
+The more users there are, the better the software is.
+In Wasabi, this is most apparent during CoinJoins.
+The more users participating in a round, the higher the anonymity set the CoinJoin achieves and the more frequent the rounds will be.
+In our calculations, if Wasabi would acquire the volume of the most popular Bitcoin mixers, Wasabi could provide a 100 anonymity set round with the denomination of 0.1 BTC every 3 to 5 minutes.
+This section consists of many small issues, waiting to be solved one-by-one.
+Since solving these issues is often more effective than discussing them, they won't be discussed in this document.
 
 ## III. Education
 
-While education, content creation and marketing have little place in a technical document, they are still important parts of the big picture. Through education, Wasabi can obtain new users. The more Wasabi users there are, the better their privacy. Advancing this issue can take various, often opportunistic forms. A few ideas:
+While education, content creation and marketing have little place in a technical document, they are still important parts of the big picture.
+Through education, Wasabi can obtain new users.
+The more Wasabi users there are, the better their privacy.
+Advancing this issue can take various, often opportunistic forms.
+A few ideas:
 
 - Add Infographics to software https://github.com/zkSNACKs/Meta/issues/32
 - Implement Bitcoin Academy https://github.com/zkSNACKs/Meta/issues/33
 
 ## IV. Bitcoin Privacy Improvements
 
-At the Blockchain level Wasabi currently helps its users achieve the desired level of privacy in three main ways: mixing, coin control and intra-wallet clustering.  
+At the Blockchain level Wasabi currently helps its users achieve the desired level of privacy in three main ways: mixing, coin control and intra-wallet clustering.
 
-Coin mixing happens through Chaumian CoinJoin, as described in the [ZeroLink](https://github.com/nopara73/ZeroLink/) protocol. In a nutshell, Wasabi users register their transaction inputs and desired outputs with a coordinator, and the cooperation of these users results in a large CoinJoin transaction. The coordinator cannot steal from, nor deanonymize the users. However, with ZeroLink, in order to statistically avoid post-mix deanonymization, coins must not be joined together. This, however, is unfeasible in practice.  
-Thus, various strategies are needed to mitigate this deanonymization risk.  
+Coin mixing happens through Chaumian CoinJoin, as described in the [ZeroLink](https://github.com/nopara73/ZeroLink/) protocol.
+In a nutshell, Wasabi users register their transaction inputs and desired outputs with a coordinator, and the cooperation of these users results in a large CoinJoin transaction.
+The coordinator cannot steal from, nor deanonymize the users.
+However, with ZeroLink, in order to statistically avoid post-mix deanonymization, coins must not be joined together.
+This, however, is unfeasible in practice.
+Thus, various strategies are needed to mitigate this deanonymization risk.
 
-One such strategy is Wasabi's current compulsory coin control feature. It helps the users to not join coins together and spend whole coins, but it does not force them, so it is not perfect.  
-Another is Wasabi's intra-wallet clustering system, where the users must use required labels. This helps the user to make an educated decision if they must join inputs together at send.  
-Another thing that the author of ZeroLink did not anticipate was the frequent remixing of already-mixed coins. In every round, more than half of the inputs are remixes, which not only results in perfect mixes for those inputs, but also results in anonymity set growth somewhere between the scales of addition and multiplication, instead of simple addition as the ZeroLink paper anticipated. Whether the anonymity set gain is closer to addition or multiplication depends on how other users behave. Right now, Wasabi simply counts the worst case scenario: so it shows the user addition. As of today, mixes are so interconnected that not even extensive input joining can deanonymize the users. However, this is happening in a low Bitcoin fee environment, so this is not to be taken for granted in the future. Additional measures are necessary.
+One such strategy is Wasabi's current compulsory coin control feature.
+It helps the users to not join coins together and spend whole coins, but it does not force them, so it is not perfect.
 
-The ideas described in this section are just ideas. Many of them are not compatible with each other, not proven or require further research.  
+Another is Wasabi's intra-wallet clustering system, where the users must use required labels.
+This helps the user to make an educated decision if they must join inputs together at send.
+
+Another thing that the author of ZeroLink did not anticipate was the frequent remixing of already-mixed coins.
+In every round, more than half of the inputs are remixes, which not only results in perfect mixes for those inputs, but also results in anonymity set growth somewhere between the scales of addition and multiplication, instead of simple addition as the ZeroLink paper anticipated.
+Whether the anonymity set gain is closer to addition or multiplication depends on how other users behave.
+Right now, Wasabi simply counts the worst case scenario: so it shows the user addition.
+As of today, mixes are so interconnected that not even extensive input joining can deanonymize the users.
+However, this is happening in a low Bitcoin fee environment, so this is not to be taken for granted in the future.
+Additional measures are necessary.
+
+The ideas described in this section are just ideas.
+Many of them are not compatible with each other, not proven or require further research.
 
 It is also worth pointing out that if [Confidential Transactions](https://people.xiph.org/~greg/confidential_values.txt) somehow make their way into Bitcoin, there would be no need for most of the improvements described in this section.
 
@@ -133,9 +213,11 @@ It is also worth pointing out that if [Confidential Transactions](https://people
 
 #### Unequal Input Mixing
 
-One of the most exciting advancements could be achieved by improving the mixing itself. The intuition behind Unequal Input Mixing, (https://github.com/zkSNACKs/Meta/issues/4, https://github.com/nopara73/ZeroLink/issues/74) that could replace today's fixed denomination mixing, is clear, and its benefits are huge. However this requires further research.
+One of the most exciting advancements could be achieved by improving the mixing itself.
+The intuition behind Unequal Input Mixing, (https://github.com/zkSNACKs/Meta/issues/4, https://github.com/nopara73/ZeroLink/issues/74) that could replace today's fixed denomination mixing, is clear, and its benefits are huge.
+However this requires further research.
 
-The currently identified advantages of unequal input mixing compared to fixed denomination mixing are discussed briefly below, using the following notation:  
+The currently identified advantages of unequal input mixing compared to fixed denomination mixing are discussed briefly below, using the following notation:
 
 ```
 UIM - Unequal Input Mixing
@@ -143,18 +225,27 @@ FDM - Fixed Denomination Mixing
 ```
 
 1. UIM's main goal is to optimize the cost/anonymity set.
-2. In FDM, those who don't have enough money to mix will not be able to mix. In UIM, this is no longer an issue.
-3. In FDM, peers often join together their utxos in order to reach the desired denomination. This exposes common ownership. There is no such an issue in UIM. Because of this, joining utxos together after the mix is no longer such a big deal.
-4. In UIM, mixing can be done over and over again until the desired anonymity set is reached. In FDM, mixing cannot be repeated, because the mixed output of the mix will never reach the sufficient input level of the next mix (due to network fees.) In FDM, if the user would decide to participate with an already mixed coin, they would have to add another input in order to meet the mix requirements, which exposes common ownership.
+2. In FDM, those who don't have enough money to mix will not be able to mix.
+In UIM, this is no longer an issue.
+3. In FDM, peers often join together their utxos in order to reach the desired denomination.
+This exposes common ownership.
+There is no such an issue in UIM.
+Because of this, joining utxos together after the mix is no longer such a big deal.
+4. In UIM, mixing can be done over and over again until the desired anonymity set is reached.
+In FDM, mixing cannot be repeated, because the mixed output of the mix will never reach the sufficient input level of the next mix (due to network fees).
+In FDM, if the user would decide to participate with an already mixed coin, they would have to add another input in order to meet the mix requirements, which exposes common ownership.
 5. People with lot of money would get matched together and would not have to wait weeks/months to mix everything out.
 
 #### Mix to Self vs Mixing to Others
 
-Mix to Others (https://github.com/zkSNACKs/Meta/issues/6, https://github.com/nopara73/ZeroLink/issues/75) also has great potential, since it could completely replace Simple Send. It is, however, dubious whether there will ever be enough liquidity for this.
+Mix to Others (https://github.com/zkSNACKs/Meta/issues/6, https://github.com/nopara73/ZeroLink/issues/75) also has great potential, since it could completely replace Simple Send.
+It is, however, dubious whether there will ever be enough liquidity for this.
 
 ### Simple Send Improvements
 
-Improving simple send using current Bitcoin anonymity techniques is also an interesting topic. These do not even have to disrupt the current user workflow, they can mostly "just happen" in the background. Some additional thoughts and details on this section can be found [here](https://github.com/zkSNACKs/Meta/issues/23#issuecomment-430514345).
+Improving simple send using current Bitcoin anonymity techniques is also an interesting topic.
+These do not even have to disrupt the current user workflow, they can mostly "just happen" in the background.
+Some additional thoughts and details on this section can be found [here](https://github.com/zkSNACKs/Meta/issues/23#issuecomment-430514345).
 
 - JoinMarket: https://github.com/zkSNACKs/Meta/issues/5
 - Friend CoinJoin Network:  https://github.com/zkSNACKs/Meta/issues/17
@@ -175,7 +266,8 @@ Improving the user friendliness, the accuracy of coin awareness and what happens
 
 ### Lightning Network Leverage
 
-At this point, it is too early to start leveraging LN in a privacy oriented wallet. However, if Bitcoin is successful in the future, there will be a need to think about these questions, since [blockchains don't scale.](https://medium.com/@nopara73/how-to-scale-a-blockchain-a997dcb12775)
+At this point, it is too early to start leveraging LN in a privacy oriented wallet.
+However, if Bitcoin is successful in the future, there will be a need to think about these questions, since [blockchains don't scale.](https://medium.com/@nopara73/how-to-scale-a-blockchain-a997dcb12775)
 
 - CoinJoinXT
 - Open Lightning Channels with ZeroLink in Wasabi - https://github.com/zkSNACKs/Meta/issues/3, https://github.com/nopara73/ZeroLink/issues/58
@@ -193,7 +285,7 @@ Wasabi today has all the features a Bitcoin wallet needs that are not related to
 
 ## VI. Accessibility
 
-The more users use the wallet the more privacy it can provide.  
+The more users use the wallet the more privacy it can provide.
 
 ### Localization
 
@@ -201,37 +293,52 @@ Since most of the world does not speak English, localization (https://github.com
 
 ### Traditional Bitcoin Addresses vs Bech32 Adoption
 
-Wasabi wallet uses bech32 addresses only. These addresses are not fully supported by the whole Bitcoin ecosystem. It would be beneficial to make pull requests to open source softwares to support sending money to bech32 addresses: https://github.com/zkSNACKs/WalletWasabi/issues/951
+Wasabi wallet uses bech32 addresses only.
+These addresses are not fully supported by the whole Bitcoin ecosystem.
+It would be beneficial to make pull requests to open source softwares to support sending money to bech32 addresses: https://github.com/zkSNACKs/WalletWasabi/issues/951
 
-Wasabi, in theory could use P2SH over P2WPKH, wrapped segwit addresses, (https://github.com/zkSNACKs/Meta/issues/7) since the ability to spend to bech32 addresses is not quite there yet. On the other hand, this could be considered a backward-looking short-sighted improvement.
+Wasabi, in theory could use P2SH over P2WPKH, wrapped segwit addresses, (https://github.com/zkSNACKs/Meta/issues/7) since the ability to spend to bech32 addresses is not quite there yet.
+On the other hand, this could be considered a backward-looking short-sighted improvement.
 
 A way of facilitating funds to make their way into the wallet would be to introduce transitionary P2WPKH over P2SH addresses those would not be checked against Golomb-Rice filters, but rather a single backend query would establish its balance only once, then immediately sweeping the money to a bech32 wallet-managed address: https://github.com/zkSNACKs/Meta/issues/34
 
 ### Smartphone
 
-In theory, Wasabi could support smart phones (Android, iOS). In practice, these platforms and their tools are not mature enough just yet. The concept of network analysis resistant smartphone wallets is not yet proven. If we would try to port Wasabi's code today, the wallet would use too much storage space, battery and network.
+In theory, Wasabi could support smart phones (Android, iOS).
+In practice, these platforms and their tools are not mature enough just yet.
+The concept of network analysis resistant smartphone wallets is not yet proven.
+If we would try to port Wasabi's code today, the wallet would use too much storage space, battery and network.
 However, technology is improving quickly, thus, timing has special importance in this matter. https://github.com/zkSNACKs/Meta/issues/9
 
 ### Web Wallet
 
-The question of a web-wallet is also something to think about. However, it may not be possible to build a network analysis resistant web wallet, nor to build a secure web wallet in general. Nevertheless this question deserves more thought. https://github.com/zkSNACKs/Meta/issues/20  
+The question of a web-wallet is also something to think about.
+However, it may not be possible to build a network analysis resistant web wallet, nor to build a secure web wallet in general.
+Nevertheless [this question](https://github.com/zkSNACKs/Meta/issues/20) deserves more thought.
 
 ### Hardware Wallet
 
-Wasabi has hardware wallet integration however in this mode CoinJoining is not possible: https://github.com/zkSNACKs/WalletWasabi/pull/1341
+Wasabi has [hardware wallet integration](https://github.com/zkSNACKs/WalletWasabi/pull/134) however in this mode CoinJoining is not possible.
 
 ### Bitcoin Core
 
-Some of the users use full nodes, mainly Bitcoin Core as their personal wallet, because this is the ultimate way of minimizing trust. Wasabi could ship with a bitcoind, much the same way as it does with Tor.
+Some of the users use full nodes, mainly Bitcoin Core as their personal wallet, because this is the ultimate way of minimizing trust.
+Wasabi could ship with a bitcoind, much the same way as it does with Tor.
 
 ### Daemon/API
 
-Another way to improve the software is to let developers play with it through a daemon (RPC?) process. This however may lead to enterprise adoption, which is good for liquidity, but there is a risk of centralization and thus Sybil attacks. May become more likely. For example an exchange could decide to add CoinJoins and if they acquire 50% of liquidity in Wasabi, this way many of the wallet assumptions about anonymity sets would become less accurate. https://github.com/zkSNACKs/Meta/issues/12
-Wasabi already has a public web API. However developers should not build wallets on top of it, since breakin changes must be expected. Misc things like Twitter bots are fine: http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/swagger/index.html (https://wasabiwallet.io/swagger/index.html)
+Another way to improve the software is to let developers play with it through a daemon (RPC?) process.
+This however may lead to enterprise adoption, which is good for liquidity, but there is a risk of centralization and thus Sybil attacks.
+May become more likely.
+For example an exchange could decide to add CoinJoins and if they acquire 50% of liquidity in Wasabi, this way many of the wallet assumptions about anonymity sets would become less accurate. https://github.com/zkSNACKs/Meta/issues/12
+Wasabi already has a public web API.
+However developers should not build wallets on top of it, since breakin changes must be expected.
+Misc things like Twitter bots are fine: http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/swagger/index.html (https://wasabiwallet.io/swagger/index.html)
 
 ### .NET Ecosystem
 
-Wasabi could roll out a NuGet package, enabling developers to build applications with Wasabi. It would be also beneficial and not difficult to integrate Wasabi into existing .NET softwares directly, like BTCPay. https://github.com/btcpayserver/btcpayserver
+Wasabi could roll out a NuGet package, enabling developers to build applications with Wasabi.
+It would be also beneficial and not difficult to integrate Wasabi into existing .NET softwares directly, like [BTCPay](https://github.com/btcpayserver/btcpayserver).
 
 ## VII. Extending the Scope of Privacy
 
@@ -246,10 +353,15 @@ Other non closely Bitcoin related features may be beneficial for the privacy of 
 
 ## VIII. Unique Wallet Features
 
-Unique wallet features are a set of unorganized ideas that are not closely related to privacy. These are by no means necessary for Wasabi, but what fun is there in programming if the developers are not allowed to play with their creativity once in a while?
+Unique wallet features are a set of unorganized ideas that are not closely related to privacy.
+These are by no means necessary for Wasabi, but what fun is there in programming if the developers are not allowed to play with their creativity once in a while?
 
 - Clipboard Hijacker Malware Defense: https://github.com/zkSNACKs/WalletWasabi/issues/496, https://github.com/zkSNACKs/WalletWasabi/pull/697
 
 ## IX. Conclusion
 
-In this document, we gave a comprehensive overview of Wasabi Wallet. Unlike the creators of many other products, we deliberately decided to honestly and extensively describe and discuss Wasabi's shortcomings, tradeoffs and design decisions. We outlined our ideas and our future technical plans and helped the reader get familiar with our thinking process. This document can be analyzed and used by anyone who would like to achieve the strongest privacy in Bitcoin today without falling prey to misinformation that is rampant in the space. Of course, it is unavoidable that the reader will still be susceptible to the authors unconscious biases, and we apologize for that in advance.
+In this document, we gave a comprehensive overview of Wasabi Wallet.
+Unlike the creators of many other products, we deliberately decided to honestly and extensively describe and discuss Wasabi's shortcomings, tradeoffs and design decisions.
+We outlined our ideas and our future technical plans and helped the reader get familiar with our thinking process.
+This document can be analyzed and used by anyone who would like to achieve the strongest privacy in Bitcoin today without falling prey to misinformation that is rampant in the space.
+Of course, it is unavoidable that the reader will still be susceptible to the authors unconscious biases, and we apologize for that in advance.

--- a/docs/building-wasabi/ToDo.md
+++ b/docs/building-wasabi/ToDo.md
@@ -1,8 +1,11 @@
 # ToDo's in Wasabi
 
-Wasabi Wallet is libre and open source software. This means that contributions are not just very welcome, but absolutely needed! If you are considering to support the project, please checkout the [contribution checklist](ContributionChecklist.md) for how to best get started!
+Wasabi Wallet is libre and open source software.
+This means that contributions are not just very welcome, but absolutely needed!
+If you are considering to support the project, please checkout the [contribution checklist](ContributionChecklist.md) for how to best get started!
 
-This document is for providing a one place stop for anyone interested in the short term ToDo's and long term goals. When you are ever bored and want to be productive, why not pick up one of these issues?
+This document is for providing a one place stop for anyone interested in the short term ToDo's and long term goals.
+When you are ever bored and want to be productive, why not pick up one of these issues?
 
 ## Short Term ToDo's
 

--- a/docs/using-wasabi/BIP.md
+++ b/docs/using-wasabi/BIP.md
@@ -4,7 +4,8 @@
 
 ---
 
-Wasabi Wallet strives toward establishing solid industry best practices and standards. Here is a list of all the supported and integrated Bitcoin Improvement Proposals:
+Wasabi Wallet strives toward establishing solid industry best practices and standards.
+Here is a list of all the supported and integrated Bitcoin Improvement Proposals:
 
 ## What is supported today
 
@@ -44,8 +45,14 @@ Wasabi Wallet strives toward establishing solid industry best practices and stan
 
 ### [BIP 37: Connection Bloom Filters](https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki)
 
-Bloom filters (BIP37) are filters that a client will send a Bitcoin full node which says "Hey, if you see any transactions that get caught in this filter, they may or may not be mine!". What would happen next is that a Bitcoin node would start sending tons and tons of transactions to the client, and the client would proceed to distinguish the 99% irrelevant transactions against the 1% relevant ones. This was quite brilliant of an idea at the time, but has since been proven to not protect user privacy, at the expense of wasting a ton of bandwidth and subjecting users to other risks.
+Bloom filters (BIP37) are filters that a client will send a Bitcoin full node which says "Hey, if you see any transactions that get caught in this filter, they may or may not be mine!".
+What would happen next is that a Bitcoin node would start sending tons and tons of transactions to the client, and the client would proceed to distinguish the 99% irrelevant transactions against the 1% relevant ones.
+This was quite brilliant of an idea at the time, but has since been proven to not protect user privacy, at the expense of wasting a ton of bandwidth and subjecting users to other risks.
 
 ### [BIP 158: Compact Block Filters for Light Clients](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki)
 
-Block Filters (BIP 158) are the reverse of Bloom filters (BIP 37) - the client will connect to a Bitcoin node and say "Hey, for every block, I would like a condensed list of addresses that were affected." What would happen next is that a Bitcoin node would give the same filter that it gives to every client, because the client has thus far revealed nothing! Once a block filter has come in and the client believes that there is a transaction that affects the client, the client pings a single random node for a single full block. It then parses the block, and finds the transaction. This has been proven to be by far the best way to do light clients privately, and is the way Wasabi works today.
+Block Filters (BIP 158) are the reverse of Bloom filters (BIP 37) - the client will connect to a Bitcoin node and say "Hey, for every block, I would like a condensed list of addresses that were affected."
+What would happen next is that a Bitcoin node would give the same filter that it gives to every client, because the client has thus far revealed nothing!
+Once a block filter has come in and the client believes that there is a transaction that affects the client, the client pings a single random node for a single full block.
+It then parses the block, and finds the transaction.
+This has been proven to be by far the best way to do light clients privately, and is the way Wasabi works today.

--- a/docs/using-wasabi/BackendDeployment.md
+++ b/docs/using-wasabi/BackendDeployment.md
@@ -6,7 +6,8 @@
 
 ## Update
 
-Consider updating the versions in `WalletWasabi.Helpers.Constants`. If versions are updated, make sure Client Release is already available before updating the backend.
+Consider updating the versions in `WalletWasabi.Helpers.Constants`.
+If versions are updated, make sure Client Release is already available before updating the backend.
 
 ```sh
 sudo apt-get update && cd ~/WalletWasabi && git pull && cd ~
@@ -69,7 +70,8 @@ ufw allow OpenSSH
 ufw enable
 ```
 
-> As the firewall is currently blocking all connections except for SSH, if you install and configure additional services, you will need to adjust the firewall settings to allow acceptable traffic in. You can learn some common UFW operations in this guide.  ~ [UFW essentials common firewal rules and commands](https://www.digitalocean.com/community/tutorials/ufw-essentials-common-firewall-rules-and-commands)
+> As the firewall is currently blocking all connections except for SSH, if you install and configure additional services, you will need to adjust the firewall settings to allow acceptable traffic in.
+>You can learn some common UFW operations in this guide.  ~ [UFW essentials common firewal rules and commands](https://www.digitalocean.com/community/tutorials/ufw-essentials-common-firewall-rules-and-commands)
 
 ### Enable External Access for User
 
@@ -250,13 +252,15 @@ sudo ufw allow https
 sudo apt-get install nginx -y
 sudo service nginx start
 ```
-Verify the browser displays the default landing page for Nginx. The landing page is reachable at `http://<server_IP_address>/index.nginx-debian.html`.
+Verify the browser displays the default landing page for Nginx.
+The landing page is reachable at `http://<server_IP_address>/index.nginx-debian.html`.
 
 ```sh
 sudo pico /etc/nginx/sites-available/default
 ```
 
-Fill out the server name with the server's IP and domain. And remove the unneeded domains (note I use `wasabiwallet.co` for testnet.)
+Fill out the server name with the server's IP and domain.
+And remove the unneeded domains (note I use `wasabiwallet.co` for testnet.)
 
 ```
 server {
@@ -276,13 +280,15 @@ sudo nginx -t
 sudo nginx -s reload
 ```
 
-Setup https, redirect to https when asks. This will modify the above config file, but oh well.
+Setup https, redirect to https when asks.
+This will modify the above config file, but oh well.
 
 ```sh
 sudo certbot -d wasabiwallet.io -d www.wasabiwallet.io -d wasabiwallet.net -d www.wasabiwallet.net -d wasabiwallet.org -d www.wasabiwallet.org -d wasabiwallet.info -d www.wasabiwallet.info -d wasabiwallet.co -d www.wasabiwallet.co -d zerolink.info -d www.zerolink.info -d hiddenwallet.org -d www.hiddenwallet.org
 ```
 
-certbot will not properly redirect www, so it must be setup by hand, one by one. Duplicate all entries like this by adding a `www.`:
+certbot will not properly redirect www, so it must be setup by hand, one by one.
+Duplicate all entries like this by adding a `www.`:
 ```
 server {
     if ($host = wasabiwallet.co) {

--- a/docs/using-wasabi/DeterministicBuild.md
+++ b/docs/using-wasabi/DeterministicBuild.md
@@ -42,7 +42,8 @@ In order to end-to-end verify all the downloaded packages you need a Windows, a 
 
 ### Windows
 
-After you installed Wasabi from the `.msi`, it will be in `C:\Program Files\WasabiWallet` folder. You can compare it with your build:
+After you installed Wasabi from the `.msi`, it will be in `C:\Program Files\WasabiWallet` folder.
+You can compare it with your build:
 
 ```sh
 git diff --no-index win7-x64 "C:\Program Files\WasabiWallet"
@@ -50,7 +51,8 @@ git diff --no-index win7-x64 "C:\Program Files\WasabiWallet"
 
 ### Linux && OSX
 
-You can use the Windows Subsystem for Linux to verify all the packages in one go. At the time of writing this guide we provide a `.tar.gz` and a `.deb` package for Linux and .dmg for OSX. 
+You can use the Windows Subsystem for Linux to verify all the packages in one go.
+At the time of writing this guide we provide a `.tar.gz` and a `.deb` package for Linux and .dmg for OSX. 
 Install the `.deb` package and extract the `tar.gz` and `.dmg` packages, then compare them with your build.
 
 After installing WSL, just type `wsl` in explorer where your downloaded and built packages are located.

--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -4,7 +4,8 @@
 
 ---
 
-It is strongly recommended to **VERIFY PGP SIGNATURES** of the downloaded packages before installing Wasabi. This protects you against malicious phising sites giving you back-doored Wallet software. Don't trust - Verify!
+It is strongly recommended to **VERIFY PGP SIGNATURES** of the downloaded packages before installing Wasabi. This protects you against malicious phising sites giving you back-doored Wallet software.
+Don't trust - Verify!
 
 Download the packages either from the official [WasabiWallet.io](https://wasabiwallet.io/) clearnet website, or for your privacy sake from the official tor hidden service [http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/).
 
@@ -39,7 +40,8 @@ If you have already imported Ádám Ficsor's public key, then jump to step 7.
 
 ![](/InstallWindowsKleopatraImportPGP.png)
 
-6. Confirm to import Ádám's public key by clicking `Yes`. [Next time you can skip previous steps because the public key is already imported.]
+6. Confirm to import Ádám's public key by clicking `Yes`.
+[Next time you can skip previous steps because the public key is already imported.]
 
 ![](/InstallWindowsKleopatraPGPConfirm.png)
 
@@ -53,7 +55,9 @@ If you have already imported Ádám Ficsor's public key, then jump to step 7.
 
 9. You can install Wasabi by double clicking the `.msi` and following the GUI instructions.
 
-Wasabi will be installed to your `C:\Program Files\WasabiWallet\` folder. You will also have an icon in your Start Menu and on your Desktop. After the first run, a working directory will be created: `%appdata%\WalletWasabi\`. Among others, here is where your wallet files and your logs reside.
+Wasabi will be installed to your `C:\Program Files\WasabiWallet\` folder.
+You will also have an icon in your Start Menu and on your Desktop. After the first run, a working directory will be created: `%appdata%\WalletWasabi\`.
+Among others, here is where your wallet files and your logs reside.
 
 ### Manual public key import
 
@@ -71,11 +75,13 @@ If you get an error upon the import of Ádám Ficsor's PGP key, then you can man
 
 4. Save the file and close.
 
-5. Right click on `PGP.txt`. In the context menu navigate to `More GpgEx options/Import keys`.
+5. Right click on `PGP.txt`.
+In the context menu navigate to `More GpgEx options/Import keys`.
 
 ![](/InstallWindowsImportPGPManualImport.png)
 
-6. Kleopatra pops up and Ádám Ficsór's key is imported. Press `OK` and close Kleopatra.
+6. Kleopatra pops up and Ádám Ficsór's key is imported.
+Press `OK` and close Kleopatra.
 
 ![](/InstallWindowsImportPGPManualKleopatra.png)
 
@@ -86,39 +92,48 @@ Check out this [video guide](https://www.youtube.com/watch?v=DUc9A76rwX4).
 
 If you have already imported Ádám Ficsor's public key, then jump to step 2.
 
-1. Download Ádám Ficsor's PGP public key [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt), and then import it with `gpg --import PGP.txt`. Verify that the fingerprint is `21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`. [Next time you can skip previous steps because the public key is already imported.]
+1. Download Ádám Ficsor's PGP public key [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt), and then import it with `gpg --import PGP.txt`.
+Verify that the fingerprint is `21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`.
+[Next time you can skip previous steps because the public key is already imported.]
 
 2. [Download](https://wasabiwallet.io) the latest Wasabi release, both the `.deb` package and the corresponding `.asc` signature file.
 
 ![](/DownloadLinux.png)
 
-3. Verify the signature in the Download repository with `gpg --verify Wasabi-X.X.X.deb.asc` [Change `X.X.X` to version you downloaded.] If the message returned says `Good signature from nopara73 aka Ficsór Ádám` and that it was signed with `Primary key fingerprint: 21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`, then the software was not tampered with since the developer signed it.
+3. Verify the signature in the Download repository with `gpg --verify Wasabi-X.X.X.deb.asc` [Change `X.X.X` to version you downloaded.]
+If the message returned says `Good signature from nopara73 aka Ficsór Ádám` and that it was signed with `Primary key fingerprint: 21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`, then the software was not tampered with since the developer signed it.
 
 4. [GUI] Install by double clicking and follow the GUI Instruction. </br>
    [CLI] In the Download repository, run the command `sudo dpkg -i Wasabi-X.X.X.deb`. [Change `X.X.X` to version you downloaded.]
 
-After the first run, a working directory will be created: `~/.walletwasabi/`. Among others, here is where your wallet files and your logs reside.
+After the first run, a working directory will be created: `~/.walletwasabi/`.
+Among others, here is where your wallet files and your logs reside.
 
 
 ## Other Linux
 
-Check out [this](https://www.youtube.com/watch?v=qFbv_b-bju4) [Note that this video was created on OSX, but the steps are the same for Linux.], or [this](https://www.youtube.com/watch?time_continue=4&v=zPKpC9cRcZo) video guide.
+Check out [this](https://www.youtube.com/watch?v=qFbv_b-bju4) [Note that this video was created on OSX, but the steps are the same for Linux], or [this](https://www.youtube.com/watch?time_continue=4&v=zPKpC9cRcZo) video guide.
 
 If you have already imported Ádám Ficsor's public key, then jump to step 2.
 
-1. Download Ádám Ficsor's PGP public key [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt), and then import it with `gpg --import PGP.txt`. Verify that the fingerprint is `21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`. [Next time you can skip previous steps because the public key is already imported.]
+1. Download Ádám Ficsor's PGP public key [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt), and then import it with `gpg --import PGP.txt`. 
+Verify that the fingerprint is `21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`.
+[Next time you can skip previous steps because the public key is already imported.]
 
 2. [Download](https://wasabiwallet.io) the latest Wasabi release, both the `.tar.gz` archive and the corresponding `.asc` signature file.
 
 ![](/DownloadLinux.png)
 
-3. In the Download folder, run `gpg2 --verify Wasabi.X.X.X.asc`. [Change `X.X.X` to version you downloaded.] If the message returned says `Good signature from nopara73 aka Ficsór Ádám` and that it was signed with `Primary key fingerprint: 21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`, then the software was not tampered with since the developer signed it.
+3. In the Download folder, run `gpg2 --verify Wasabi.X.X.X.asc`.
+[Change `X.X.X` to version you downloaded.]
+If the message returned says `Good signature from nopara73 aka Ficsór Ádám` and that it was signed with `Primary key fingerprint: 21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`, then the software was not tampered with since the developer signed it.
 
 4. Extract the archive while keeping the file permissions: `tar -pxzf WasabiLinux-X.X.X.tar.gz`. [Change `X.X.X` to version you downloaded.]
 
 5. Run Wasabi by executing `./wassabee`.
 
-After the first run, a working directory will be created: `~/.walletwasabi/`. Among others, here is where your wallet files and your logs reside.
+After the first run, a working directory will be created: `~/.walletwasabi/`.
+Among others, here is where your wallet files and your logs reside.
 
 
 ## OSX
@@ -129,15 +144,20 @@ If you have already imported Ádám Ficsor's public key, then jump to step 4.
 
 1. [Get GnuPG](https://www.gnupg.org/download/index.html).
 
-2. Copy [Ádám Ficsor's PGP public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) into a new `TextEdit` document and saving it as `PGP.txt`. Before saving, you need to go to `Format / Make Plain Text` (otherwise TextEdit will not be able to save it as a .txt file).
+2. Copy [Ádám Ficsor's PGP public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) into a new `TextEdit` document and saving it as `PGP.txt`.
+Before saving, you need to go to `Format / Make Plain Text` (otherwise TextEdit will not be able to save it as a .txt file).
 
-3. Open Terminal and go to the folder in which you saved the `PGP.txt` file and import the public key with `sudo gpg2 --import PGP.txt`. This should return the output: `key B4B72266C47E075E: public key "nopara73 (GitHub key) <nopara73@github.com>" imported`. [Next time you can skip previous steps because the public key is already imported.]
+3. Open Terminal and go to the folder in which you saved the `PGP.txt` file and import the public key with `sudo gpg2 --import PGP.txt`.
+This should return the output: `key B4B72266C47E075E: public key "nopara73 (GitHub key) <nopara73@github.com>" imported`.
+[Next time you can skip previous steps because the public key is already imported.]
 
 4. [Download](https://wasabiwallet.io) the latest Wasabi release, both the `.dmg` package and the corresponding `.asc` signature file.
 
 ![](/DownloadMac.png)
 
-5. In the Download folder, run `sudo gpg2 --verify Wasabi.X.X.X.asc`. [Change `X.X.X` to version you downloaded.] If the message returned says `Good signature from nopara73 aka Ficsór Ádám` and that it was signed with `Primary key fingerprint: 21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`, then the software was not tampered with since the developer signed it.
+5. In the Download folder, run `sudo gpg2 --verify Wasabi.X.X.X.asc`.
+[Change `X.X.X` to version you downloaded.]
+If the message returned says `Good signature from nopara73 aka Ficsór Ádám` and that it was signed with `Primary key fingerprint: 21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`, then the software was not tampered with since the developer signed it.
 
 6. Double click `.dmg` to open it.
 
@@ -145,6 +165,10 @@ If you have already imported Ádám Ficsor's public key, then jump to step 4.
 
 ![](/InstallMacDragDrop.png)
 
-8. After opening Wasabi, you may encounter a security popup. You can bypass it in multiple ways. One way would be to keep the control key down while opening Wasabi. Another way is to go to System Preferences / Security & Privacy, where you should find a message `"Wasabi Wallet" was blocked from opening because it is not from an identified developer` and an `open anyway` button. Click the button and confirm by entering your Mac user password.
+8. After opening Wasabi, you may encounter a security popup.
+You can bypass it in multiple ways.
+One way would be to keep the control key down while opening Wasabi.
+Another way is to go to System Preferences / Security & Privacy, where you should find a message `"Wasabi Wallet" was blocked from opening because it is not from an identified developer` and an `open anyway` button.
+Click the button and confirm by entering your Mac user password.
 
 ![](/InstallMacConfirmOpen.png)

--- a/docs/using-wasabi/NetworkLevelPrivacy.md
+++ b/docs/using-wasabi/NetworkLevelPrivacy.md
@@ -4,43 +4,79 @@
 
 ---
 
-Bitcoin Core, more specifically full nodes are considered to be the pinnacle of network level privacy in Bitcoin wallets that no other wallet type can come close to. It is not difficult to see why: full nodes download the whole Blockchain and establish your wallet balances locally, so there is zero chance of any third party figuring out which addresses are in your wallet and which addresses are not.
+Bitcoin Core, more specifically full nodes are considered to be the pinnacle of network level privacy in Bitcoin wallets that no other wallet type can come close to.
+It is not difficult to see why: full nodes download the whole Blockchain and establish your wallet balances locally, so there is zero chance of any third party figuring out which addresses are in your wallet and which addresses are not.
 
-Compare this to other light wallets, which query a backend server to get information regarding specific addresses or use [BIP37](https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki) bloom filtering SPV wallet protocol, which is probably [even worse](https://jonasnick.github.io/blog/2015/02/12/privacy-in-bitcoinj/). And there is Electrum, which [sends your addresses](https://www.reddit.com/r/Bitcoin/comments/2feox9/electrum_securityprivacy_model/ck8szc0/) to random Electrum servers.
+Compare this to other light wallets, which query a backend server to get information regarding specific addresses or use [BIP37](https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki) bloom filtering SPV wallet protocol, which is probably [even worse](https://jonasnick.github.io/blog/2015/02/12/privacy-in-bitcoinj/).
+And there is Electrum, which [sends your addresses](https://www.reddit.com/r/Bitcoin/comments/2feox9/electrum_securityprivacy_model/ck8szc0/) to random Electrum servers.
 
-The vision of a light wallet that does not leak too much information while establishing the user’s UTXO set had haunted Bitcoin developers for centuries. In fact, even BIP37 started out as a privacy improvement, it just turned out to be not one later. But there were decent attempts: some developers, like Jonas Schnelli, the Stratis team and myself [built](https://github.com/bitcoin/bitcoin/pull/9076) [wallet](https://github.com/stratisproject/Breeze) [software](https://github.com/zkSNACKs/WalletWasabi/tree/hiddenwallet-v0.6) that only downloaded blocks from the creation of the user’s wallet. Some devs, like Nicolas Dorier attempted to [patch](https://github.com/NicolasDorier/NBitcoin.SPVSample) the BIP37 and some others, like the guys at Lightning Labs came up with a whole new light wallet architecture: BIP[157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki)-[158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki). The MoneroWorld folks want you to delegate [running your node to the cloud](https://moneroworld.com/). There were also others, like Chris Belcher, who said: “fuck that” and created [Electrum Personal Server](https://github.com/chris-belcher/electrum-personal-server) that lets you connect your Electrum client to your full node. Finally I have been noticing a positive trend recently of companies selling [boxes](https://www.nodl.it) those will run a full node for you out of the box.
+The vision of a light wallet that does not leak too much information while establishing the user’s UTXO set had haunted Bitcoin developers for centuries.
+In fact, even BIP37 started out as a privacy improvement, it just turned out to be not one later.
+But there were decent attempts: some developers, like Jonas Schnelli, the Stratis team and myself [built](https://github.com/bitcoin/bitcoin/pull/9076) [wallet](https://github.com/stratisproject/Breeze) [software](https://github.com/zkSNACKs/WalletWasabi/tree/hiddenwallet-v0.6) that only downloaded blocks from the creation of the user’s wallet.
+Some devs, like Nicolas Dorier attempted to [patch](https://github.com/NicolasDorier/NBitcoin.SPVSample) the BIP37 and some others, like the guys at Lightning Labs came up with a whole new light wallet architecture: BIP[157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki)-[158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki).
+The MoneroWorld folks want you to delegate [running your node to the cloud](https://moneroworld.com/).
+There were also others, like Chris Belcher, who said: “fuck that” and created [Electrum Personal Server](https://github.com/chris-belcher/electrum-personal-server) that lets you connect your Electrum client to your full node.
+Finally I have been noticing a positive trend recently of companies selling [boxes](https://www.nodl.it) those will run a full node for you out of the box.
 
-And then, there’s [Wasabi Wallet](https://wasabiwallet.io), which is a BIP157-ish client side filtering light wallet and partly integrates to your full node, too. Which brings me to the topic of this article: Just a few hours ago, with Wasabi Wallet, we achieved the best network level privacy that is possible with today’s Bitcoin.
+And then, there’s [Wasabi Wallet](https://wasabiwallet.io), which is a BIP157-ish client side filtering light wallet and partly integrates to your full node, too.
+Which brings me to the topic of this article: Just a few hours ago, with Wasabi Wallet, we achieved the best network level privacy that is possible with today’s Bitcoin.
 
 ## Terminology
 
-`V` Stands for Verification or Validation. They are used interchangeably, but I’m pretty sure one of it is correct. Veridation?
+`V` Stands for Verification or Validation.
+They are used interchangeably, but I’m pretty sure one of it is correct.
+Veridation?
 
-`FN`, Full Node, Fully Veridating Node. Downloads and veridates all the Bitcoin blocks ever created, but for our purposes (privacy) only the downloading part matters.
+`FN`, Full Node, Fully Veridating Node.
+Downloads and veridates all the Bitcoin blocks ever created, but for our purposes (privacy) only the downloading part matters.
 
-`SPV Node`, Simplified Payment Veridating Node. Only synchronizes the header chain (whatever that is) and can veridate that you have a transaction by applying some merkle magic. None of this matters for us though. The important thing is to notice that SPV has nothing to do with privacy, it’s really just a way of making sure transactions happened. By extension a full node has nothing to do with privacy either. It’s just describing how the node makes sure transactions happened. It veridates the whole blockchain, of course in order to do so, it has to download the whole blockchain, which enables wallet UTXO retrieval locally, which is the most private way to do that. Wait, so it has something to do with privacy after all?
+`SPV Node`, Simplified Payment Veridating Node.
+Only synchronizes the header chain (whatever that is) and can veridate that you have a transaction by applying some merkle magic.
+None of this matters for us though.
+The important thing is to notice that SPV has nothing to do with privacy, it’s really just a way of making sure transactions happened.
+By extension a full node has nothing to do with privacy either.
+It’s just describing how the node makes sure transactions happened.
+It veridates the whole blockchain, of course in order to do so, it has to download the whole blockchain, which enables wallet UTXO retrieval locally, which is the most private way to do that.
+Wait, so it has something to do with privacy after all?
 
-`Full-SPV`, Full-Block SPV, Full Block Downloading SPV Node. Downloads all the blocks from the creation of the wallet and does SPV verification on them. Wait, did I just doubled the V word there? Yes, developers are this inconsistent. I also hope nobody will ever build a full-SPV wallet that downloads all the blocks, but does centralized validation, because it is impossible to come up with a proper term for that.
+`Full-SPV`, Full-Block SPV, Full Block Downloading SPV Node.
+Downloads all the blocks from the creation of the wallet and does SPV verification on them.
+Wait, did I just doubled the V word there?
+Yes, developers are this inconsistent.
+I also hope nobody will ever build a full-SPV wallet that downloads all the blocks, but does centralized validation, because it is impossible to come up with a proper term for that.
 
-Confused yet? Good. Now that you recognized the nuanced nature of the topic, you’ll be more forgiving for me butchering the rest of this section with vast oversimplifications:
+Confused yet?
+Good.
+Now that you recognized the nuanced nature of the topic, you’ll be more forgiving for me butchering the rest of this section with vast oversimplifications:
 
-`Hybrid Full Node`. Is A light node until the full node synchronizes. I want Wasabi to be such wallet in the future.
+`Hybrid Full Node`.
+Is A light node until the full node synchronizes.
+I want Wasabi to be such wallet in the future.
 
-`BIP37`. Client sends bloom filter to full nodes, full nodes send back data matching the bloom filter.
+`BIP37`.
+Client sends bloom filter to full nodes, full nodes send back data matching the bloom filter.
 
-`Bloom Filter`. Lets you test if an element is in a set without revealing the set itself.
+`Bloom Filter`.
+Lets you test if an element is in a set without revealing the set itself.
 
-`Golomb-Rice Filters`. Smaller bloom filters, used by BIP158.
+`Golomb-Rice Filters`.
+Smaller bloom filters, used by BIP158.
 
-`Client Side Filtering`, Neutrino Filtering, BIP157, BIP158. The idea that clients don’t have to send filters to full nodes, but rather they do the opposite: full nodes create filters and send them to clients instead. From here on clients can download blocks from other sources. It’s a decently private way of establishing wallet UTXO state.
+`Client Side Filtering`, Neutrino Filtering, [BIP157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki), [BIP158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki).
+The idea that clients don’t have to send filters to full nodes, but rather they do the opposite: full nodes create filters and send them to clients instead.
+From here on clients can download blocks from other sources.
+It’s a decently private way of establishing wallet UTXO state.
 
-`Neutrino`. Lightning Lab’s implementation of the client side filtering protocol.
+`Neutrino`.
+Lightning Lab’s implementation of the client side filtering protocol.
 
-`Whatever Wasabi Is Doing`. Our implementation of the client side filtering protocol.
+`Whatever Wasabi Is Doing`.
+Our implementation of the client side filtering protocol.
 
 ## Zooming Out
 
-It is worth pointing out that network level privacy is just half of the battle. The other half is the blockchain level privacy, which is outside of the scope of this article.
+It is worth pointing out that network level privacy is just half of the battle.
+The other half is the blockchain level privacy, which is outside of the scope of this article.
 
 Furthermore network level privacy consists of two sub categories:
 
@@ -70,9 +106,12 @@ While in practice I suspect it doesn’t matter much, this article intends to ex
 
 ## Bitcoin Core + Tor
 
-You can use Bitcoin Core with Tor, which solves the above mentioned issue. In this case a supernode cannot track back transactions to your IP address.
+You can use Bitcoin Core with Tor, which solves the above mentioned issue.
+In this case a supernode cannot track back transactions to your IP address.
 
-I will consider any entity that can break Tor, a universal adversary, however note, this is inaccurate. For example most Tor attacks are not possible if exit nodes are not involved. This and other things like Core’s configurability would overcomplicate the analysis, so that’s why I choose to draw the line here.
+I will consider any entity that can break Tor, a universal adversary, however note, this is inaccurate.
+For example most Tor attacks are not possible if exit nodes are not involved.
+This and other things like Core’s configurability would overcomplicate the analysis, so that’s why I choose to draw the line here.
 I assume that this entity can break the onion routing, not Tor’s encryption itself.
 
 ### Adversaries Identified
@@ -83,23 +122,44 @@ I assume that this entity can break the onion routing, not Tor’s encryption it
 
 ### Private Transaction Broadcasting
 
-Wasabi previously did not maintain its P2P connections over Tor. Since Wasabi is a non-listening node, broadcasting transactions through other P2P nodes over the clearnet would’ve let the peer to link your IP address to the transaction. This is why we were broadcasting our transactions to our backend server over Tor.
+Wasabi previously did not maintain its P2P connections over Tor.
+Since Wasabi is a non-listening node, broadcasting transactions through other P2P nodes over the clearnet would’ve let the peer to link your IP address to the transaction.
+This is why we were broadcasting our transactions to our backend server over Tor.
 
 Now, we started tunneling all our P2P traffic through Tor, too:
 
-- We did it in a way that we only connect to onion nodes, so end to end encryption is now enforced between us and our peers. All this without involving any exit node.
+- We did it in a way that we only connect to onion nodes, so end to end encryption is now enforced between us and our peers.
+All this without involving any exit node.
 - We connect to each peer through a different Tor stream.
-- This enabled us to replace our transaction broadcasting mechanism. Now, we broadcast transactions to only one peer over Tor and immediately after that we disconnect the peer.
+- This enabled us to replace our transaction broadcasting mechanism.
+Now, we broadcast transactions to only one peer over Tor and immediately after that we disconnect the peer.
 
 ### Private UTXO Retrieval
 
-Finally we arrived to the interesting part. Before the P2P Tor implementation Wasabi was doing the following:
+Finally we arrived to the interesting part.
+Before the P2P Tor implementation Wasabi was doing the following:
 
-The backend server served a constant filter table to all the clients over Tor. From those filters the clients could figure out which blocks they are interested in and downloaded these blocks and some false-positive blocks from peers. One block per peer. When a block was acquired, the peer was disconnected. There were two issues with this. What if all the peers Wasabi connected to was the same entity for an extended period of time? Then the Sybil attacking entity would know all the blocks a client is interested in, of which some information could’ve been obtained. The question arises? How do you make sure you are the only peer a client connects to for en extended period of time?
+The backend server served a constant filter table to all the clients over Tor.
+From those filters the clients could figure out which blocks they are interested in and downloaded these blocks and some false-positive blocks from peers.
+One block per peer.
+When a block was acquired, the peer was disconnected.
+There were two issues with this. What if all the peers Wasabi connected to was the same entity for an extended period of time?
+Then the Sybil attacking entity would know all the blocks a client is interested in, of which some information could’ve been obtained.
+The question arises?
+How do you make sure you are the only peer a client connects to for en extended period of time?
 
-The second issue is, what if your ISP is spying on you for an extended period of time? This is more plausible. In fact Wasabi’s privacy rating on Bitcoin.org listing was almost scored down to be the same as Bread wallet, because of this, which of course would’ve been ridiculous, since Bread is a BIP37 wallet. What saved the rating was that I noted, if ISP is an adversary, then Bitcoin Core would’ve failed that in a more spectacular way, since transactions are broadcasted over the clearnet and even if the node is listening, the only transaction that doesn’t come in, but only goes out of the wallet must be the one that originates from the node.
+The second issue is, what if your ISP is spying on you for an extended period of time?
+This is more plausible.
+In fact Wasabi’s privacy rating on Bitcoin.org listing was almost scored down to be the same as Bread wallet, because of this, which of course would’ve been ridiculous, since Bread is a BIP37 wallet.
+What saved the rating was that I noted, if ISP is an adversary, then Bitcoin Core would’ve failed that in a more spectacular way, since transactions are broadcasted over the clearnet and even if the node is listening, the only transaction that doesn’t come in, but only goes out of the wallet must be the one that originates from the node.
 
-Anyway, Wasabi does this over Tor now. Because of the end-to-end encryption of the onion network, it immediately defeats an ISP adversary and makes the already impossible job of the Sybil adversary even more impossible. How do Sybil for an extended period of time, all the nodes those connect to Wasabi? Or even just one node? The client is hiding behind Tor. You cannot even tie together two connections of the client, since the client connects to all your Sybils through a different Tor stream. The only adversary that could possibly overcome this would have to setup thousands of full nodes over onion and also break Tor itself.
+Anyway, Wasabi does this over Tor now.
+Because of the end-to-end encryption of the onion network, it immediately defeats an ISP adversary and makes the already impossible job of the Sybil adversary even more impossible.
+How do Sybil for an extended period of time, all the nodes those connect to Wasabi?
+Or even just one node?
+The client is hiding behind Tor.
+You cannot even tie together two connections of the client, since the client connects to all your Sybils through a different Tor stream.
+The only adversary that could possibly overcome this would have to setup thousands of full nodes over onion and also break Tor itself.
 
 ### Adversaries Identified
 - ISP
@@ -109,10 +169,14 @@ Anyway, Wasabi does this over Tor now. Because of the end-to-end encryption of t
 
 ### Private UTXO Retrieval
 
-If you have a listening full node running in the background (not only Bitcoin Core, any full node) then Wasabi automatically picks it up and instead of asking peers for blocks, it asks blocks from your own node. Using Wasabi this way results in the same privacy model as Bitcoin Core’s regarding Private UTXO Retrieval.
+If you have a listening full node running in the background (not only Bitcoin Core, any full node) then Wasabi automatically picks it up and instead of asking peers for blocks, it asks blocks from your own node.
+Using Wasabi this way results in the same privacy model as Bitcoin Core’s regarding Private UTXO Retrieval.
 
 ## Conclusion
 
 > To be useful, security metrics should reflect the difficulty an adversary has in overcoming them. — [entropist](https://www.freehaven.net/anonbib/cache/entropist.pdf)
 
-Because against all reasonable adversaries, a comparison between Bitcoin Core and Wasabi Wallet on network level privacy does not make sense you might think this article was a waste of time. But you are greatly mistaken. This article will surely help me win Internet arguments. And, in the end, isn’t that’s what really matters?
+Because against all reasonable adversaries, a comparison between Bitcoin Core and Wasabi Wallet on network level privacy does not make sense you might think this article was a waste of time.
+But you are greatly mistaken.
+This article will surely help me win Internet arguments.
+And, in the end, isn’t that’s what really matters?

--- a/docs/using-wasabi/PasswordFinder.md
+++ b/docs/using-wasabi/PasswordFinder.md
@@ -1,18 +1,21 @@
-# Wasabi Password Finder
+# Password Finder
 
 [[toc]]
 
 ---
 
-Wasabi Password Finder is a tool for helping those who made a mistake typing the password during the wallet creation process. This tool tries to find the password that decrypts the encrypted secret key stored in a given wallet file. 
+Wasabi Password Finder is a tool for helping those who made a mistake typing the password during the wallet creation process.
+This tool tries to find the password that decrypts the encrypted secret key stored in a given wallet file. 
 
 ## Limitations
 
-Wasabi Wallet protects the encrypted secret key with the same technology used to protect paper wallets (bip 38) and for that reason it is computationally infeasible to brute force the password using all the possible combinations. It is important to know that Wasabi Password Finder is not for breaking wallet passwords but for finding errors (typos) in an already known password. 
+Wasabi Wallet protects the encrypted secret key with the same technology used to protect paper wallets (bip 38) and for that reason it is computationally infeasible to brute force the password using all the possible combinations.
+It is important to know that Wasabi Password Finder is not for breaking wallet passwords but for finding errors (typos) in an already known password. 
 
 ## Usage
 
-To use Wasabi's command line tools on Windows you have to use `wassabeed.exe` that is inside your `Program Files\WasabiWallet`. On Linux and OSX you can use the same software that you use for launching the GUI (`wassabee`).
+To use Wasabi's command line tools on Windows you have to use `wassabeed.exe` that is inside your `Program Files\WasabiWallet`.
+On Linux and OSX you can use the same software that you use for launching the GUI (`wassabee`).
 
 Let us start giving a glance to the command `help`:
 
@@ -32,7 +35,8 @@ eg: ./wassabee findpassword --wallet:MyWalletName --numbers:false --symbold:true
   -h, --help                 Show Help
 ```
 
-Now, let us find a typo in a wallet called `MagicalCryptoWallet.json`. For the sake of the example let us say I have created this wallet and I think the password is `pasd` but it was created with the password `pass` by accident.
+Now, let us find a typo in a wallet called `MagicalCryptoWallet.json`.
+For the sake of the example let us say I have created this wallet and I think the password is `pasd` but it was created with the password `pass` by accident.
 
 ```
 $ wassabee findpassword --wallet:MagicalCryptoWallet
@@ -48,14 +52,18 @@ SUCCESS: Password found: >>> pass <<<
 
 ```
 
-Note that you can also specify an encrypted secret instead of the wallet file. This is useful if you lost your password for a Bitcoin wallet, other than Wasabi.
+Note that you can also specify an encrypted secret instead of the wallet file.
+This is useful if you lost your password for a Bitcoin wallet, other than Wasabi.
 
-Note that for a 4 characters length password it took more than a minute to find. Moreover, the process is heavy in CPU and for that reason it can be a good idea to use the best combination of parameters to reduce the search space.
+Note that for a 4 characters length password it took more than a minute to find.
+Moreover, the process is heavy in CPU and for that reason it can be a good idea to use the best combination of parameters to reduce the search space.
 
-* __language__ (default: en) specify the charset (characters to search in) to reduce the search space. For example, while the *Italian* charset is "abcdefghimnopqrstuvxyzABCDEFGHILMNOPQRSTUVXYZ", the *French* charset is "aâàbcçdæeéèëœfghiîïjkmnoôpqrstuùüvwxyÿzAÂÀBCÇDÆEÉÈËŒFGHIÎÏJKMNOÔPQRSTUÙÜVWXYŸZ". 
+* __language__ (default: en) specify the charset (characters to search in) to reduce the search space.
+For example, while the *Italian* charset is "abcdefghimnopqrstuvxyzABCDEFGHILMNOPQRSTUVXYZ", the *French* charset is "aâàbcçdæeéèëœfghiîïjkmnoôpqrstuùüvwxyÿzAÂÀBCÇDÆEÉÈËŒFGHIÎÏJKMNOÔPQRSTUÙÜVWXYŸZ". 
 
 * __numbers__ (default: true) is for indicating that our password contains, or could contain, at least one digit. This increases the charset by 10 (from 0 to 9).
 
-* __symbols__ (default: true) is for indicating that our password contains, or could contain, at least one symbol. This increases the charset by 34 (|!¡@$¿?_-\"#$/%&()´+*=[]{},;:.^`<>). Note that only the most commonly used characters are available.
+* __symbols__ (default: true) is for indicating that our password contains, or could contain, at least one symbol.
+This increases the charset by 34 (|!¡@$¿?_-\"#$/%&()´+*=[]{},;:.^`<>). Note that only the most commonly used characters are available.
 
 

--- a/docs/using-wasabi/PayToEndPoint.md
+++ b/docs/using-wasabi/PayToEndPoint.md
@@ -6,12 +6,16 @@
 
 > Satoshi's Vision + CoinJoin + Bulletproofs = Sad Blockchain Analysts
 
-I attended a brainstorming event on Bitcoin privacy. In this article, I will assume all participants of this meeting would like to remain anonymous, unless she or he explicitly asks me to properly credit her or him.
+I attended a brainstorming event on Bitcoin privacy.
+In this article, I will assume all participants of this meeting would like to remain anonymous, unless she or he explicitly asks me to properly credit her or him.
 To keep this post coherent, I will refer to specific participants as Jessie, James and Meowth in an interchangeable, (not pseudonymous) way, hence Team Rocket.
 
-My goal today is to put out one of the ideas of this meeting in a digestible way. I assume some other Team Rocket member will do the same, in their own way. But first, let me walk you through some basic concepts. But before that, I’d like to credit some attendees and link to their articles on the event.
+My goal today is to put out one of the ideas of this meeting in a digestible way.
+I assume some other Team Rocket member will do the same, in their own way.
+But first, let me walk you through some basic concepts.
+But before that, I’d like to credit some attendees and link to their articles on the event.
 
-### Non-Anonymous Attendees
+#### Non-Anonymous Attendees
 
 - [Matthew Haywood](https://twitter.com/wintercooled)
 - [Adam Back](https://twitter.com/adam3us)
@@ -24,83 +28,128 @@ My goal today is to put out one of the ideas of this meeting in a digestible way
 
 ### P2IP
 
-> Bitcoin 0.1 supported Bitcoin addresses just like today, but it also had a “pay to IP address” feature. When you used this, you’d connect to the IP and get the sender’s full public key, and then send to that. […] Pay-to-IP was removed around 0.5, I think. — [Theymos](https://reddit.com/u/theymos), 2016
+> Bitcoin 0.1 supported Bitcoin addresses just like today, but it also had a “pay to IP address” feature.
+>When you used this, you’d connect to the IP and get the sender’s full public key, and then send to that.
+>[…] Pay-to-IP was removed around 0.5, I think. — [Theymos](https://reddit.com/u/theymos), 2016
 
-Satoshi built a feature into Bitcoin, called P2IP. This has terrible security and privacy drawbacks, so it was removed. Little we knew, when we came up with our Pay To EndPoint (P2EP) scheme, that we reinvented this feature, but in a secure and a privacy enhancing way. In our scheme the EndPoint can not only be an IP address, but also a domain, preferably a Tor onion.
+Satoshi built a feature into Bitcoin, called P2IP.
+This has terrible security and privacy drawbacks, so it was removed.
+Little we knew, when we came up with our Pay To EndPoint (P2EP) scheme, that we reinvented this feature, but in a secure and a privacy enhancing way.
+In our scheme the EndPoint can not only be an IP address, but also a domain, preferably a Tor onion.
 
 When Jessie realized what we have done, she jokingly noted: _"We perfected Satoshi's vision!"_
 
 ### Bulletproofs
 
-Bulletproofs (BP) is a zero-knowledge proof system, often cited together with Confidential Transactions. However we use BP for a different purpose. We utilize it to prevent a UTXO spoofing attack, that I will expand upon later. However James argues, we do not even need to deal with the implementation complexity of Bulletproofs, since a simple cut and choose defense might be sufficient.
+Bulletproofs (BP) is a zero-knowledge proof system, often cited together with Confidential Transactions.
+ However we use BP for a different purpose.
+We utilize it to prevent a UTXO spoofing attack, that I will expand upon later.
+However James argues, we do not even need to deal with the implementation complexity of Bulletproofs, since a simple cut and choose defense might be sufficient.
 
 It is also worth noting, that our scheme does not require any soft or hard fork.
 
 ### CoinJoin
 
-My regular readers are probably sick of me repeatedly explaining CoinJoin, (CJ) so feel free to skip this two sentences here. CJ stands for joining multiple users’ inputs into one transaction. It is also worth pointing out that most CJ scheme uses equal sized outputs. If it does not, then it provides zero privacy. But that is just an oversimplification, I often say. No matter how unintuitive it may seem, there are CJs with unequal sized outputs those still provide privacy, because the adversary have to recognize this was a CJ transaction in the first place. I will expand upon it later.
+My regular readers are probably sick of me repeatedly explaining CoinJoin, (CJ) so feel free to skip this two sentences here.
+CJ stands for joining multiple users’ inputs into one transaction.
+It is also worth pointing out that most CJ scheme uses equal sized outputs.
+If it does not, then it provides zero privacy. But that is just an oversimplification, I often say.
+No matter how unintuitive it may seem, there are CJs with unequal sized outputs those still provide privacy, because the adversary have to recognize this was a CJ transaction in the first place.
+I will expand upon it later.
 
 ### Blockchain Heuristics
 
-Blockchain Heuristics are the methods Blockchain Analytics uses to deanonymize you. These companies are founded on these heuristics. The scheme Team Rocket is proposing breaks some of these heuristics to the point that today’s Blockchain Analysis would be instantly broken, even if you do not use our scheme, since it would be really hard to figure out if you used P2EP or not.
+Blockchain Heuristics are the methods Blockchain Analytics uses to deanonymize you.
+These companies are founded on these heuristics. The scheme Team Rocket is proposing breaks some of these heuristics to the point that today’s Blockchain Analysis would be instantly broken, even if you do not use our scheme, since it would be really hard to figure out if you used P2EP or not.
 
 #### Heuristic 1: All inputs are co-owned.
 
-This means, if you are joining together more than one input, then it must all come from you. You could say that CJ breaks this assumption instantly, but (equal sized) CJ is easily identifiable, so that is easy to handle.
+This means, if you are joining together more than one input, then it must all come from you.
+You could say that CJ breaks this assumption instantly, but (equal sized) CJ is easily identifiable, so that is easy to handle.
 
 #### Mixing Heuristics: Subset-Sum Analysis.
 
-This heuristics can be applied to CJ transactions, (and all mixing technique in general,) where the output sizes are not equal. For example if James and Meowth joins their 1 BTC and 2 BTC coins together and the outputs would be 2 BTC and 1 BTC, it is easy to delink that transaction. Note, it is only possible if CJ transaction was identified.
+This heuristics can be applied to CJ transactions, (and all mixing technique in general,) where the output sizes are not equal.
+For example if James and Meowth joins their 1 BTC and 2 BTC coins together and the outputs would be 2 BTC and 1 BTC, it is easy to delink that transaction.
+Note, it is only possible if CJ transaction was identified.
 
 #### Heuristics Meta: What Doesn’t Exist Doesn’t Exist.
 
-It is evident, but it is worth pointing out. If Blockchain Analysis sees a transaction on the Blockchain that theoretically can be interpreted in many different ways, but in practice only one way of interpretation is implemented at that point in time, then that interpretation is what Blockchain Analysis assumes. This is why it is really easy to be anonymous with Bitcoin today. Just get familiar with some Blockchain Analysis heuristics, break them manually and they will interpret your transaction in the wrong way with 99% accuracy, because you are the only person who builds such transaction in the world and they are not aware of them.
+It is evident, but it is worth pointing out.
+If Blockchain Analysis sees a transaction on the Blockchain that theoretically can be interpreted in many different ways, but in practice only one way of interpretation is implemented at that point in time, then that interpretation is what Blockchain Analysis assumes.
+This is why it is really easy to be anonymous with Bitcoin today.
+Just get familiar with some Blockchain Analysis heuristics, break them manually and they will interpret your transaction in the wrong way with 99% accuracy, because you are the only person who builds such transaction in the world and they are not aware of them.
 To denounce the evils of Blockchain Analytics!
 
 To go to town with heuristics, see Adam Gibson’s [Building on Bitcoin talk](https://www.youtube.com/watch?v=XORDEX-RrAI&feature=youtu.be&t=23359), Kristov Atlas’s [CoinJoin Sudoku](https://www.coinjoinsudoku.com), where he broke Blockchain info’s now discontinued SharedCoin feature and [Nick Jonas’s 2016 talk](https://www.youtube.com/watch?v=HScK4pkDNds) in a Zurich Meetup.
 
 ### Clusterfuck Wallet
 
-The last concept I would like to get you familiar with is something I have written about. It is the [clusterfuck wallet](https://medium.com/@nopara73/new-bitcoin-anonymity-technique-the-clusterfuck-wallet-d48aa1787324). This is either the craziest idea I ever had or the most brilliant one
+The last concept I would like to get you familiar with is something I have written about.
+It is the [clusterfuck wallet](https://medium.com/@nopara73/new-bitcoin-anonymity-technique-the-clusterfuck-wallet-d48aa1787324).
+This is either the craziest idea I ever had or the most brilliant one
 medium.com
 
-> I remember reading a while ago Mircea Popescu’s ridiculous article, where he states something like Bitcoin is perfectly anonymous. His reasoning went like this: Blockchain analysis cannot make any reasonable conclusion, because a Bitcoin transaction can be interpreted in many different ways. — Ádám Ficsor
+> I remember reading a while ago Mircea Popescu’s ridiculous article, where he states something like Bitcoin is perfectly anonymous.
+>His reasoning went like this: Blockchain analysis cannot make any reasonable conclusion, because a Bitcoin transaction can be interpreted in many different ways. — Ádám Ficsor
 
-The goal of this wallet was to make Blockchain Heuristics as unreliable as it can get, by take advantage of Heuristics Meta: What Doesn’t Exist Doesn’t Exist. The idea is: make them to exist. With that creating chaos, or “clusterfuck” if you like. Turns out P2EP is a great tool to bring many exotic transactions into existence, not only the one the Team Moon Rocket is proposing here.
+The goal of this wallet was to make Blockchain Heuristics as unreliable as it can get, by take advantage of Heuristics Meta: What Doesn’t Exist Doesn’t Exist.
+The idea is: make them to exist. With that creating chaos, or “clusterfuck” if you like.
+Turns out P2EP is a great tool to bring many exotic transactions into existence, not only the one the Team Moon Rocket is proposing here.
 
 ## The Protocol
 
 ### Part 1: End-To-End Connection Establishment
 
-The idea is to make the recipient participate in the transaction, which would be great for many different reasons, I will come back to later. For now, we had a practical problem to solve. How do we establish a connection between the sender and the recipient in a P2P way?
+The idea is to make the recipient participate in the transaction, which would be great for many different reasons, I will come back to later.
+For now, we had a practical problem to solve.
+How do we establish a connection between the sender and the recipient in a P2P way?
 
-Jessie’s idea was to extend the [BIP21 Bitcoin URI Scheme](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) with an endpoint. Somehow like this: 
+Jessie’s idea was to extend the [BIP21 Bitcoin URI Scheme](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) with an endpoint.
+Somehow like this: 
 `bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?endpoint=http://3g2upl4pq6kufc4m.onion`
 
-In this case, first the sender would try to figure out if the recipient is online. If it is, then make a joint transaction together. If it is not, then make the transaction in the traditional way. The problem is BIP21 is not fully adopted and it would be confusing to some user to copypaste a BIP21 uri instead of just an address. Team Rocket still debates if this is acceptable or not.
+In this case, first the sender would try to figure out if the recipient is online.
+If it is, then make a joint transaction together.
+If it is not, then make the transaction in the traditional way.
+The problem is BIP21 is not fully adopted and it would be confusing to some user to copypaste a BIP21 uri instead of just an address.
+Team Rocket still debates if this is acceptable or not.
 
 **James has provided an arguably infeasible solution to this issue. What if we would generate the endpoint from the given Bitcoin address?**
 
-In this case, UX would stay the same: the receiver gives a Bitcoin address to the sender. However in the background the sender would try to establish a connection to the location corresponding to the Bitcoin address given and if that does not work, the sender sends the transaction normally.
+In this case, UX would stay the same: the receiver gives a Bitcoin address to the sender.
+However in the background the sender would try to establish a connection to the location corresponding to the Bitcoin address given and if that does not work, the sender sends the transaction normally.
 
 The impracticality of James’s idea is that we would need either our own anonymity network to achieve this, like a fork of Tor or we would have to convince an existing anonymity network to incorporate our scheme.
 Nevertheless, the idea is novel and worth keeping in mind.
 
 ### Part 2: Sender-Receiver CoinJoin
 
-It may seem like I do not even have to say more, because negotiating a transaction where the sender and the recipient both participates is not that hard, especially that they usually trust each other, right? Wrong. Their was a point where Team Rocket gave up on this scheme, because they thought they encountered an unsolvable issue.
+It may seem like I do not even have to say more, because negotiating a transaction where the sender and the recipient both participates is not that hard, especially that they usually trust each other, right?
+Wrong.
+Their was a point where Team Rocket gave up on this scheme, because they thought they encountered an unsolvable issue.
 
 What if a random sender connects to a publicly known receiver, start negotiating the transaction and ends up not signing in the end? So the sender would learn a UTXO of the receiver and run away with that sensitive information, without following up.
 
 In the most desperate moment Meowth had an idea: What if the receiver would feed the sender with fake UTXOs for a while, forcing the sender to sign a final transaction every time, but only the final, transaction with the receiver’s real UTXO would be broadcasted at the end?
 
-In this case, if the sender is malicious and does not follow up, the only thing he can learn is “there is a small chance of probability that this utxo is the receiver’s.” We called this to **The Serial Method**. James quickly came up with **The Parallel Method**, where many UTXOs would be sent in parallel and one of them is the real one. It reduces the number of rounds, however it tells the attacker that one of the UTXO is the real UTXO.
+In this case, if the sender is malicious and does not follow up, the only thing he can learn is “there is a small chance of probability that this utxo is the receiver’s.”
+We called this to **The Serial Method**.
+James quickly came up with **The Parallel Method**, where many UTXOs would be sent in parallel and one of them is the real one.
+It reduces the number of rounds, however it tells the attacker that one of the UTXO is the real UTXO.
 
-And finally Jessie came up with something elegant: **The Bulletproofs Method**. But I will not pretend that I fully understand it and I will leave it to others to expand upon the exact way of doing this. The bottom line is, both the Serial and the Parallel method leaks a small amount of information, the Bulletproofs method does not leak any, and it does not need monitoring the Blockchain to select fake UTXOs.
+And finally Jessie came up with something elegant: **The Bulletproofs Method**.
+But I will not pretend that I fully understand it and I will leave it to others to expand upon the exact way of doing this.
+The bottom line is, both the Serial and the Parallel method leaks a small amount of information, the Bulletproofs method does not leak any, and it does not need monitoring the Blockchain to select fake UTXOs.
 
 ### Extensions
 
-Before I explain the novelty of Part 2: Sender-Receiver CoinJoin protocol, I would like to point out that, Part 1: End-To-End Connection Establishment protocol has a side effect, namely it can be used to facilitate many things, I described in the Clusterfuck Wallet post. One thing this can easily facilitate is merge avoidance. If the sender would want to join multiple coins together, it could ask for multiple Bitcoin addresses from the receiver and send the coins one by one. It could also establish a future cooperation with the receiver. For example, the receiver, if online could participate in later transactions of the sender, thus breaking Heuristics 1 and Meta. But really, if this P2EP would get adopted, the limit of the number of strange schemes, all breaking Blockchain Analysis assumptions is just the developer’s imagination.
+Before I explain the novelty of Part 2: Sender-Receiver CoinJoin protocol, I would like to point out that, Part 1: End-To-End Connection Establishment protocol has a side effect, namely it can be used to facilitate many things, I described in the Clusterfuck Wallet post.
+One thing this can easily facilitate is merge avoidance.
+If the sender would want to join multiple coins together, it could ask for multiple Bitcoin addresses from the receiver and send the coins one by one.
+It could also establish a future cooperation with the receiver.
+For example, the receiver, if online could participate in later transactions of the sender, thus breaking Heuristics 1 and Meta.
+But really, if this P2EP would get adopted, the limit of the number of strange schemes, all breaking Blockchain Analysis assumptions is just the developer’s imagination.
 
 ## The Novelty of Sender-Receiver Scheme
 
@@ -110,26 +159,46 @@ If Blockchain Analysis looks at the transaction above, it will deduct:
 - The largest coin of the sender was 5 BTC.
 - The change is 2 BTC.
 
-And some other things. However if it the receiver participated in the transaction above, then this transaction could be interpreted in multiple ways, **breaking some blockchain analysis heuristics, not only the transaction level, but globally!** Remember Heuristics Meta? What does not exist, that does not exist. Thus if some people start using strange schemes, that affects how Blockchain analysis interprets other transactions, too.
+And some other things.
+However if it the receiver participated in the transaction above, then this transaction could be interpreted in multiple ways, **breaking some blockchain analysis heuristics, not only the transaction level, but globally!** Remember Heuristics Meta?
+What does not exist, that does not exist.
+Thus if some people start using strange schemes, that affects how Blockchain analysis interprets other transactions, too.
 
 #### Side effect 1: 
-In exchange for the privacy benefit, the sender has to pay more fees than a normal transaction. It is a con for the sender, but a pro for the receiver, since the receiver does not have to consolidate its coin later. Also it is a pro from a global point of view, due to its UTXO consolidation effects, I will detail a few lines below.
+In exchange for the privacy benefit, the sender has to pay more fees than a normal transaction.
+It is a con for the sender, but a pro for the receiver, since the receiver does not have to consolidate its coin later.
+Also it is a pro from a global point of view, due to its UTXO consolidation effects, I will detail a few lines below.
 
 #### Side effect 2: 
-Harder to coordinate, since the receiver must be online and the payment will take a few seconds longer. But it is arguable, that if everyone would be able to use this scheme all the time, then that would be the new pattern, thus the new reliable Heuristics for Blockchain analysis. It is crucial that not everyone use this pattern all the time. Its practical limitations achieves its goal.
+Harder to coordinate, since the receiver must be online and the payment will take a few seconds longer.
+But it is arguable, that if everyone would be able to use this scheme all the time, then that would be the new pattern, thus the new reliable Heuristics for Blockchain analysis.
+It is crucial that not everyone use this pattern all the time. Its practical limitations achieves its goal.
 
 #### Side effect 3: 
-Receiver must have a hot wallet. This is problematic in a buyer to merchant payment, since merchants usually receive coins to cold wallets. While my above comment still applies here, notice that this notion makes our problem of UTXO spying a corner case? That attack only applied if “the receiver is publicly known.” In peer to peer, person to person payments, the attacker would have to somehow first acquire an endpoint to a receiver.
+Receiver must have a hot wallet.
+This is problematic in a buyer to merchant payment, since merchants usually receive coins to cold wallets.
+While my above comment still applies here, notice that this notion makes our problem of UTXO spying a corner case?
+That attack only applied if “the receiver is publicly known.”
+In peer to peer, person to person payments, the attacker would have to somehow first acquire an endpoint to a receiver.
 
 #### Side effect 4: 
-Wallets must be deencrypted. Since many wallets only send-time decrypt the private keys, it would need to decrypt receive-time, too. There are multiple ways to implement this. It could be implemented in address generation time, which in our case it is also an endpoint generation time. But if it is strictly implemented at receive time, the UTXO spying defense may not be needed at all.
+Wallets must be deencrypted.
+Since many wallets only send-time decrypt the private keys, it would need to decrypt receive-time, too.
+There are multiple ways to implement this.
+It could be implemented in address generation time, which in our case it is also an endpoint generation time.
+But if it is strictly implemented at receive time, the UTXO spying defense may not be needed at all.
 
 ##### Side effect 5: 
-It helps with UTXO bloat. Let us assume the above transaction is a Sender-Receiver transaction. Then, if the receiver would not participate, that would mostly result in a one input, two output transaction.
+It helps with UTXO bloat.
+Let us assume the above transaction is a Sender-Receiver transaction.
+Then, if the receiver would not participate, that would mostly result in a one input, two output transaction.
 This also means, the receiver would not have to consolidate its UTXOs later, which is a huge win for privacy.
 
 ## Conclusion
 
-Overall, I feel this scheme can help a lot in Bitcoin’s privacy globally, especially if it is mixed with other clusterfuck wallet techniques. However, it must be said, there are some practical problems with it on the receiver’s side. Nevertheless it is simple to implement on the sender side and it affects globally everyone’s privacy, even those who do not use this scheme.
+Overall, I feel this scheme can help a lot in Bitcoin’s privacy globally, especially if it is mixed with other clusterfuck wallet techniques.
+However, it must be said, there are some practical problems with it on the receiver’s side. Nevertheless it is simple to implement on the sender side and it affects globally everyone’s privacy, even those who do not use this scheme.
 
-In the end… at the very least. Crazy ideas always worth writing down. Sometimes they end up changing things.
+In the end… at the very least.
+Crazy ideas always worth writing down.
+Sometimes they end up changing things.

--- a/docs/why-wasabi/10Commandments.md
+++ b/docs/why-wasabi/10Commandments.md
@@ -8,7 +8,9 @@
 
 ## 2. Verify the integrity of your software
 
-Wasabi Wallet is an open-source project with many contributors. When downloading the wallet, you may chose to go to the official site or to the official GitHub to build from source. Wasabi is available at our official site:
+Wasabi Wallet is an open-source project with many contributors.
+When downloading the wallet, you may chose to go to the official site or to the official GitHub to build from source.
+Wasabi is available at our official site:
 
 Clear-net: [wasabiwallet.io](https://wasabiwallet.io)
 
@@ -20,11 +22,19 @@ Alternatively, as Wasabi is [libre and open source software](https://github.com/
 
 ## 3. Keep your mnemonic words and password safely stored (BOTH!)
 
-When creating a new wallet - write down your mnemonic seed AND password and store those safely. Wasabi is a fully non-custodial wallet, which means that should always be in possession of your keys, and this means safely storing a backup in case your computer is lost or the wallet crashes. Often times when things go wrong, users panic. If you have done this step, there is very little you have to worry about. Also, under no circumstance should you reveal the password or mnemonic words to anyone that asks for them. Lastly, understand that if you lose your password, it becomes much harder (if not impossible) to restore your wallet - so store both safely!
+When creating a new wallet - write down your mnemonic seed AND password and store those safely.
+Wasabi is a fully non-custodial wallet, which means that should always be in possession of your keys, and this means safely storing a backup in case your computer is lost or the wallet crashes.
+Often times when things go wrong, users panic.
+If you have done this step, there is very little you have to worry about.
+Also, under no circumstance should you reveal the password or mnemonic words to anyone that asks for them.
+Lastly, understand that if you lose your password, it becomes much harder (if not impossible) to restore your wallet - so store both safely!
 
 ## 4. Practice good labeling AND try to never reuse addresses
 
-Each time you receive coins, you will be asked to create a label. This label is only for you and is stored exclusively on your device. Wasabi has strong coin control features, and as you continue to use the wallet, you will observe that the history of your coins will appear, and this history is only useful to you if you are practicing good labeling. An example of a good label:
+Each time you receive coins, you will be asked to create a label.
+This label is only for you and is stored exclusively on your device.
+Wasabi has strong coin control features, and as you continue to use the wallet, you will observe that the history of your coins will appear, and this history is only useful to you if you are practicing good labeling. 
+An example of a good label:
 
 June 20 - $400 from Coinbase, primary account
 
@@ -36,25 +46,41 @@ Address #1
 
 0.5 BTC
 
-Lastly, if you must use an exchange, try to ask for a new deposit address on each deposit. In the same way that you should never receive Bitcoin to the same address twice, you should try to avoiding sending Bitcoin to the same address twice.
+Lastly, if you must use an exchange, try to ask for a new deposit address on each deposit.
+In the same way that you should never receive Bitcoin to the same address twice, you should try to avoiding sending Bitcoin to the same address twice.
 
 ## 5. CoinJoin whenever possible and be patient!
 
-The process of engaging in a CoinJoin is as simple as selecting a coin or coins to en-queue and entering your password. Once coins have en-queued for CoinJoining, you must keep your computer online and awake, as the coin join process is interactive. As a coin join is really just many users (up to 100) en-queuing coins at the same time, it may take up to two hours for you to successfully participate in a CoinJoin and clean outputs should only be spent once the coin join transaction is confirmed. For context, Wasabi currently does 18 CoinJoins a day, or roughly one every 1 hour and 20 minutes. As more users join the network, the frequency of these CoinJoins will go up. Lastly, if you are able and patient enough to re-mix your coins, please do so. Re-mixing coins is nearly free and greatly encouraged!
+The process of engaging in a CoinJoin is as simple as selecting a coin or coins to en-queue and entering your password.
+Once coins have en-queued for CoinJoining, you must keep your computer online and awake, as the coin join process is interactive.
+As a coin join is really just many users (up to 100) en-queuing coins at the same time, it may take up to two hours for you to successfully participate in a CoinJoin and clean outputs should only be spent once the coin join transaction is confirmed.
+For context, Wasabi currently does 18 CoinJoins a day, or roughly one every 1 hour and 20 minutes.
+As more users join the network, the frequency of these CoinJoins will go up.
+Lastly, if you are able and patient enough to re-mix your coins, please do so.
 
 ## 6. Use separate profiles
 
-When you put a label on an address, or ask a question on this Reddit or send coins to a merchant be wary of the profile you choose. If you can create a dummy Reddit account as opposed to an account where you may have revealed your personal details elsewhere - use that. When you spend coins from your wallet, consider what you might want to keep private from the merchant or individual you are interacting with. In the same way that reusing addresses hurts your privacy, consolidating all of your online behavior into one profile can do the same.
+When you put a label on an address, or ask a question on this Reddit or send coins to a merchant be wary of the profile you choose.
+If you can create a dummy Reddit account as opposed to an account where you may have revealed your personal details elsewhere - use that.
+When you spend coins from your wallet, consider what you might want to keep private from the merchant or individual you are interacting with.
+In the same way that reusing addresses hurts your privacy, consolidating all of your online behavior into one profile can do the same.
 
 ## 7. Never merge mixed and unmixed coins, and avoid large merges of mixed coins!
 
-The first part should be somewhat intuitive - coins in your wallet have shields (red, yellow, green and green +) and it is at a minimum important to never send non-red coins (coins with anonset > 1) with red coins (coins with anonset == 1). By merging your tainted coins with your mixed coins, you undo the privacy benefits of CoinJoins! Further, when sending mixed coins to your cold storage, make sure to send your coins in parallel. Don't merge all of your Bitcoin (more than 0.8 BTC) in a single transaction! Instead, take your time and send coins to multiple addresses belong to your cold storage over a few hours or days. If you are sending coins to an exchange, you can get the same result by requesting a brand new address to receive coins.
+The first part should be somewhat intuitive - coins in your wallet have shields (red, yellow, green and green +) and it is at a minimum important to never send non-red coins (coins with anonset > 1) with red coins (coins with anonset == 1).
+By merging your tainted coins with your mixed coins, you undo the privacy benefits of CoinJoins!
+Further, when sending mixed coins to your cold storage, make sure to send your coins in parallel.
+Don't merge all of your Bitcoin (more than 0.8 BTC) in a single transaction!
+Instead, take your time and send coins to multiple addresses belong to your cold storage over a few hours or days.
+If you are sending coins to an exchange, you can get the same result by requesting a brand new address to receive coins.
 
 For more information, please see the discussions [here](https://www.reddit.com/r/WasabiWallet/comments/avxbjy/combining_mixed_coins_privacy_megathread/).
 
 ## 8. Avoid 3rd party servers & Buy Bitcoin P2P
 
-Wasabi is designed to allow users to see their balances without any concern that a third party would be able to link your addresses to you, or to each other. Very few wallets can say this, but if you proceed to enter your address into a block explorer, or use a third party wallet with your keys or your hardware device - all bets are off. So if you want to check on the status of a transaction or the balance on an address, you should first:
+Wasabi is designed to allow users to see their balances without any concern that a third party would be able to link your addresses to you, or to each other.
+Very few wallets can say this, but if you proceed to enter your address into a block explorer, or use a third party wallet with your keys or your hardware device - all bets are off.
+So if you want to check on the status of a transaction or the balance on an address, you should first:
 
 (a) Check your Wasabi Wallet
 
@@ -62,20 +88,31 @@ Wasabi is designed to allow users to see their balances without any concern that
 
 (c) Use a block explorer through Tor (e.g. [Blockstream Esplora Tor](http://http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/))
 
-If you think that forensics companies are not paying big money to block explorers for user information, you are wrong. Even something as simple as leaving a comment on a YouTube video or Reddit post will be scraped.
+If you think that forensics companies are not paying big money to block explorers for user information, you are wrong.
+Even something as simple as leaving a comment on a YouTube video or Reddit post will be scraped.
 
-More importantly, if you are using a hardware wallet, an easy way to undo the previous times you plugged in the wallet through non-private applications is to create a new account on the device with a passphrase. For example, for ledger nano s, you can do this in the device home screen > security > passphrase. Remember Commandment 2!
+More importantly, if you are using a hardware wallet, an easy way to undo the previous times you plugged in the wallet through non-private applications is to create a new account on the device with a passphrase.
+For example, for ledger nano s, you can do this in the device home screen > security > passphrase.
+Remember Commandment 2!
 
-Remember, Bitcoin is a peer-to-peer cash system, so when you have the opportunity to do so, buy your coins directly from someone you know or through a P2P market place. Not only will this benefit your privacy, it will save you on exchange fees and potential insolvency issues with the exchange you are dealing with.
+Remember, Bitcoin is a peer-to-peer cash system, so when you have the opportunity to do so, buy your coins directly from someone you know or through a P2P market place.
+Not only will this benefit your privacy, it will save you on exchange fees and potential insolvency issues with the exchange you are dealing with.
 
 ## 9. Run your own full node (if you can)
 
-Wasabi will work just fine without a local full node on your device, however, if you can spare the resources on your device, running a full node will do that much more for your privacy. Local full nodes will (when running in tandem with Wasabi) be automatically used for querying blocks.
+Wasabi will work just fine without a local full node on your device, however, if you can spare the resources on your device, running a full node will do that much more for your privacy.
+Local full nodes will (when running in tandem with Wasabi) be automatically used for querying blocks.
 
 ## 10. Use Lightning
 
-Wasabi is an ideal wallet for many things, but trade-offs exist with everything. If you have small amounts of un-mixed change from previous CoinJoins and you are unable to meet the requirements to engage in a CoinJoin, consider using that coin to open a lightning channel. Lightning is still a project in its' early days, but the privacy topology of lightning payments is much more ideal over on-chain payments if you have the choice. Routing large amounts can be uncertain, but for small amounts the network is becoming steadily more reliable. Currently Wasabi does not support in-wallet lightning features, but it is on the road-map.
+Wasabi is an ideal wallet for many things, but trade-offs exist with everything.
+If you have small amounts of un-mixed change from previous CoinJoins and you are unable to meet the requirements to engage in a CoinJoin, consider using that coin to open a lightning channel.
+Lightning is still a project in its' early days, but the privacy topology of lightning payments is much more ideal over on-chain payments if you have the choice.
+Routing large amounts can be uncertain, but for small amounts the network is becoming steadily more reliable.
+Currently Wasabi does not support in-wallet lightning features, but it is on the road-map.
 
 ## Credits
 
-Much of this list comes from the work of our good friends at JoinMaket. In particular, we need to thank [Adam Gibson](https://twitter.com/waxwing__) and [Chris Belcher](https://twitter.com/chris_belcher_) for their outstanding contribution to privacy in Bitcoin. Please take a look at the [Bitcoin Privacy Wiki](https://en.bitcoin.it/wiki/Privacy), the [Join Market Wiki](https://en.bitcoin.it/wiki/JoinMarket) and the [Join Market source code](https://github.com/JoinMarket-Org).
+Much of this list comes from the work of our good friends at JoinMaket.
+In particular, we need to thank [Adam Gibson](https://twitter.com/waxwing__) and [Chris Belcher](https://twitter.com/chris_belcher_) for their outstanding contribution to privacy in Bitcoin.
+Please take a look at the [Bitcoin Privacy Wiki](https://en.bitcoin.it/wiki/Privacy), the [Join Market Wiki](https://en.bitcoin.it/wiki/JoinMarket) and the [Join Market source code](https://github.com/JoinMarket-Org).

--- a/docs/why-wasabi/BitcoinPrivacy.md
+++ b/docs/why-wasabi/BitcoinPrivacy.md
@@ -18,9 +18,13 @@ The second rule of Bitcoin privacy:
 
 _**Easy wallet clustering**_
 
-A Bitcoin address commits to the spending condition of this UTXO. For example in Wasabi, each address is a [native SegWit pay to witness public key hash P2WPKH](https://programmingblockchain.gitbook.io/programmingblockchain/other_types_of_ownership/p2wpkh_pay_to_witness_public_key_hash), meaning that this coin can only be spend with a single valid signature of the corresponding private key. When the same address is used for several UTXOs, then this means that the same private key can spend all these coins. It is very easy to find all the UTXOs with the same address, and thus to find out how many bitcoin this private key holds. 
+A Bitcoin address commits to the spending condition of this UTXO.
+For example in Wasabi, each address is a [native SegWit pay to witness public key hash P2WPKH](https://programmingblockchain.gitbook.io/programmingblockchain/other_types_of_ownership/p2wpkh_pay_to_witness_public_key_hash), meaning that this coin can only be spend with a single valid signature of the corresponding private key.
+When the same address is used for several UTXOs, then this means that the same private key can spend all these coins.
+It is very easy to find all the UTXOs with the same address, and thus to find out how many bitcoin this private key holds. 
 
-Further, when in a transaction one output has a reused address, then it is very likely that this output is the payment destination, and not the change. Most wallets automatically generate a new change addresses for every transaction, but payment addresses are selected manually by the user.
+Further, when in a transaction one output has a reused address, then it is very likely that this output is the payment destination, and not the change.
+Most wallets automatically generate a new change addresses for every transaction, but payment addresses are selected manually by the user.
 
 Read more about the privacy concerns of address reuse in the [separate entry](https://en.bitcoin.it/wiki/Address_reuse) and the [privacy chapter](https://en.bitcoin.it/Privacy#Address_reuse) of the Bitcoin wiki.
 
@@ -28,26 +32,37 @@ Read more about the privacy concerns of address reuse in the [separate entry](ht
 
 _**Remove used address from GUI**_
 
-Wasabi uses the industry best practice [BIP 44 hierarchical deterministic wallet](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki), where out of one master secret a tree structure of child private keys are generated. It is deterministic because the same parent secret calculates always the same child private keys. When given a hardened child private key, then the parent private key cannot be calculated. In the `Receive` tab, a new address is generated every time, and as soon as a coin is sent to it, this specific address is removed from the GUI. 
+Wasabi uses the industry best practice [BIP 44 hierarchical deterministic wallet](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki), where out of one master secret a tree structure of child private keys are generated.
+It is deterministic because the same parent secret calculates always the same child private keys. When given a hardened child private key, then the parent private key cannot be calculated.
+In the `Receive` tab, a new address is generated every time, and as soon as a coin is sent to it, this specific address is removed from the GUI. 
 
 
 ## Inputs and outputs
 
-Bitcoin has an accounting model of [unspent transaction outputs [UTXO]](https://bitcoin.org/en/blockchain-guide#introduction). A transaction has inputs: the coins that are spent, and outputs: the coins that are received. The input of one transaction has to be an output of a previous transaction that is not yet spent. Each UTXO is the tip of the chain of links between inputs and outputs, all the way back to a [coin base transaction](https://en.bitcoin.it/wiki/Coinbase) that pays the miner.
+Bitcoin has an accounting model of [unspent transaction outputs [UTXO]](https://bitcoin.org/en/blockchain-guide#introduction).
+A transaction has inputs: the coins that are spent, and outputs: the coins that are received.
+The input of one transaction has to be an output of a previous transaction that is not yet spent.
+Each UTXO is the tip of the chain of links between inputs and outputs, all the way back to a [coin base transaction](https://en.bitcoin.it/wiki/Coinbase) that pays the miner.
 
 ### Problem
 
 _**UTXOs are not fungible**_
 
-Each UTXO is a unique snow flake with a public transaction history. For example, when Alice sends a coin to Bob, then Bob does not just have any random UTXO, but he has specifically the coin that Alice has sent him. When Bob sends this coin to Charlie, than Charlie can look back two hops to see the transaction from Alice to Bob. If Bob does not want Charlie to know that the transaction between Alice and Bob happened, then Bob needs to send Charlie a different coin.
+Each UTXO is a unique snow flake with a public transaction history.
+For example, when Alice sends a coin to Bob, then Bob does not just have any random UTXO, but he has specifically the coin that Alice has sent him.
+When Bob sends this coin to Charlie, than Charlie can look back two hops to see the transaction from Alice to Bob.
+If Bob does not want Charlie to know that the transaction between Alice and Bob happened, then Bob needs to send Charlie a different coin.
 
-Further, when Alice has one non-private coin and one private coin, and she selects both of them as the input of one transaction, then it might be clear that the previously private coin also belongs to Alice. This means that coin consolidation can lead to an overall decrease of privacy, especially when using a automatic coin selection algorithm.
+Further, when Alice has one non-private coin and one private coin, and she selects both of them as the input of one transaction, then it might be clear that the previously private coin also belongs to Alice.
+This means that coin consolidation can lead to an overall decrease of privacy, especially when using a automatic coin selection algorithm.
 
 ### Wasabi's Solution
 
 _**Manual coin labeling and selection**_
 
-Contrarily to many other wallets, Wasabi does not show only the total value of bitcoins in the wallet. Rather, in the `Send` and `Coin Join` tab is a list of all the UTXOs individually. Because it is required to label every receiving address, the history of this coin is clear at first glance. In order to spend a specific coin, it is manually selected, which prevents that the wrong coin is included in the transaction.
+Contrarily to many other wallets, Wasabi does not show only the total value of bitcoins in the wallet. Rather, in the `Send` and `Coin Join` tab is a list of all the UTXOs individually.
+Because it is required to label every receiving address, the history of this coin is clear at first glance.
+In order to spend a specific coin, it is manually selected, which prevents that the wrong coin is included in the transaction.
 
 
 ## Transaction graph
@@ -56,37 +71,59 @@ Contrarily to many other wallets, Wasabi does not show only the total value of b
 
 _**Public transaction history**_
 
-Because of the input and output model of Bitcoin, there is a chain of digital signatures all the way from the coinbase reward, to the current UTXO. This transaction history is can reveal sensitive information of the spending patterns of individuals. The receiver of a coin can look back into the transaction history of the sender. And the sender can see the future spending of the receiver.
+Because of the input and output model of Bitcoin, there is a chain of digital signatures all the way from the coinbase reward, to the current UTXO.
+This transaction history is can reveal sensitive information of the spending patterns of individuals.
+The receiver of a coin can look back into the transaction history of the sender.
+And the sender can see the future spending of the receiver.
 
 ### Wasabi's Solution
 
 _**Zero Link CoinJoins**_
 
-In order to obfuscate the link between outputs and inputs, Wasabi uses the [Zero Link](https://github.com/nopara73/zerolink) CoinJoin protocol. The Wasabi central coordinator cannot steal and cannot spy, he simple helps many peers to build a huge transaction, with many inputs, and many outputs. The non-private inputs can be linked to their previous transaction history. However, the equal value CoinJoin outputs with an anonymity set can not be tied to the inputs.
+In order to obfuscate the link between outputs and inputs, Wasabi uses the [Zero Link](https://github.com/nopara73/zerolink) CoinJoin protocol.
+The Wasabi central coordinator cannot steal and cannot spy, he simple helps many peers to build a huge transaction, with many inputs, and many outputs.
+The non-private inputs can be linked to their previous transaction history.
+However, the equal value CoinJoin outputs with an anonymity set can not be tied to the inputs.
 
-This means that when sending an anonset coin, the receiver does not know about the transaction history before the CoinJoin. And when the receiver does a CoinJoin himself, then the sender cannot spy on the later spending patterns. An outside observer can only guess the correct link at a rate of 1 in the anonset, for example 1-in-100, or 1%.
+This means that when sending an anonset coin, the receiver does not know about the transaction history before the CoinJoin.
+And when the receiver does a CoinJoin himself, then the sender cannot spy on the later spending patterns.
+An outside observer can only guess the correct link at a rate of 1 in the anonset, for example 1-in-100, or 1%.
 
 
 ## Network snooping
 
-Bitcoin is a peer to peer network of full nodes, who define, verify and enforce the Nakamoto consensus rules. There is a lot of communication between them and metadata can be used to de-anonymize Bitcoin users.
+Bitcoin is a peer to peer network of full nodes, who define, verify and enforce the Nakamoto consensus rules.
+There is a lot of communication between them and metadata can be used to de-anonymize Bitcoin users.
 
 ### Problem
 
 _**Clear net light clients**_
 
-When the communication to the network is unencrypted over clear net, then there is a easy correlation of the Bitcoin transactions to the IP address of the peer who send it. The IP address can be used to even find out about the physical location of the user!
+When the communication to the network is unencrypted over clear net, then there is a easy correlation of the Bitcoin transactions to the IP address of the peer who send it.
+The IP address can be used to even find out about the physical location of the user!
 
-A Bitcoin full node broadcasts not just the transaction of its user, but also it gossips all the other transactions it has received from its peers. Thus it is very difficult to find out which transactions are send from what full node. However, when a node or wallet does not gossip all transactions, but only the transactions of the user, then it is easier to find out which node has send that specific transaction.
+A Bitcoin full node broadcasts not just the transaction of its user, but also it gossips all the other transactions it has received from its peers.
+Thus it is very difficult to find out which transactions are send from what full node.
+However, when a node or wallet does not gossip all transactions, but only the transactions of the user, then it is easier to find out which node has send that specific transaction.
 
 ### Wasabi's Solution
 
 _**Full node by default & block filters over tor**_
 
-Wasabi checks if there is a local Tor instance installed, and if yes it uses this to onion-route all the traffic to and from the network. If there Tor is not already installed, then it is installed automatically within Wasabi. This means that per default, all network communication is secured from outside snooping and the IP address is hidden.
+Wasabi checks if there is a local Tor instance installed, and if yes it uses this to onion-route all the traffic to and from the network.
+If there Tor is not already installed, then it is installed automatically within Wasabi.
+This means that per default, all network communication is secured from outside snooping and the IP address is hidden.
 
-In order to fully verify everything, running a full node is essential. If [bitcoind](https://github.com/bitcoin/bitcoin) is installed on the same computer as Wasabi, then it will automatically and per default connect to the full node. It is also possible to connect Wasabi to a remote full node on another computer by specifying the local IP address or Tor hidden service in the settings. Now Wasabi pulls the verified blocks from the full node, and it also broadcasts the transactions to the P2P network from this full node.
+In order to fully verify everything, running a full node is essential.
+If [bitcoind](https://github.com/bitcoin/bitcoin) is installed on the same computer as Wasabi, then it will automatically and per default connect to the full node.
+It is also possible to connect Wasabi to a remote full node on another computer by specifying the local IP address or Tor hidden service in the settings.
+Now Wasabi pulls the verified blocks from the full node, and it also broadcasts the transactions to the P2P network from this full node.
 
-However, even if no full node is installed, Wasabi has a light client mode based on [BIP 158 block filters](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki). When the user sends the extended public key, or a filter of all the addresses to the central server, then the server can **COMPLETELY** deanonymize the users. Therefore the Wasabi server sends a filter of all the transactions in each block to all the users. Now they check locally if the block contains a transaction with their address. If no, then the filter is stored for later reference, and no block is downloaded. However, if there is a user transaction in that block, then Wasabi connects to a random Bitcoin P2P node over tor, and asks for this entire block, not only one transaction. This block request is indistinguishable from the regular P2P gossip, and thus nobody, neither the server nor the full node, know which addresses belong to the user.
+However, even if no full node is installed, Wasabi has a light client mode based on [BIP 158 block filters](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki).
+When the user sends the extended public key, or a filter of all the addresses to the central server, then the server can **COMPLETELY** deanonymize the users.
+Therefore the Wasabi server sends a filter of all the transactions in each block to all the users.
+Now they check locally if the block contains a transaction with their address.
+If no, then the filter is stored for later reference, and no block is downloaded. However, if there is a user transaction in that block, then Wasabi connects to a random Bitcoin P2P node over tor, and asks for this entire block, not only one transaction.
+This block request is indistinguishable from the regular P2P gossip, and thus nobody, neither the server nor the full node, know which addresses belong to the user.
 
 Wasabi is per default [as private as a Bitcoin full node](https://medium.com/@nopara73/bitcoin-core-vs-wasabi-wallet-network-level-privacy-bdca1d501387).

--- a/docs/why-wasabi/WhyPrivacyImportant.md
+++ b/docs/why-wasabi/WhyPrivacyImportant.md
@@ -2,7 +2,9 @@
 
 > It's not that I have something to hide. It's that I have nothing to share.
 
-Privacy is the selective revealing of your Self to your peers. You have many thoughts in your mind which you choose to never tell anyone, and many of your actions are never witnessed by another person. The ability to keep a secret is an essential part of the human experience.
+Privacy is the selective revealing of your Self to your peers.
+You have many thoughts in your mind which you choose to never tell anyone, and many of your actions are never witnessed by another person.
+The ability to keep a secret is an essential part of the human experience.
 
 - Why do you draw the curtains at night?
 - Why do you close the door when in the shower?
@@ -10,6 +12,7 @@ Privacy is the selective revealing of your Self to your peers. You have many tho
 
 [Privacy is Everywhere](https://youtu.be/laem7G6LPAM), by [Patrícia Estevão](https://twitter.com/patestevao) and [Marco Agner](https://twitter.com/marcoagner).
 
-Economic trade of goods and services is based on mutual beneficial voluntary action. But when an outside authority demands that the peers reveal the details of their exchange, then they must beg for permission of every act. Yet individuals can use the tools of self defense at their disposal to regain their sovereignty.
+Economic trade of goods and services is based on mutual beneficial voluntary action. But when an outside authority demands that the peers reveal the details of their exchange, then they must beg for permission of every act.
+Yet individuals can use the tools of self defense at their disposal to regain their sovereignty.
 
 > Without financial privacy, there is no human dignity.


### PR DESCRIPTION
This is a PR based on a suggestion by @dennisreimann to write this documentation with a simple, yet powerful convention:

### Each sentence starts a new line.

Why is this useful?

- Easy to spot too long, or too short sentences
- Changes to a sentence are only affect that line
- The `line addition and deletion` metric is meaningful again

### Example

### A regular paragraph looks like this in the mark down file:

```
foo.
bar.
foo.
```

and this renders to:
> foo. bar. foo.

### A line break is coded like this:

```
foo.
bar.

foo.
bar.
```

or


```
foo.
bar. </br>
foo.
bar.
```


and this renders to:
> foo. bar.
> foo. bar. 
