### PR TITLE
Add details toggles for FAQs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -15,24 +15,29 @@ module.exports = {
       type: "details",
       render (tokens, idx) {
         const token = tokens[idx]
-
+        // turn details headline into summary
         if (token.type === 'container_details_open') {
           const next = tokens[idx + 1]
           const match = token.info.trim().match(/^details\s+(.*)$/)
           let title = match && match[1]
           if (next.type === 'heading_open' && !title) {
-            const headNext = tokens[idx + 2]
-            title = headNext && headNext.content || ''
+            const headContent = tokens[idx + 2]
+            const headClose = tokens[idx + 3]
+            // hide headline and its contents
+            next.hidden = headClose.hidden = headContent.hidden = true
+            headContent.children = []
+            // extract title
+            title = headContent.content || ''
           } else {
             title = ''
           }
           const slug = slugify(title)
-          return `<details><summary><h3 id="${slug}"><a href="#${slug}" aria-hidden="true" class="header-anchor">#</a> ${title}</h3></summary>`
+          return `<details id="${slug}"><summary><a href="#${slug}" aria-hidden="true" class="header-anchor">#</a> ${title}</summary>`
         } else if (token.type === 'container_details_close') {
           return '</details>'
         }
       }
-    }],
+    }]
   ],
   markdown: {
     extendMarkdown (md) {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -9,7 +9,12 @@ module.exports = {
     ["link", { rel: "stylesheet", href: "https://fonts.googleapis.com/css?family=Inconsolata:400,700|Playfair+Display:700&display=swap" }]
   ],
   plugins: [
-    "@vuepress/back-to-top"
+    "@vuepress/back-to-top",
+    ["container", {
+      type: "details",
+      before: title => `<details><summary>${title}</summary>`,
+      after: '</details>'
+    }],
   ],
   markdown: {
     extendMarkdown (md) {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,3 +1,4 @@
+const { slugify } = require('@vuepress/shared-utils')
 const customBlock = require('markdown-it-custom-block')
 const youtubeEmbed = path => `<div class="ytEmbed"><iframe src="https://www.youtube-nocookie.com/embed/${path}" frameborder="0" allow="autoplay;encrypted-media;picture-in-picture" allowfullscreen></iframe></div>`
 
@@ -12,7 +13,7 @@ module.exports = {
     "@vuepress/back-to-top",
     ["container", {
       type: "details",
-      before: title => `<details><summary>${title}</summary>`,
+      before: title => `<details id="${slugify(title)}"><summary>${title}</summary>`,
       after: '</details>'
     }],
   ],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -13,7 +13,7 @@ module.exports = {
     "@vuepress/back-to-top",
     ["container", {
       type: "details",
-      before: title => `<details id="${slugify(title)}"><summary>${title}</summary>`,
+      before: title => `<details id="${slugify(title)}"><summary><h3><a href="#${slugify(title)}" aria-hidden="true" class="header-anchor">#</a> ${title}</h3></summary>`,
       after: '</details>'
     }],
   ],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -13,8 +13,25 @@ module.exports = {
     "@vuepress/back-to-top",
     ["container", {
       type: "details",
-      before: title => `<details id="${slugify(title)}"><summary><h3><a href="#${slugify(title)}" aria-hidden="true" class="header-anchor">#</a> ${title}</h3></summary>`,
-      after: '</details>'
+      render (tokens, idx) {
+        const token = tokens[idx]
+
+        if (token.type === 'container_details_open') {
+          const next = tokens[idx + 1]
+          const match = token.info.trim().match(/^details\s+(.*)$/)
+          let title = match && match[1]
+          if (next.type === 'heading_open' && !title) {
+            const headNext = tokens[idx + 2]
+            title = headNext && headNext.content || ''
+          } else {
+            title = ''
+          }
+          const slug = slugify(title)
+          return `<details><summary><h3 id="${slug}"><a href="#${slug}" aria-hidden="true" class="header-anchor">#</a> ${title}</h3></summary>`
+        } else if (token.type === 'container_details_close') {
+          return '</details>'
+        }
+      }
     }],
   ],
   markdown: {

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -1,21 +1,24 @@
 // https://v1.vuepress.vuejs.org/guide/basic-config.html#app-level-enhancements
-export default () => {
-  // hackish way to open FAQ item after page initialization
-  const { hash } = location
-
-  if (hash) {
-    window.setTimeout(() => {
-      const el = document.getElementById(hash.substr(1))
-      const summary = el.parentNode
-      if (el && summary && summary.tagName.toLowerCase() === 'summary') {
-        const details = summary.parentNode
-        if (details.tagName.toLowerCase() === 'details') {
-          details.setAttribute('open', true)
-          const { offsetTop } = details
-          const top = offsetTop - 70 // subtract navbar height
-          window.scrollTo({ top })
-        }
-      }
-    }, 500)
+const openDetails = hash => {
+  const el = document.getElementById(hash.substr(1))
+  console.log(el)
+  if (el && el.tagName.toLowerCase() === 'details') {
+    el.setAttribute('open', true)
+    const { offsetTop } = el
+    window.scrollTo({ top: offsetTop })
   }
+}
+
+export default ({ router }) => {
+  // initial page rendering
+  document.addEventListener('DOMContentLoaded', () => {
+    window.setTimeout(() => openDetails(location.hash), 500)
+  })
+
+  // sidebar link clicks
+  document.addEventListener('click', e => {
+    if (e.target.matches('.sidebar-link')) {
+      openDetails(location.hash)
+    }
+  })
 }

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -1,0 +1,18 @@
+// https://v1.vuepress.vuejs.org/guide/basic-config.html#app-level-enhancements
+export default () => {
+  // hackish way to open FAQ item after page initialization
+  const { hash } = location
+
+  if (hash) {
+    window.setTimeout(() => {
+      const el = document.getElementById(hash.substr(1))
+
+      if (el && el.tagName.toLowerCase() === 'details') {
+        el.setAttribute('open', true)
+        const { offsetTop } = el
+        const top = offsetTop - 70 // subtract navbar height
+        window.scrollTo({ top })
+      }
+    }, 500)
+  }
+}

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -6,12 +6,15 @@ export default () => {
   if (hash) {
     window.setTimeout(() => {
       const el = document.getElementById(hash.substr(1))
-
-      if (el && el.tagName.toLowerCase() === 'details') {
-        el.setAttribute('open', true)
-        const { offsetTop } = el
-        const top = offsetTop - 70 // subtract navbar height
-        window.scrollTo({ top })
+      const summary = el.parentNode
+      if (el && summary && summary.tagName.toLowerCase() === 'summary') {
+        const details = summary.parentNode
+        if (details.tagName.toLowerCase() === 'details') {
+          details.setAttribute('open', true)
+          const { offsetTop } = details
+          const top = offsetTop - 70 // subtract navbar height
+          window.scrollTo({ top })
+        }
       }
     }, 500)
   }

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -64,8 +64,11 @@ body
     margin 1rem 0
     &::marker
       color $accentColor
+    & +
+      h1, h2, h3, h4, h5, h6
+        display none
     h3
-      display inline-block
+      display inline
       margin 0
       .header-anchor
         margin-left -2.25rem

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -224,7 +224,7 @@ body
 
     .ytEmbed
       position relative
-      margin-bottom 2rem
+      margin 1rem 0 2rem
       height 0
       overflow hidden
       max-width 100%

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -64,6 +64,11 @@ body
     margin 1rem 0
     &::marker
       color $accentColor
+    h3
+      display inline-block
+      margin 0
+      .header-anchor
+        margin-left -2.25rem
 
   // home
   .home

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -55,23 +55,22 @@ body
     font-weight 700
 
   details
-    margin 1rem 0
+    margin -4rem 0 0 0
     &[open]
       > :last-child
         margin-bottom 3rem
 
   summary
-    margin 1rem 0
+    margin-top (0.5rem - $navbarHeight)
+    padding-top ($navbarHeight + 1rem)
+    margin-bottom 0
+    &:first-child
+      margin-top -1.5rem
+      margin-bottom 1rem
+    &:hover .header-anchor
+      opacity 1
     &::marker
       color $accentColor
-    & +
-      h1, h2, h3, h4, h5, h6
-        display none
-    h3
-      display inline
-      margin 0
-      .header-anchor
-        margin-left -2.25rem
 
   // home
   .home

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -49,9 +49,21 @@ body
 
   h3
   h4
+  summary
     text-transform uppercase
     letter-spacing 0.05rem
     font-weight 700
+
+  details
+    margin 1rem 0
+    &[open]
+      > :last-child
+        margin-bottom 3rem
+
+  summary
+    margin 1rem 0
+    &::marker
+      color $accentColor
 
   // home
   .home
@@ -143,7 +155,6 @@ body
 
   // content
   .page
-
     a:not(.nav-link)
       text-decoration none
       color $accentColor

--- a/docs/FAQ/FAQ-Contribution.md
+++ b/docs/FAQ/FAQ-Contribution.md
@@ -1,12 +1,8 @@
 # Contributions to Wasabi
 
-[[toc]]
-
----
-
 ## The Wasabikas of the dojo
 
-### Who is contributing to Wasabi already?
+:::details Who is contributing to Wasabi already?
 There are many Wasabikas working with great effort and care to manifest this powerful tool of self defense.
 [Over 35 peers](https://github.com/zkSNACKs/WalletWasabi/graphs/contributors) have already contributed to the repository, and more and more supporters are joining the [dojo](/building-wasabi/Dojo.md).
 Four of the main contributors are [Ádám Ficsor](https://github.com/nopara73) [co-founder and CTO of [zkSnacks Ltd](https://zksnacks.com/), co-author of the [zero link Bitcoin fungibility framework](https://github.com/nopara73/ZeroLink)], [Lucas Ontivero](https://github.com/lontivero) [lead engineer of [zkSnacks Ltd](https://zksnacks.com/)], [Dávid Molnár](https://github.com/molnard) [[zkSnacks Ltd](https://zksnacks.com/) employee], and [Dan Walmsley](https://github.com/danwalmsley) [maintainer of [Avalonia UI Framework](https://github.com/AvaloniaUI/Avalonia)].
@@ -17,8 +13,9 @@ For an inclusive list of all the Wasabikas, not just the code developers, please
 @[youtube](Yg7_3LIutJA)
 
 @[youtube](X9BB_9faJE8)
+:::
 
-### Who reviews and merges the pull requests?
+:::details Who reviews and merges the pull requests?
 As the Wasabi code is libre and open source, anyone has access to review the latest contritions and browse the [open pull requests](https://github.com/zkSNACKs/WalletWasabi/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc).
 The review of any Wasabika is not just deeply appreciated, but desperately needed!
 Wasabi is cutting-edge high security software, and there can never be enough eyes seeking and squashing bugs.
@@ -28,8 +25,9 @@ There are three developers who have the ability to merge code into master branch
 - [Ádám Ficsor](https://github.com/nopara73) [co-founder and CTO of [zkSnacks Ltd](https://zksnacks.com/), co-author of the [zero link Bitcoin fungibility framework](https://github.com/nopara73/ZeroLink)] is the [admin](https://help.github.com/en/articles/repository-permission-levels-for-an-organization) of the [GitHub repository](https://github.com/zksnacks/walletwasabi) and has full write access to everything in it, he has the ability to merge any code that he wants.
 - [Lucas Ontivero](https://github.com/lontivero) [lead engineer of [zkSnacks Ltd](https://zksnacks.com/)] is [co-maintainer](https://help.github.com/en/articles/repository-permission-levels-for-an-organization) of the [GitHub repository](https://github.com/zksnacks/walletwasabi), he can merge a pull request, but only when both Ádám and Dávid have reviewed and acknowledged the changes.
 - [Dávid Molnár](https://github.com/molnard) is [co-maintainer](https://help.github.com/en/articles/repository-permission-levels-for-an-organization) of the [GitHub repository](https://github.com/zksnacks/walletwasabi), he can merge a pull request, but only when both Ádám and Lucas have reviewed and acknowledged the changes.
+:::
 
-### What is on the future roadmap of Wasabi development?
+:::details What is on the future roadmap of Wasabi development?
 Wasabi is far from complete, there are many Wasabikas contributing every day to make this tool of self defense even more powerful.
 Because Wasabi is libre and open source software, anyone can support the project without asking for permission.
 Thus it is relatively tricky to give a precise roadmap with what will be implemented in the near and distant future.
@@ -37,23 +35,25 @@ You can check the [ToDo list](/building-wasabi/ToDo.md) for a somewhat up-to-dat
 
 ## You can become a Wasabika
 
-### How should I start contributing to Wasabi?
+:::details How should I start contributing to Wasabi?
 Thank you for considering to support this beautiful libre and open source project!
 Nobody owns this software, and thus it is the responsibility of everyone using it to contribute to its growth.
 Thus your help is deeply appreciated, and very much needed!
 First please read the [contribution checklist](/building-wasabi/ContributionChecklist.md) to get introduced to the project and to start out in the right direction.
 You can also see the [ToDo list](/building-wasabi/ToDo.md) for inspiration of what other Wasabikas are tinkering on.
 Join our [Slack](https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2NzQ1ODI0LWIzOTg5YTM3YmNkOTg1NjZmZTQ3NmM1OTAzYmQyYzk1M2M0MTdlZDk2OTQwNzFiNTg1ZmExNzM0NjgzY2M0Yzg), [Telegram](https://t.me/WasabiWallet) or [Sub-Reddit](https://www.reddit.com/r/WasabiWallet/), and check out the [GitHub](https://github.com/zkSnacks/WalletWasabi), so that you can stay up-to-date with the latest contributions.
+:::
 
-### Is there a bounty program?
+:::details Is there a bounty program?
 Yes!
 The beauty of Wasabi is that it's not just a very awesome wallet by default, but it has the additional opt-in CoinJoin serivce.
 This is provided by [zkSnacks Ltd.](https://zksnacks.com), and in exchange for this additional service the user pays a coordinator fee.
 In return, zkSnacks is supporting several developers to dedicate their full time to contribute to this open source project.
 There are also projects like the [contribution game](/building-wasabi/ContributionGame.md) where a bounty is paid out to any contributor worthy the praise.
 Specifically for the documentation, there is a monthly budget of 1.000 USD to cover for the maintenance and expansion of this knowledge archive.
+:::
 
-### How can I report a bug?
+::::details How can I report a bug?
 Code is speech, and can never be perfect.
 Thus it is expected that there are many known and unknown bugs, quirks and issues in Wasabi.
 Such a complex software requires constant and rigorous review by the developers and the users, this is everyone's responsibility working with Wasabi.
@@ -69,8 +69,9 @@ In some cases it might be useful to see your logs, though please consider your p
 If you find a critical bug that puts users at serious harm, please take great care with responsible disclosure!
 Securely encrypt the detailed report with Ádám Ficsor's PGP key [21D7 CA45 565D BCCE BE45 115D B4B7 2266 C47E 075E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) and send it to [adam.ficsor73@gmail.com](mailto:adam.ficsor73@gmail.com).
 :::
+::::
 
-### How can I request a feature?
+:::details How can I request a feature?
 Wasabi is a quite beautiful piece of software already.
 Yet there are also 1001 things that could be just a little better, or even quite substantially superior.
 The beauty and bain of libre and open source software is that it is never complete, there is always more work to be done.
@@ -82,19 +83,22 @@ If no, then please consider to [open a new issue](https://github.com/zkSNACKs/Wa
 It makes sense to first explain the problem you have in the incumbent version of Wasabi, this is the place to express your frustrations and annoyances.
 Then describe the solution that you have envisioned, with all the nuances and details of how this would fix your problem.
 To flesh our your argument, please consider alternatives and different approaches to this feature request.
+:::
 
-### How can I get help and support?
+:::details How can I get help and support?
 You are already on the right track by first checking [this documentation](https://docs.wasabiwallet.io) for the knowledge you are seeking.
 It's likely that you are not the first peer who has an issue and question, and hopefully one has curated the answer in here already.
 You can use the search function in the top navbar to look for a specific topic, and the sidebar menu as a table of content.
 Though often times it is quite useful to start a conversation with other Wasabikas about a specific problem.
 It is useful to reach out to the contributors on [Twitter](https://twitter.com/wasabiwallet), [Reddit](https://old.reddit.com/r/WasabiWallet/), and [Telegram](https://t.me/WasabiWallet).
 If your trouble is specific to the code, then it might also be suitable to check the existing [GitHub issues](https://github.com/zkSNACKs/WalletWasabi/issues/) and open a new one.
+:::
 
-### What does the Wasabi project need help with?
+:::details What does the Wasabi project need help with?
 Wasabi is libre and open source software, thus it relies on the support of several contributors on all fronts.
 Of course, this includes coding new features, bug fixes and stability improvements.
 Yet just equally important is the review of the commits of all other Wasabikas.
 It's not just the contributions to the code, but also to the documentation and the effort to educate peers using Wasabi.
 This includes education in meatspace tribe gatherings, but also in cyberspace peer support.
 So basically, we need help with building and shilling Wasabi!
+:::

--- a/docs/FAQ/FAQ-Contribution.md
+++ b/docs/FAQ/FAQ-Contribution.md
@@ -2,7 +2,9 @@
 
 ## The Wasabikas of the dojo
 
-:::details Who is contributing to Wasabi already?
+:::details
+### Who is contributing to Wasabi already?
+
 There are many Wasabikas working with great effort and care to manifest this powerful tool of self defense.
 [Over 35 peers](https://github.com/zkSNACKs/WalletWasabi/graphs/contributors) have already contributed to the repository, and more and more supporters are joining the [dojo](/building-wasabi/Dojo.md).
 Four of the main contributors are [Ádám Ficsor](https://github.com/nopara73) [co-founder and CTO of [zkSnacks Ltd](https://zksnacks.com/), co-author of the [zero link Bitcoin fungibility framework](https://github.com/nopara73/ZeroLink)], [Lucas Ontivero](https://github.com/lontivero) [lead engineer of [zkSnacks Ltd](https://zksnacks.com/)], [Dávid Molnár](https://github.com/molnard) [[zkSnacks Ltd](https://zksnacks.com/) employee], and [Dan Walmsley](https://github.com/danwalmsley) [maintainer of [Avalonia UI Framework](https://github.com/AvaloniaUI/Avalonia)].
@@ -15,7 +17,9 @@ For an inclusive list of all the Wasabikas, not just the code developers, please
 @[youtube](X9BB_9faJE8)
 :::
 
-:::details Who reviews and merges the pull requests?
+:::details
+### Who reviews and merges the pull requests?
+
 As the Wasabi code is libre and open source, anyone has access to review the latest contritions and browse the [open pull requests](https://github.com/zkSNACKs/WalletWasabi/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc).
 The review of any Wasabika is not just deeply appreciated, but desperately needed!
 Wasabi is cutting-edge high security software, and there can never be enough eyes seeking and squashing bugs.
@@ -27,7 +31,9 @@ There are three developers who have the ability to merge code into master branch
 - [Dávid Molnár](https://github.com/molnard) is [co-maintainer](https://help.github.com/en/articles/repository-permission-levels-for-an-organization) of the [GitHub repository](https://github.com/zksnacks/walletwasabi), he can merge a pull request, but only when both Ádám and Lucas have reviewed and acknowledged the changes.
 :::
 
-:::details What is on the future roadmap of Wasabi development?
+:::details
+### What is on the future roadmap of Wasabi development?
+
 Wasabi is far from complete, there are many Wasabikas contributing every day to make this tool of self defense even more powerful.
 Because Wasabi is libre and open source software, anyone can support the project without asking for permission.
 Thus it is relatively tricky to give a precise roadmap with what will be implemented in the near and distant future.
@@ -36,7 +42,9 @@ You can check the [ToDo list](/building-wasabi/ToDo.md) for a somewhat up-to-dat
 
 ## You can become a Wasabika
 
-:::details How should I start contributing to Wasabi?
+:::details
+### How should I start contributing to Wasabi?
+
 Thank you for considering to support this beautiful libre and open source project!
 Nobody owns this software, and thus it is the responsibility of everyone using it to contribute to its growth.
 Thus your help is deeply appreciated, and very much needed!
@@ -45,7 +53,9 @@ You can also see the [ToDo list](/building-wasabi/ToDo.md) for inspiration of wh
 Join our [Slack](https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2NzQ1ODI0LWIzOTg5YTM3YmNkOTg1NjZmZTQ3NmM1OTAzYmQyYzk1M2M0MTdlZDk2OTQwNzFiNTg1ZmExNzM0NjgzY2M0Yzg), [Telegram](https://t.me/WasabiWallet) or [Sub-Reddit](https://www.reddit.com/r/WasabiWallet/), and check out the [GitHub](https://github.com/zkSnacks/WalletWasabi), so that you can stay up-to-date with the latest contributions.
 :::
 
-:::details Is there a bounty program?
+:::details
+### Is there a bounty program?
+
 Yes!
 The beauty of Wasabi is that it's not just a very awesome wallet by default, but it has the additional opt-in CoinJoin serivce.
 This is provided by [zkSnacks Ltd.](https://zksnacks.com), and in exchange for this additional service the user pays a coordinator fee.
@@ -54,7 +64,9 @@ There are also projects like the [contribution game](/building-wasabi/Contributi
 Specifically for the documentation, there is a monthly budget of 1.000 USD to cover for the maintenance and expansion of this knowledge archive.
 :::
 
-::::details How can I report a bug?
+::::details
+### How can I report a bug?
+
 Code is speech, and can never be perfect.
 Thus it is expected that there are many known and unknown bugs, quirks and issues in Wasabi.
 Such a complex software requires constant and rigorous review by the developers and the users, this is everyone's responsibility working with Wasabi.
@@ -72,7 +84,9 @@ Securely encrypt the detailed report with Ádám Ficsor's PGP key [21D7 CA45 565
 :::
 ::::
 
-:::details How can I request a feature?
+:::details
+### How can I request a feature?
+
 Wasabi is a quite beautiful piece of software already.
 Yet there are also 1001 things that could be just a little better, or even quite substantially superior.
 The beauty and bain of libre and open source software is that it is never complete, there is always more work to be done.
@@ -86,7 +100,9 @@ Then describe the solution that you have envisioned, with all the nuances and de
 To flesh our your argument, please consider alternatives and different approaches to this feature request.
 :::
 
-:::details How can I get help and support?
+:::details
+### How can I get help and support?
+
 You are already on the right track by first checking [this documentation](https://docs.wasabiwallet.io) for the knowledge you are seeking.
 It's likely that you are not the first peer who has an issue and question, and hopefully one has curated the answer in here already.
 You can use the search function in the top navbar to look for a specific topic, and the sidebar menu as a table of content.
@@ -95,7 +111,9 @@ It is useful to reach out to the contributors on [Twitter](https://twitter.com/w
 If your trouble is specific to the code, then it might also be suitable to check the existing [GitHub issues](https://github.com/zkSNACKs/WalletWasabi/issues/) and open a new one.
 :::
 
-:::details What does the Wasabi project need help with?
+:::details
+### What does the Wasabi project need help with?
+
 Wasabi is libre and open source software, thus it relies on the support of several contributors on all fronts.
 Of course, this includes coding new features, bug fixes and stability improvements.
 Yet just equally important is the review of the commits of all other Wasabikas.

--- a/docs/FAQ/FAQ-Contribution.md
+++ b/docs/FAQ/FAQ-Contribution.md
@@ -32,6 +32,7 @@ Wasabi is far from complete, there are many Wasabikas contributing every day to 
 Because Wasabi is libre and open source software, anyone can support the project without asking for permission.
 Thus it is relatively tricky to give a precise roadmap with what will be implemented in the near and distant future.
 You can check the [ToDo list](/building-wasabi/ToDo.md) for a somewhat up-to-date summary of the short term priorities of the next #twoweeks, and what might be implemented in the distant future.
+:::
 
 ## You can become a Wasabika
 

--- a/docs/FAQ/FAQ-GeneralBitcoinPrivacy.md
+++ b/docs/FAQ/FAQ-GeneralBitcoinPrivacy.md
@@ -5,7 +5,7 @@
 
 ## The Privacy of Bitcoin
 
-### How is Bitcoin good in terms of privacy?
+:::details How is Bitcoin good in terms of privacy?
 
 Privacy in traditional banking is guaranteed by the institutions that make up the system, such as banks, credit card companies, and governments.
 They (try to) ensure that your bank balance stays a secret.
@@ -15,8 +15,9 @@ Instead, in Bitcoin pseudonyms protect your identity.
 In the Bitcoin ecosystem, everyone can see the history of every account balance, but they cannot see who controls an account.
 All addresses and transactions are recorded in Bitcoin’s publicly distributed database, the blockchain.
 The addresses do not have names or IP addresses attached to them, so it is not always possible to know which transaction belongs to which individual.
+:::
 
-### How is Bitcoin bad in terms of privacy?
+:::details How is Bitcoin bad in terms of privacy?
 
 Bitcoin is by default a transparent system, in which every piece of information is available to the public.
 As such, every Bitcoin user requires some level of protection.
@@ -46,8 +47,9 @@ Again it’s a 50% guess, but now you have one extra publicly visible Bitcoin ad
 Having publicly visible Bitcoin addresses could make it easier to find out your identity.
 
 ## The Privacy of Tor
+:::
 
-### How does Tor protect my network-level privacy? 
+:::details How does Tor protect my network-level privacy? 
 
 When you make a Bitcoin transaction, you are essentially creating a message on your phone or computer and sending it to the Bitcoin network.
 Someone operating a large number of nodes in the Bitcoin network might be able to match some of your transactions to your IP address, then deanonymize your stack of bitcoin.

--- a/docs/FAQ/FAQ-GeneralBitcoinPrivacy.md
+++ b/docs/FAQ/FAQ-GeneralBitcoinPrivacy.md
@@ -45,9 +45,9 @@ This is why making lots of transactions, increases your anonymity in the Bitcoin
 Similarly, if you receive 0.5 bitcoin but want to spend 1 bitcoin, you need to own additional Bitcoin addresses with a combined value of at least 0.5 bitcoin in them.
 Again it’s a 50% guess, but now you have one extra publicly visible Bitcoin address.
 Having publicly visible Bitcoin addresses could make it easier to find out your identity.
+:::
 
 ## The Privacy of Tor
-:::
 
 :::details How does Tor protect my network-level privacy? 
 
@@ -62,3 +62,4 @@ Route everything through Tor by default.
 
 It is also good practice to route your chats through the Tor network.
 You can also configure many cloud storage providers in this way.
+:::

--- a/docs/FAQ/FAQ-GeneralBitcoinPrivacy.md
+++ b/docs/FAQ/FAQ-GeneralBitcoinPrivacy.md
@@ -5,7 +5,8 @@
 
 ## The Privacy of Bitcoin
 
-:::details How is Bitcoin good in terms of privacy?
+:::details
+### How is Bitcoin good in terms of privacy?
 
 Privacy in traditional banking is guaranteed by the institutions that make up the system, such as banks, credit card companies, and governments.
 They (try to) ensure that your bank balance stays a secret.
@@ -17,12 +18,13 @@ All addresses and transactions are recorded in Bitcoin’s publicly distributed 
 The addresses do not have names or IP addresses attached to them, so it is not always possible to know which transaction belongs to which individual.
 :::
 
-:::details How is Bitcoin bad in terms of privacy?
+:::details
+### How is Bitcoin bad in terms of privacy?
 
 Bitcoin is by default a transparent system, in which every piece of information is available to the public.
 As such, every Bitcoin user requires some level of protection.
 Anyone with substantial wealth in Bitcoin would not want to advertise their funds to every person they transact with, for obvious reasons.
-But every time you spend just a tiny portion of your Bitcoin wallet, you reveal your wealth to the other party. 
+But every time you spend just a tiny portion of your Bitcoin wallet, you reveal your wealth to the other party.
 Doing that on the internet is like flashing large stacks of cash in a dark back alley, so obviously it’s not advisable!
 A criminal might see how much you have and decide to come after it.
 Distributing your wealth between several wallets and using a different address for each transaction is a common practice that prevents others from knowing how much Bitcoin you have.
@@ -49,7 +51,8 @@ Having publicly visible Bitcoin addresses could make it easier to find out your 
 
 ## The Privacy of Tor
 
-:::details How does Tor protect my network-level privacy? 
+:::details
+### How does Tor protect my network-level privacy?
 
 When you make a Bitcoin transaction, you are essentially creating a message on your phone or computer and sending it to the Bitcoin network.
 Someone operating a large number of nodes in the Bitcoin network might be able to match some of your transactions to your IP address, then deanonymize your stack of bitcoin.

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -27,6 +27,7 @@ When you have a software package that was signed by this key, then you can be su
 This protects you against malicious man in the middle attacks where bad guys give you a fake version of Wasabi with malicious code.
 
 @[youtubePlaylist](PLPj3KCksGbSZkVpgAZjAFfFp4D0SHLnFw)
+
 :::
 
 :::details How can I verify PGP signatures?
@@ -38,6 +39,7 @@ Everything is valid if it returns `Good signature from nopara73 aka Ficsór Ád�
 For an in depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.html#debian-and-ubuntu), [other Linux](/using-wasabi/InstallPackage.html#other-linux), [Windows](/using-wasabi/InstallPackage.html#windows), and [OSX](/using-wasabi/InstallPackage.html#osx) see the main documentation.
 
 @[youtube](mTrClVA_o5A)
+
 :::
 
 :::details How do I install Wasabi on Debian and Ubuntu?
@@ -50,6 +52,7 @@ Now install Wasabi with `sudo dpkg -i Wasabi-1.1.6.deb.asc`, and run it with `wa
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#debian-and-ubuntu).
 
 @[youtube](mTrClVA_o5A,122)
+
 :::
 
 :::details How do I install Wasabi on other Linux?
@@ -82,6 +85,7 @@ Now install Wasabi with double clicking the `.dmg` file.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#mac).
 
 @[youtube](_Zmc54XYzBA)
+
 :::
 
 :::details How do I check the current version of Wasabi?

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -1,22 +1,19 @@
 # Installation of Wasabi
 
-[[toc]]
-
----
-
 ## Installing the Package
 
-### Where can I download Wasabi?
+:::details Where can I download Wasabi?
 It's always best to download software directly from the official source acknowledged by the developers.
 You can find the recent version of the compiled packages for Linux, Windows and Mac available on the official [wasabiwallet.io](https://wasabiwallet.io).
 In order to preserve your network level privacy from the very first step on, please consider visiting the tor hidden service [wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 The old versions of the software can be found in the [releases](https://github.com/zksnacks/walletwasabi/releases) of the GitHub repository, [here](https://github.com/zksnacks/walletwasabi) you also find the libre & open source code for when you want to [build it yourself](https://docs.wasabiwallet.io/using-wasabi/BuildSource.html).
 Please take special care to verify the PGP signatures of Àdàm's PGP key [21D7 CA45 565D BCCE BE45 115D B4B7 2266 C47E 075E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) over the software packages and code commits.
-
-### Why is it important to verify PGP signatures?
-::: danger
-don't trust ~ verify
 :::
+
+:::details Why is it important to verify PGP signatures?
+:::: danger
+don't trust ~ verify
+::::
 
 These are not just empty words.
 Self sovereignty is at the core of Bitcoin in general, and Wasabi specifically.
@@ -30,8 +27,9 @@ When you have a software package that was signed by this key, then you can be su
 This protects you against malicious man in the middle attacks where bad guys give you a fake version of Wasabi with malicious code.
 
 @[youtubePlaylist](PLPj3KCksGbSZkVpgAZjAFfFp4D0SHLnFw)
+:::
 
-### How can I verify PGP signatures?
+:::details How can I verify PGP signatures?
 On the [WasabiWallet.io](https://wasabiwallet.io) website you can download the packages of the latest release.
 Make sure that in addition you also download the separate signature `.asc` file.
 In the terminal, change the directory to the one with the downloaded files, and verify the signature with `gpg --verify Wasabi-1.1.6.deb.asc`.
@@ -40,8 +38,9 @@ Everything is valid if it returns `Good signature from nopara73 aka Ficsór Ád�
 For an in depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.html#debian-and-ubuntu), [other Linux](/using-wasabi/InstallPackage.html#other-linux), [Windows](/using-wasabi/InstallPackage.html#windows), and [OSX](/using-wasabi/InstallPackage.html#osx) see the main documentation.
 
 @[youtube](mTrClVA_o5A)
+:::
 
-### How do I install Wasabi on Debian and Ubuntu?
+:::details How do I install Wasabi on Debian and Ubuntu?
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.deb` package and the `.deb.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadDeb.png)
@@ -51,8 +50,9 @@ Now install Wasabi with `sudo dpkg -i Wasabi-1.1.6.deb.asc`, and run it with `wa
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#debian-and-ubuntu).
 
 @[youtube](mTrClVA_o5A,122)
+:::
 
-### How do I install Wasabi on other Linux?
+:::details How do I install Wasabi on other Linux?
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.tar.gz` package and the `.tar.gz.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadTar.png)
@@ -60,8 +60,9 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 Verify the signature of the package with `gpg --verify Wasabi-X.X.X.tar.gz.asc` and ensure the software was signed by Àdàm's PGP key [21D7 CA45 565D BCCE BE45 115D B4B7 2266 C47E 075E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi with `sudo tar -pxzf Wasabi-X.X.X.tar.gz`, and run it with `./wassabee`.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#other-linux).
+:::
 
-### How do I install Wasabi on Windows?
+:::details How do I install Wasabi on Windows?
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.msi` package and the `.msi.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadWindows.png)
@@ -69,8 +70,9 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 Verify the signature of the package with with `right click on the signature file > More GpgEX options > Verify` and ensure the software was signed by Àdàm's PGP key [21D7 CA45 565D BCCE BE45 115D B4B7 2266 C47E 075E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi with double clicking the `.msi` file.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#windows).
+:::
 
-### How do I install Wasabi on OSX?
+:::details How do I install Wasabi on OSX?
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.dmg` package and the `.dmg.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadMac.png)
@@ -80,23 +82,27 @@ Now install Wasabi with double clicking the `.dmg` file.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#mac).
 
 @[youtube](_Zmc54XYzBA)
+:::
 
-### How do I check the current version of Wasabi?
+:::details How do I check the current version of Wasabi?
 In the GUI go to the top left menu `Help > About`, here you see the current version of your Wasabi.
 You can also verify in the command line by executing `wassabee --version`.
 Wasabi is cutting edge software, so it is well advised to stay up-to-date.
+:::
 
-### How do I know about a new version of Wasabi?
+:::details How do I know about a new version of Wasabi?
 When a new version has been released, you'll see a notification in the bottom left status bar `New Version Available`.
 The [website](https://wasabiwallet.io) always links to the most recent build of the software.
 It will also be announced on [Twitter](https://twitter.com/wasabiwallet), [Reddit](https://old.reddit.com/r/WasabiWallet/), and [Telegram](https://t.me/WasabiWallet).
+:::
 
-### How do I securely upgrade Wasabi?
+:::details How do I securely upgrade Wasabi?
 You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 Make sure you also download the signatures of the build and verify them for [Adam Ficsor's public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 For step by step instructions, follow [this guide](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/InstallInstructions.md) or [see this video](https://youtu.be/DUc9A76rwX4).
+:::
 
-### Do I need to install Tor separately?
+:::details Do I need to install Tor separately?
 All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself.
 If you do already have Tor, and it is running, then Wasabi will try to use that first.
 
@@ -104,16 +110,16 @@ You can turn off Tor in the Settings.
 Note that in this case you are still private, except when you CoinJoin and when you broadcast a transaction.
 In the first case, the coordinator would know the links between your inputs and outputs based on your IP address.
 In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
+:::
 
-
-### Can I install Wasabi on TAILS?
+:::details Can I install Wasabi on TAILS?
 
 Yes, just follow the [How do I install Wasabi on other Linux?](/FAQ-Installation.html#how-do-i-install-wasabi-on-other-linux) guide and remember to save/backup the wallet on the Persistence.
-
+:::
 
 ## Advanced Installation
 
-### How do I compile Wasabi from source?
+:::details How do I compile Wasabi from source?
 A new version of Wasabi is released when ready, roughly once every #twoweeks.
 Yet in the meantime there are many commits to the latest master branch, not just bug fixes, but also new features and stability improvements.
 If you cannot wait until the next release, and you want to experience the most cutting-edge version of Wasabi, then you can [build the source code](/using-wasabi/BuildSourc.md).
@@ -124,17 +130,19 @@ In order to build the Wallet software, change directory to `cd WalletWasabi/Wall
 Wasabi is written in C# with the .NET framework, and it is very easy to compile it from source, with only one command `dotnet build`, this will only take a minute or two.
 To start Wasabi simply execute `dotnet run` from the `WalletWasabi.Gui` folder.
 You can update the master branch with `git pull`.
+:::
 
-### How can I verify the deterministic build?
+:::details How can I verify the deterministic build?
 Wasabi has [reproducible and deterministic builds](/using-wasabi/DeterministicBuild.html), which means that you can verify that the compiled packages are from the [source code](https://github.com/zksnacks/walletwasabi).
 On Windows, you can verify this with `git diff --no-index win7-x64 "C:\Program Files\WasabiWallet".
 On Debian and Ubuntu do `git diff --no-index linux-x64/ /usr/local/bin/wasabiwallet/`.
 On other Linux do `git diff --no-index linux-x64/ WasabiLinux-1.1.6`.
 And on Mac first unzip with `7z x Wasabi-1.1.6.dmg -oWasabiOsx` and verify with `git diff --no-index osx-x64/ WasabiOsx/Wasabi\ Wallet.App/Contents/MacOS/`.
+:::
 
 ---
 
-#### Further Questions
+### Further Questions
+
 - How can I install Wasabi headless daemon without GUI?
 - How do I install the Wasabi backend server?
-

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -11,6 +11,7 @@ Please take special care to verify the PGP signatures of Àdàm's PGP key [21D7 
 :::
 
 :::details Why is it important to verify PGP signatures?
+
 :::: danger
 don't trust ~ verify
 ::::
@@ -27,7 +28,6 @@ When you have a software package that was signed by this key, then you can be su
 This protects you against malicious man in the middle attacks where bad guys give you a fake version of Wasabi with malicious code.
 
 @[youtubePlaylist](PLPj3KCksGbSZkVpgAZjAFfFp4D0SHLnFw)
-
 :::
 
 :::details How can I verify PGP signatures?

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -2,7 +2,9 @@
 
 ## Installing the Package
 
-:::details Where can I download Wasabi?
+:::details
+### Where can I download Wasabi?
+
 It's always best to download software directly from the official source acknowledged by the developers.
 You can find the recent version of the compiled packages for Linux, Windows and Mac available on the official [wasabiwallet.io](https://wasabiwallet.io).
 In order to preserve your network level privacy from the very first step on, please consider visiting the tor hidden service [wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
@@ -10,7 +12,9 @@ The old versions of the software can be found in the [releases](https://github.c
 Please take special care to verify the PGP signatures of Àdàm's PGP key [21D7 CA45 565D BCCE BE45 115D B4B7 2266 C47E 075E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) over the software packages and code commits.
 :::
 
-::::details Why is it important to verify PGP signatures?
+::::details
+### Why is it important to verify PGP signatures?
+
 :::danger
 **Don't trust ~ verify.**
 :::
@@ -28,7 +32,9 @@ This protects you against malicious man in the middle attacks where bad guys giv
 @[youtubePlaylist](PLPj3KCksGbSZkVpgAZjAFfFp4D0SHLnFw)
 ::::
 
-:::details How can I verify PGP signatures?
+:::details
+### How can I verify PGP signatures?
+
 On the [WasabiWallet.io](https://wasabiwallet.io) website you can download the packages of the latest release.
 Make sure that in addition you also download the separate signature `.asc` file.
 In the terminal, change the directory to the one with the downloaded files, and verify the signature with `gpg --verify Wasabi-1.1.6.deb.asc`.
@@ -39,7 +45,9 @@ For an in depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.html#
 @[youtube](mTrClVA_o5A)
 :::
 
-:::details How do I install Wasabi on Debian and Ubuntu?
+:::details
+### How do I install Wasabi on Debian and Ubuntu?
+
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.deb` package and the `.deb.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadDeb.png)
@@ -51,7 +59,9 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 @[youtube](mTrClVA_o5A,122)
 :::
 
-:::details How do I install Wasabi on other Linux?
+:::details
+### How do I install Wasabi on other Linux?
+
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.tar.gz` package and the `.tar.gz.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadTar.png)
@@ -61,7 +71,9 @@ Now install Wasabi with `sudo tar -pxzf Wasabi-X.X.X.tar.gz`, and run it with `.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#other-linux).
 :::
 
-:::details How do I install Wasabi on Windows?
+:::details
+### How do I install Wasabi on Windows?
+
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.msi` package and the `.msi.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadWindows.png)
@@ -71,7 +83,9 @@ Now install Wasabi with double clicking the `.msi` file.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#windows).
 :::
 
-:::details How do I install Wasabi on OSX?
+:::details
+### How do I install Wasabi on OSX?
+
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.dmg` package and the `.dmg.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadMac.png)
@@ -83,25 +97,33 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 @[youtube](_Zmc54XYzBA)
 :::
 
-:::details How do I check the current version of Wasabi?
+:::details
+### How do I check the current version of Wasabi?
+
 In the GUI go to the top left menu `Help > About`, here you see the current version of your Wasabi.
 You can also verify in the command line by executing `wassabee --version`.
 Wasabi is cutting edge software, so it is well advised to stay up-to-date.
 :::
 
-:::details How do I know about a new version of Wasabi?
+:::details
+### How do I know about a new version of Wasabi?
+
 When a new version has been released, you'll see a notification in the bottom left status bar `New Version Available`.
 The [website](https://wasabiwallet.io) always links to the most recent build of the software.
 It will also be announced on [Twitter](https://twitter.com/wasabiwallet), [Reddit](https://old.reddit.com/r/WasabiWallet/), and [Telegram](https://t.me/WasabiWallet).
 :::
 
-:::details How do I securely upgrade Wasabi?
+:::details
+### How do I securely upgrade Wasabi?
+
 You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 Make sure you also download the signatures of the build and verify them for [Adam Ficsor's public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 For step by step instructions, follow [this guide](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/InstallInstructions.md) or [see this video](https://youtu.be/DUc9A76rwX4).
 :::
 
-:::details Do I need to install Tor separately?
+:::details
+### Do I need to install Tor separately?
+
 All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself.
 If you do already have Tor, and it is running, then Wasabi will try to use that first.
 
@@ -111,13 +133,17 @@ In the first case, the coordinator would know the links between your inputs and 
 In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
 :::
 
-:::details Can I install Wasabi on TAILS?
+:::details
+### Can I install Wasabi on TAILS?
+
 Yes, just follow the [How do I install Wasabi on other Linux?](/FAQ-Installation.html#how-do-i-install-wasabi-on-other-linux) guide and remember to save/backup the wallet on the Persistence.
 :::
 
 ## Advanced Installation
 
-:::details How do I compile Wasabi from source?
+:::details
+### How do I compile Wasabi from source?
+
 A new version of Wasabi is released when ready, roughly once every #twoweeks.
 Yet in the meantime there are many commits to the latest master branch, not just bug fixes, but also new features and stability improvements.
 If you cannot wait until the next release, and you want to experience the most cutting-edge version of Wasabi, then you can [build the source code](/using-wasabi/BuildSourc.md).
@@ -130,7 +156,9 @@ To start Wasabi simply execute `dotnet run` from the `WalletWasabi.Gui` folder.
 You can update the master branch with `git pull`.
 :::
 
-:::details How can I verify the deterministic build?
+:::details
+### How can I verify the deterministic build?
+
 Wasabi has [reproducible and deterministic builds](/using-wasabi/DeterministicBuild.html), which means that you can verify that the compiled packages are from the [source code](https://github.com/zksnacks/walletwasabi).
 
 On Windows, you can verify this with `git diff --no-index win7-x64 "C:\Program Files\WasabiWallet".

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -10,12 +10,10 @@ The old versions of the software can be found in the [releases](https://github.c
 Please take special care to verify the PGP signatures of Àdàm's PGP key [21D7 CA45 565D BCCE BE45 115D B4B7 2266 C47E 075E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) over the software packages and code commits.
 :::
 
-:::details Why is it important to verify PGP signatures?
-
-:::: danger
-don't trust ~ verify
-::::
-
+::::details Why is it important to verify PGP signatures?
+:::danger
+**Don't trust ~ verify.**
+:::
 These are not just empty words.
 Self sovereignty is at the core of Bitcoin in general, and Wasabi specifically.
 You have powerful tools at your disposal, yet they only work when used as they are designed.
@@ -28,7 +26,7 @@ When you have a software package that was signed by this key, then you can be su
 This protects you against malicious man in the middle attacks where bad guys give you a fake version of Wasabi with malicious code.
 
 @[youtubePlaylist](PLPj3KCksGbSZkVpgAZjAFfFp4D0SHLnFw)
-:::
+::::
 
 :::details How can I verify PGP signatures?
 On the [WasabiWallet.io](https://wasabiwallet.io) website you can download the packages of the latest release.
@@ -39,7 +37,6 @@ Everything is valid if it returns `Good signature from nopara73 aka Ficsór Ád�
 For an in depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.html#debian-and-ubuntu), [other Linux](/using-wasabi/InstallPackage.html#other-linux), [Windows](/using-wasabi/InstallPackage.html#windows), and [OSX](/using-wasabi/InstallPackage.html#osx) see the main documentation.
 
 @[youtube](mTrClVA_o5A)
-
 :::
 
 :::details How do I install Wasabi on Debian and Ubuntu?
@@ -52,7 +49,6 @@ Now install Wasabi with `sudo dpkg -i Wasabi-1.1.6.deb.asc`, and run it with `wa
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#debian-and-ubuntu).
 
 @[youtube](mTrClVA_o5A,122)
-
 :::
 
 :::details How do I install Wasabi on other Linux?
@@ -85,7 +81,6 @@ Now install Wasabi with double clicking the `.dmg` file.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#mac).
 
 @[youtube](_Zmc54XYzBA)
-
 :::
 
 :::details How do I check the current version of Wasabi?
@@ -117,7 +112,6 @@ In the second case, if you happen to broadcast a transaction of yours to a full 
 :::
 
 :::details Can I install Wasabi on TAILS?
-
 Yes, just follow the [How do I install Wasabi on other Linux?](/FAQ-Installation.html#how-do-i-install-wasabi-on-other-linux) guide and remember to save/backup the wallet on the Persistence.
 :::
 
@@ -138,15 +132,27 @@ You can update the master branch with `git pull`.
 
 :::details How can I verify the deterministic build?
 Wasabi has [reproducible and deterministic builds](/using-wasabi/DeterministicBuild.html), which means that you can verify that the compiled packages are from the [source code](https://github.com/zksnacks/walletwasabi).
+
 On Windows, you can verify this with `git diff --no-index win7-x64 "C:\Program Files\WasabiWallet".
-On Debian and Ubuntu do `git diff --no-index linux-x64/ /usr/local/bin/wasabiwallet/`.
-On other Linux do `git diff --no-index linux-x64/ WasabiLinux-1.1.6`.
-And on Mac first unzip with `7z x Wasabi-1.1.6.dmg -oWasabiOsx` and verify with `git diff --no-index osx-x64/ WasabiOsx/Wasabi\ Wallet.App/Contents/MacOS/`.
+
+On Debian and Ubuntu do
+<br />
+`git diff --no-index linux-x64/ /usr/local/bin/wasabiwallet/`.
+
+On other Linux do
+<br />
+`git diff --no-index linux-x64/ WasabiLinux-1.1.6`.
+
+And on Mac first unzip with
+<br />
+`7z x Wasabi-1.1.6.dmg -oWasabiOsx`
+<br />
+and verify with
+<br />
+`git diff --no-index osx-x64/ WasabiOsx/Wasabi\ Wallet.App/Contents/MacOS/`.
 :::
 
----
-
-### Further Questions
+## Further Questions
 
 - How can I install Wasabi headless daemon without GUI?
 - How do I install the Wasabi backend server?

--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -2,7 +2,9 @@
 
 ## The Basics
 
-:::details Explain Wasabi like I'm 5
+:::details
+### Explain Wasabi like I'm 5
+
 Wasabi is a software wallet to manage your Bitcoin private keys.
 It is tailor made to protect your privacy on every step.
 You can easily send and receive bitcoin without the permission of anyone.
@@ -12,7 +14,9 @@ You can also use Wasabi to manage your hardware wallet, and it even connects to 
 Of course, Wasabi is libre and open source, which means you have full control over the software you manage your money with.
 :::
 
-::::details Who can use Wasabi?
+::::details
+### Who can use Wasabi?
+
 Every single line of code in Wasabi, the [wallet](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Gui), the [backend server](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Backend), the [tests](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Tests), the [packager](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Packager), the [library](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi), the [daemon](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Gui/CommandLine), the [api](https://wasabiwallet.io/swagger/), the [documentation](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs) - has always been and will always be libre and open source under the [MIT license](https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md).
 This means that anyone, yes, ANYONE can use Wasabi without permission, for any use case, free of charge.
 
@@ -25,7 +29,9 @@ Wasabi is a tool for everyone.
 :::
 ::::
 
-:::details What is a CoinJoin?
+:::details
+### What is a CoinJoin?
+
 A mechanism by which multiple participants combine their coins (or UTXOs, to be more precise) into one large transaction with multiple inputs and multiple outputs.
 An observer cannot determine which output belongs to which input, and neither can the participants themselves.
 This makes it difficult for outside parties to trace where a particular coin originated from and where it was sent to (as opposed to regular bitcoin transactions, where there is usually one sender and one receiver).
@@ -46,13 +52,16 @@ In very simple terms, CoinJoin means: “when you want to make a transaction, fi
 See also the [Bitcoin Wiki on CoinJoins](https://en.bitcoin.it/wiki/CoinJoin)
 :::
 
-:::details Do I need to trust Wasabi with my coins?
+:::details
+### Do I need to trust Wasabi with my coins?
+
 No, Wasabi's CoinJoin implementation is trustless by design.
 The participants do not need to trust each other or any third party. Both the sending address (the CoinJoin input) and the receiving address (the CoinJoin output) are controlled by your own private keys.
 Wasabi merely coordinates the process of combining the inputs of the participants into one single transaction, but the wallet can neither steal your coins, nor figure out which outputs belong to which inputs (look up “[Chaumian CoinJoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin)” if you want to know more).
 :::
 
-:::details What is the privacy I get after mixing with Wasabi?
+:::details
+### What is the privacy I get after mixing with Wasabi?
 This depends on how you handle your outputs after the CoinJoin.
 There are some ways how you can unintentionally undo the mixing by being careless.
 For example, if you make a 1.8 BTC transaction into Wasabi, do the CoinJoin, and then make one single outgoing transaction of 1.8 BTC, a third party observer can reasonably assume that both transactions belong to one single entity, due to both amounts being virtually the same even though they have been through a CoinJoin.
@@ -64,13 +73,17 @@ The practice of being careful with your post-mix outputs is commonly facilitated
 Find out more about coin control it [here](https://medium.com/@nopara73/coin-control-is-must-learn-if-you-care-about-your-privacy-in-bitcoin-33b9a5f224a2).
 :::
 
-:::details Can I hurt my privacy using Wasabi?
+:::details
+### Can I hurt my privacy using Wasabi?
+
 No.
 The worst thing that can happen (through user’s negligence post-mix) is that the level of your privacy stays the same as before CoinJoin.
 It is crucial to understand that Wasabi is not a fool-proof solution if you neglect to practice coin control after the mixing process.
 :::
 
-:::details Why is Wasabi Bitcoin-only?
+:::details
+### Why is Wasabi Bitcoin-only?
+
 There are countless reasons why it is the only logical choice to be [bitcoin-only](https://bitcoin-only.com).
 With Bitcoin we have a once in a lifetime opportunity to manifest libre sound money.
 If we suceed, then this might emerge an utmost beautiful agora of sovereign individuals.
@@ -81,7 +94,9 @@ Any line of code written to support a random shitcoin takes away scarce develope
 
 ## For advanced Wasabikas
 
-:::details Can the coordinator attack me?
+:::details
+### Can the coordinator attack me?
+
 The nature of Wasabi is that you should not need to trust the developers or the Wasabi coordinating server, as you can verify that the code does not leak information to anyone.
 The developers have gone to great lengths in an attempt to ensure that the coordinator cannot steal funds nor harvest information (for example, the outputs sent from your Wasabi Wallet are blinded, meaning that even the Wasabi server cannot link the outputs to the inputs).
 

--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -12,7 +12,7 @@ You can also use Wasabi to manage your hardware wallet, and it even connects to 
 Of course, Wasabi is libre and open source, which means you have full control over the software you manage your money with.
 :::
 
-:::details Who can use Wasabi?
+::::details Who can use Wasabi?
 Every single line of code in Wasabi, the [wallet](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Gui), the [backend server](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Backend), the [tests](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Tests), the [packager](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Packager), the [library](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi), the [daemon](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Gui/CommandLine), the [api](https://wasabiwallet.io/swagger/), the [documentation](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs) - has always been and will always be libre and open source under the [MIT license](https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md).
 This means that anyone, yes, ANYONE can use Wasabi without permission, for any use case, free of charge.
 
@@ -20,10 +20,10 @@ Wasabi is used by individuals to receive and spend every day payments, to manage
 There are also entrepreneurs who use Wasabi to defend their customers from spies and to ensure a private business relationship.
 Young kids have Wasabi to stack the sats gifted by grandma, and they learn the importance of hodling.
 
-::::tip
+:::tip
 Wasabi is a tool for everyone.
-::::
 :::
+::::
 
 :::details What is a CoinJoin?
 A mechanism by which multiple participants combine their coins (or UTXOs, to be more precise) into one large transaction with multiple inputs and multiple outputs.
@@ -102,9 +102,7 @@ That said, if multiple chain-analysis companies attempt to flood the zkSNACKs mi
 See [here](https://github.com/nopara73/ZeroLink/#e-sybil-attack) for more info.
 :::
 
----
-
-### Further Questions
+## Further Questions
 
 - What is the history of Wasabi?
 - How does Zero Link differ from other CoinJoin implementations?

--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -1,12 +1,8 @@
 # Introduction to Wasabi
 
-[[toc]]
-
----
-
 ## The Basics
 
-### Explain Wasabi like I'm 5
+:::details Explain Wasabi like I'm 5
 Wasabi is a software wallet to manage your Bitcoin private keys.
 It is tailor made to protect your privacy on every step.
 You can easily send and receive bitcoin without the permission of anyone.
@@ -14,20 +10,22 @@ With a special tool called a CoinJoin you can make sure nobody finds out how you
 Although Wasabi has some very advanced magic under the hood, it is rather easy to use.
 You can also use Wasabi to manage your hardware wallet, and it even connects to your own full node.
 Of course, Wasabi is libre and open source, which means you have full control over the software you manage your money with.
+:::
 
-### Who can use Wasabi?
-Every single line of code in Wasabi, the [wallet](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Gui), the [backend server](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Backend), the [tests](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Tests), the [packager](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Packager), the [library](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi), the [daemon](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Gui/CommandLine), the [api](https://wasabiwallet.io/swagger/), the [documentation](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs) - has always been and will always be libre and open source under the [MIT license](https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md). 
+:::details Who can use Wasabi?
+Every single line of code in Wasabi, the [wallet](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Gui), the [backend server](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Backend), the [tests](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Tests), the [packager](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Packager), the [library](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi), the [daemon](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Gui/CommandLine), the [api](https://wasabiwallet.io/swagger/), the [documentation](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs) - has always been and will always be libre and open source under the [MIT license](https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md).
 This means that anyone, yes, ANYONE can use Wasabi without permission, for any use case, free of charge.
 
 Wasabi is used by individuals to receive and spend every day payments, to manage their hardware wallet long term hodlings, and to CoinJoin their sats for added privacy.
 There are also entrepreneurs who use Wasabi to defend their customers from spies and to ensure a private business relationship.
 Young kids have Wasabi to stack the sats gifted by grandma, and they learn the importance of hodling.
 
-:::tip
+::::tip
 Wasabi is a tool for everyone.
+::::
 :::
 
-### What is a CoinJoin?
+:::details What is a CoinJoin?
 A mechanism by which multiple participants combine their coins (or UTXOs, to be more precise) into one large transaction with multiple inputs and multiple outputs.
 An observer cannot determine which output belongs to which input, and neither can the participants themselves.
 This makes it difficult for outside parties to trace where a particular coin originated from and where it was sent to (as opposed to regular bitcoin transactions, where there is usually one sender and one receiver).
@@ -39,20 +37,22 @@ The funds will always be in a Bitcoin address that you control.
 It’s possible to do this in a decentralized way so that the service does not rely on external parties or centralized servers.
 It just needs the participants of the transaction.
 
-CoinJoin can be applied multiple times, and as many transactions are grouped together, participants may save on transaction fees. 
+CoinJoin can be applied multiple times, and as many transactions are grouped together, participants may save on transaction fees.
 CoinJoin is the preferred method of gaining privacy in the Bitcoin network.
 It is even possible that this functionality might one day be included directly on the protocol level as standard, as some altcoins already do.
 
 In very simple terms, CoinJoin means: “when you want to make a transaction, find someone else who also wants to make a transaction and make a joint transaction together”.
 
 See also the [Bitcoin Wiki on CoinJoins](https://en.bitcoin.it/wiki/CoinJoin)
+:::
 
-### Do I need to trust Wasabi with my coins?
+:::details Do I need to trust Wasabi with my coins?
 No, Wasabi's CoinJoin implementation is trustless by design.
 The participants do not need to trust each other or any third party. Both the sending address (the CoinJoin input) and the receiving address (the CoinJoin output) are controlled by your own private keys.
 Wasabi merely coordinates the process of combining the inputs of the participants into one single transaction, but the wallet can neither steal your coins, nor figure out which outputs belong to which inputs (look up “[Chaumian CoinJoin](https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin)” if you want to know more).
+:::
 
-### What is the privacy I get after mixing with Wasabi?
+:::details What is the privacy I get after mixing with Wasabi?
 This depends on how you handle your outputs after the CoinJoin.
 There are some ways how you can unintentionally undo the mixing by being careless.
 For example, if you make a 1.8 BTC transaction into Wasabi, do the CoinJoin, and then make one single outgoing transaction of 1.8 BTC, a third party observer can reasonably assume that both transactions belong to one single entity, due to both amounts being virtually the same even though they have been through a CoinJoin.
@@ -62,29 +62,32 @@ Another deanonymizing scenario happens when you combine mixed outputs with unmix
 
 The practice of being careful with your post-mix outputs is commonly facilitated through coin control, which is the default way of interacting with the wallet.
 Find out more about coin control it [here](https://medium.com/@nopara73/coin-control-is-must-learn-if-you-care-about-your-privacy-in-bitcoin-33b9a5f224a2).
+:::
 
-### Can I hurt my privacy using Wasabi?
+:::details Can I hurt my privacy using Wasabi?
 No.
 The worst thing that can happen (through user’s negligence post-mix) is that the level of your privacy stays the same as before CoinJoin.
 It is crucial to understand that Wasabi is not a fool-proof solution if you neglect to practice coin control after the mixing process.
+:::
 
-### Why is Wasabi Bitcoin-only?
+:::details Why is Wasabi Bitcoin-only?
 There are countless reasons why it is the only logical choice to be [bitcoin-only](https://bitcoin-only.com).
 With Bitcoin we have a once in a lifetime opportunity to manifest libre sound money.
 If we suceed, then this might emerge an utmost beautiful agora of sovereign individuals.
 If we fail, then this will conjure up the most horrific Orwellian nightmare.
 There is no room for wasted time and energy, this Great Work requires our full attention.
 Any line of code written to support a random shitcoin takes away scarce developer time to work on real problems.
+:::
 
 ## For advanced Wasabikas
 
-### Can the coordinator attack me?
+:::details Can the coordinator attack me?
 The nature of Wasabi is that you should not need to trust the developers or the Wasabi coordinating server, as you can verify that the code does not leak information to anyone.
-The developers have gone to great lengths in an attempt to ensure that the coordinator cannot steal funds nor harvest information (for example, the outputs sent from your Wasabi Wallet are blinded, meaning that even the Wasabi server cannot link the outputs to the inputs). 
+The developers have gone to great lengths in an attempt to ensure that the coordinator cannot steal funds nor harvest information (for example, the outputs sent from your Wasabi Wallet are blinded, meaning that even the Wasabi server cannot link the outputs to the inputs).
 
 The only known possible 'malicious' actions that the server *could* perform are two sides of the same coin;
 - **Blacklisted UTXO's**:
-Though this would not affect the users who are able to successfully mix with other 'honest/real' peers. 
+Though this would not affect the users who are able to successfully mix with other 'honest/real' peers.
 - **Targeted Sybil Attack**:
 The follow-up concern is the inverse of the above.
 It is possible that the server could *only* include one 'honest/real' coin in the mix and supply the other coins themselves.
@@ -97,10 +100,11 @@ Taking the 'worst case' (100 people, each mixing 0.1 BTC) gives 0.03 BTC per rou
 This is not prohibitive and is thus a valid concern.
 That said, if multiple chain-analysis companies attempt to flood the zkSNACKs mix (to decrease the true anonymity set) they will hinder each other's efforts (unless they are cooperating).
 See [here](https://github.com/nopara73/ZeroLink/#e-sybil-attack) for more info.
+:::
 
 ---
 
-#### Further Questions
+### Further Questions
 
 - What is the history of Wasabi?
 - How does Zero Link differ from other CoinJoin implementations?

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -352,7 +352,7 @@ There are no hard and fast rules for what to do with the change.
 Generally try to avoid the change and use the `Max` button extensively to send whole coins.
 The most problematic type of change is what has `anonymity set 1` [red shield] You should treat it as a kind of toxic waste [handled with great care].
 
-**Warning**
+#### Warning
 
 You want to avoid merging `anonymity set 1 coins` with `anonymity set > 1 coins` wherever possible, because this will link your `anonymity set > 1 coin` to the coin you merge it with.
 Note that, this is also true if you merge them in a mix, however that is slightly less problematic, because some blockchain analysis techniques become [computationally infeasible](https://www.comsys.rwth-aachen.de/fileadmin/papers/2017/2017-maurer-trustcom-coinjoin.pdf).
@@ -378,7 +378,7 @@ Thus the coordinator knows that this is a consolidation transaction.
 It is wise to assume that every one knows what the coordinator knows.
 So consolidating in a CoinJoin is better, but it might still reveal the common ownership of the coins.
 
-**Your Options**
+#### Your Options
 
 - If you do not care about linking the history of the coins because they are all from the same source then you could combine them in a mix (queue all the change from the same source until you reach the minimum input required to mix, currently ~ 0.1 BTC).
 - Mix with [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver).
@@ -388,7 +388,7 @@ So consolidating in a CoinJoin is better, but it might still reveal the common o
 - The ultimate solution is to 'close the loop' i.e. spend a change coin without merging it with other coins, do not generate it in the first place by sending whole coins.
 :::
 
-### Further Questions
+## Further Questions
 
 Wallet Manager
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -4,7 +4,9 @@
 
 @[youtube](XykixYdbFpA)
 
-:::details How do I generate a new wallet?
+:::details
+### How do I generate a new wallet?
+
 You can generate as many new wallets as you'd like, for now extra cost and without asking for permission.
 Go to the `Wallet Manager` tab and the `Generate Wallet` menu.
 As with everything in Wasabi, it is required to label this new wallet, make sure that you are precise so that you know later what this is for.
@@ -60,7 +62,9 @@ Please see [this great guide](https://github.com/6102bitcoin/FAQ/blob/master/see
 
 @[youtube](9i7CceIdFg4)
 
-:::details Why is it bad to re-use addresses?
+:::details
+### Why is it bad to re-use addresses?
+
 Bitcoin is designed so that for every payment you can use a new address that is not tied to any of your previous addresses.
 When you use a new address for every coin, then it becomes much much more difficult to find out that these coins are from you.
 However, when you use the same address for every coin, then everyone knows that they all can be spend by one individual who has knowledge of the private key - you!
@@ -77,7 +81,9 @@ Everytime you a coin is received, then the address is removed from the GUI so th
 Remember: ***NEVER RE-USE ADDRESSES***
 :::
 
-:::details Why does Wasabi only use SegWit bech32 addresses?
+:::details
+### Why does Wasabi only use SegWit bech32 addresses?
+
 Wasabi generates Bech32 addresses only, also known as bc1 addresses or native SegWit addresses.
 These addresses start with the characters `bc1...` Some wallets/exchanges do not yet support this type of address and may give an error message (e.g. "unknown bitcoin address").
 The solution is to manage your funds with a wallet which does support Bech32, [see list](https://en.bitcoin.it/wiki/Bech32_adoption).
@@ -91,7 +97,9 @@ Be careful, if you send all your coins from an old wallet to a new wallet (from 
 
 @[youtube](AdmlM-Qvco0)
 
-:::details Why does Wasabi choose a new random node every time I send a transaction?
+:::details
+### Why does Wasabi choose a new random node every time I send a transaction?
+
 When you broadcast a transaction from a full node, that transaction is flooded into the network.
 Essentially, all nearby nodes are passed your transaction, and those nodes will pass to all of their nearby nodes, etc.
 However, if a malicious adversary were to get enough relay nodes in the network, they could pretty easily connect the initial location of a transaction by simply observing from which node the transaction appeared first.
@@ -108,7 +116,9 @@ This reduces the risk of a passive bystander being able to link two transactions
 
 @[youtube](ypfZT9GlqTw)
 
-:::details What are the fees for the CoinJoin?
+:::details
+### What are the fees for the CoinJoin?
+
 You currently pay a fee of 0.003% * anonymity set.
 If the anonymity set of a coin is 50 then you pay 0.003% * 50 (=0.15%).
 If you set the target anonymity set to 53 then Wasabi will continue mixing until this is reached, so you may end up with an anonymity set of say 60, and you will pay 0.003% * 60 (=0.18%).
@@ -123,7 +133,9 @@ This happens when network fees go down between the start of the round and its en
 In this case, the difference is split between the active outputs of the mix.
 :::
 
-:::details What is the anonymity set?
+:::details
+### What is the anonymity set?
+
 The anonymity set is effectively the size of the group you are hiding in.
 
 If 3 people take part in a CoinJoin (with equal size inputs) and there are 3 outputs then each of those output coins has an anonymity set of 3.
@@ -144,7 +156,9 @@ Your Wasabi software has limited information on what the anonymity set should be
 With Wasabi we are trying to do lower estimations, rather than higher ones.
 :::
 
-:::details Can I mix more than the round's minimum?
+:::details
+### Can I mix more than the round's minimum?
+
 Yes.
 
 In a round with a ~0.1 BTC minimum, you could mix ~0.3 BTC and get a ~0.1 BTC output & a ~ 0.2 BTC output.
@@ -157,12 +171,16 @@ The possible values of equal output that can be created are 0.1 x 2^n where n is
 @[youtube](3Ezru07J674)
 :::
 
-:::details Why are the denominations such an odd number?
+:::details
+### Why are the denominations such an odd number?
+
 The output value changes each round to ensure that you can enqueue a coin and have it remix (mix over and over again - increasing the anonymity set, improving privacy).
 As a result the round mixing amount will often be a specific number which generally decreases as the rounds proceed, with a reset once a lower bound is reached.
 :::
 
-:::details What is happening in the input registration phase?
+:::details
+### What is happening in the input registration phase?
+
 During the [input registration](https://github.com/nopara73/zerolink#1-input-registration-phase), you select which coins you want to register for CoinJoin.
 These coins need to be confirmed on the Bitcoin timechain, unless they are from a Wasabi CoinJoin and you re-register them.
 In the background, Wasabi generates an input proof so that the coordinator can verify that you actually own this coin.
@@ -189,7 +207,9 @@ The input registration phase ends when either, the number of registered inputs e
 [missing: explanation of uniqueld]
 :::
 
-:::details What is happening in the connection confirmation phase?
+:::details
+### What is happening in the connection confirmation phase?
+
 There are many Alice's registering their inputs in the first phase, and the connection confirmation phase makes sure that all of them are still online.
 The coordinator verifies the uniqueld from all the Alice's, and when everyone is still communicating, then he returns the round hash of all the registered inputs.
 The round is abandoned and re-started if too many Alice's have dropped, for example when Wasabi is shut down, or when the tor connection is temporarily broken.
@@ -201,7 +221,9 @@ The connection confirmation phase ends when all Alice's have provided their inpu
 [missing: explanation of uniqueld]
 :::
 
-:::details What is happening in the output registration phase?
+:::details
+### What is happening in the output registration phase?
+
 Now that all peers are online, we are ready to proceed with the [output registration phase](https://github.com/nopara73/zerolink#2-output-registration-phase) of the round.
 Wasabi generates a completely new tor identity Bob, he is in no way tied to Alice.
 Bob sends to the Wasabi coordinator: [i] the clear-text address for the anonset CoinJoin output; [ii] the coordinator signature over that output; and [iii] the round Hash of all the inputs.
@@ -216,7 +238,9 @@ The output registration phase ends when the value of clear-text outputs plus cha
 If after a timeout not all outputs are registered, then this round is abandoned, the missing peers are banned, and a new round is started.
 :::
 
-:::details What is happening in the signing phase?
+:::details
+### What is happening in the signing phase?
+
 Now that all inputs and outputs are registered, the Wasabi coordinator can start the [signing phase](https://github.com/nopara73/zerolink#3-signing-phase) by building the CoinJoin transaction with all the registered inputs, the anonset outputs, and the change outputs.
 He sends this transaction to all the Alice's of this round.
 Each Alice verifies that: [i] the committed round Hash is equal to the hash of all the inputs in the proposed transaction; and [ii] her inputs and outputs are correctly included.
@@ -226,7 +250,9 @@ Alice sends the uniqueld, the signature and the input index to the coordinator, 
 The signing phase ends when the coordinator has all the valid signatures for all the registered inputs.
 :::
 
-:::details What is happening in the broadcasting phase?
+:::details
+### What is happening in the broadcasting phase?
+
 The CoinJoin transaction is successfully built and signed, and it is now ready to be [broadcasted](https://github.com/nopara73/zerolink#transaction-broadcasting) to the peers of the Bitcoin network.
 The coordinator sends this transaction over the tor network to a random full node, and from there it is gossiped to other nodes and miners.
 Wasabi is saving on mining fees by setting a confirmation target of roughly 12 hours, but you can re-register unconfirmed anonset outputs for the next round of CoinJoin.
@@ -240,51 +266,69 @@ Wasabi is saving on mining fees by setting a confirmation target of roughly 12 h
 
 @[youtube](sM2uhyROpAQ)
 
-:::details How can I generate a Wasabi skeleton wallet file in ColdCard?
+:::details
+### How can I generate a Wasabi skeleton wallet file in ColdCard?
+
 On the ColdCard (Mk2, firmware 2.1.1 and up) you go to ```>Advanced>MicrcoSD Card>Wasabi Wallet``` and it will save a skeleton json-file to the MicroSD card in the hardware wallet.
 :::
 
-:::details How can I import the Wasabi skeleton wallet file?
+:::details
+### How can I import the Wasabi skeleton wallet file?
+
 Take the MicroSD card from the ColdCard and plug it in the computer with the Wasabi Wallet software.
 In Wasabi Wallet go to the Wallet Manager, select Hardware Wallet option and in the bottom right corner click ```Import Coldcard```.
 Now select the Wasabi skeleton json-file from the MicroSD card, if this fails you can manually enter the file location in Wasabi Wallet window and load the file.
 :::
 
-:::details How can I generate a receiving address of my hardware wallet?
+:::details
+### How can I generate a receiving address of my hardware wallet?
+
 In Wasabi Wallet you load your previously imported wallet (from Wasabi skeleton, or USB detection) and go to the ```Receive``` tab, here you enter a label for the incoming transaction and click ```Generate Receive Address```.
 In the tab below the newly generated receive address can be viewd/copied.
 :::
 
-:::details How can I sign a transaction with a USB connected hardware wallet?
+:::details
+### How can I sign a transaction with a USB connected hardware wallet?
+
 To send a transaction you will need to connect your Hardware wallet and unlock the device (using PIN or password), in Wasabi Wallet you go to the ```Send``` tab where you can specify the address to send to, amount of bitcoin to send and which coins to use as input (only use green/private coins here!).
 After filling in all transaction details you click ```Send Transaction``` to sign it with the connected hardware wallet and broadcast on the network.
 :::
 
-:::details How can I build and export a transaction to ColdCard?
+:::details
+### How can I build and export a transaction to ColdCard?
+
 In the Wallet Explorer on the right side of the GUI, select ```YourWallet>Advanced>Build Transaction```.
 This brings up the ```Build Transaction``` tab where you can specify the address, amount of bitcoin and coins to use.
 Then by clicking ```Build Transaction``` a new tab will open containing the raw transaction data, here you click ```Export Binary PSBT``` to save the partially signed bitcoin transaction (PSBT) to a file.
 This file should be moved to the MicroSD card that you can then insert in the ColdCard for manual verification and signing.
 :::
 
-:::details How can I sign a transaction on the ColdCard?
+:::details
+### How can I sign a transaction on the ColdCard?
+
 On the ColdCard (Mk2, firmware 2.1.1 and up) you enter the PIN code to unlock the hardware wallet and press ```>Ready To Sign``` with the MicroSD card containing the previously generated transaction or PSBT-file.
 Verify the address and amount and the ColdCard will then create a signed.psbt and final.txn file on the MicroSD card.
 The finalized transaction (xxx-final.txn) can now be broadcasted by Wasabi Wallet or even a radio or satelite dish if someone is listening!
 :::
 
-:::details How can I import and broadcast a final transaction from ColdCard?
+:::details
+### How can I import and broadcast a final transaction from ColdCard?
+
 In the Wallet Explorer you go to ```YourWallet>Advanced>Broadcast Transaction``` and click ```Import Transaction```, now you can select the previously finalized (and signed) transaction file from the MicroSD card.
 If this fails you can manually type the path to this file in Wasabi Wallet to load the transaction.
 Now click ```Broadcast Transaction``` to send it off over Tor to a random Bitcoin node so it can flood over to the miners for confirmation in a block.
 :::
 
-:::details Can I CoinJoin the bitcoin on my hardware wallet?
+:::details
+### Can I CoinJoin the bitcoin on my hardware wallet?
+
 You can't do that directly, so send them (in small portions >0.1BTC if needed) to a ''hot'' Wasabi Wallet for CoinJoin and then send them back to a new address on the Hardware wallet for cold-storage.
 
 ## Settings
 
-:::details How do I connect my own full node to Wasabi?
+:::details
+### How do I connect my own full node to Wasabi?
+
 There is currently a basic implementation of connecting your full node to Wasabi.
 The server will still send you [BIP 158 block filters](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki), and when you realize that a block contains a transaction of yours, then you pull this block from your own full node, instead of a random P2P node, thus you can verify that this is actually a valid block including your transaction.
 One attack vector could be that Wasabi lies to you and gives you wrong filters that exclude your transaction, thus you would see in the wallet less coins than you actually control. [BIP 157 solves this](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki).
@@ -295,14 +339,18 @@ If your node is on a remote device [raspberry pi, nodl, server], then you can sp
 @[youtube](gWo2RAkIVrE)
 :::
 
-:::details How can I turn off Tor?
+:::details
+### How can I turn off Tor?
+
 You can turn off Tor in the Settings.
 Note that in this case you are still private, except when you CoinJoin and when you broadcast a transaction.
 In the first case, the coordinator would know the links between your inputs and outputs based on your IP address.
 In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
 :::
 
-:::details How can I change the anonset target?
+:::details
+### How can I change the anonset target?
+
 In the Settings tab at the bottom you can change the three `PrivacyLevelX` values of the desired anon set of the yellow, green, and checkmark shield button in the GUI.
 The `MixUntilAnonymitySet` is the last selected value from previous use.
 
@@ -326,7 +374,9 @@ Remember that you pay a fee proportional to the Anonymity Set.
 
 @[youtube](k4VzJ6dUT9I)
 
-:::details Can I consolidate anonset coins?
+:::details
+### Can I consolidate anonset coins?
+
 It is advisable to limit the recombining of mixed coins because it can only decrease the privacy of said coins.
 This links all the consolidated UTXOs in one transaction, creating only one output, which then clearly controls all these funds.
 That said, if you combine less than 1 BTC it is less likely to reveal your pre-CoinJoin transaction history.
@@ -338,7 +388,9 @@ If you would like to dive into the details of this topic, you can [read more her
 @[youtube](Tk8-N1kHa4g)
 :::
 
-:::details How can I send my anonset coins to my hardware wallet?
+:::details
+### How can I send my anonset coins to my hardware wallet?
+
 Most hardware wallets communicate with servers to provide you with your balance.
 This reveals your public key to the server, which damages your privacy - the hardware company can now theoretically link together all your addresses.
 As a result **it is not recommended** that you send your mixed coins to an address associated with your hardware wallet unless you are confident that you have set up your hardware wallet in a way that it does not communicate with a 3rd party server (see below).
@@ -347,7 +399,9 @@ You can, however, manage your hardware wallet with the Wasabi interface.
 Alternatively, you can use your hardware wallet with Electrum, which connects to your Bitcoin Core full node through [Electrum Personal Server](https://github.com/chris-belcher/electrum-personal-server).
 :::
 
-:::details What can I do with small change?
+:::details
+### What can I do with small change?
+
 There are no hard and fast rules for what to do with the change.
 Generally try to avoid the change and use the `Max` button extensively to send whole coins.
 The most problematic type of change is what has `anonymity set 1` [red shield] You should treat it as a kind of toxic waste [handled with great care].

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -323,6 +323,7 @@ Now click ```Broadcast Transaction``` to send it off over Tor to a random Bitcoi
 ### Can I CoinJoin the bitcoin on my hardware wallet?
 
 You can't do that directly, so send them (in small portions >0.1BTC if needed) to a ''hot'' Wasabi Wallet for CoinJoin and then send them back to a new address on the Hardware wallet for cold-storage.
+:::
 
 ## Settings
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1,14 +1,10 @@
 # Use of Wasabi
 
-[[toc]]
-
----
-
 ## Wallet Manager
 
 @[youtube](XykixYdbFpA)
 
-### How do I generate a new wallet?
+:::details How do I generate a new wallet?
 You can generate as many new wallets as you'd like, for now extra cost and without asking for permission.
 Go to the `Wallet Manager` tab and the `Generate Wallet` menu.
 As with everything in Wasabi, it is required to label this new wallet, make sure that you are precise so that you know later what this is for.
@@ -28,8 +24,11 @@ In order to protect your paper backup, consider to store the password and recove
 You have successfully setup your wallet when you click `I wrote down my Recovery Words!`
 
 ![](/WalletManagerRecoveryWords.png)
+:::
 
+::::details
 ### How do I back up my mnemonic words?
+
 :::tip
 Always back up your encrypted private keys!
 :::
@@ -51,7 +50,7 @@ Use two different backups and locations for the mnemonic and password, because w
 Find a secure physical location to store the backups, maybe home safe, or an expert security deposit box.
 
 Please see [this great guide](https://github.com/6102bitcoin/FAQ/blob/master/seed.md#3-Storing-your-Seed) on how to properly store your seed.
-
+::::
 
 ## Synchronization
 
@@ -60,7 +59,6 @@ Please see [this great guide](https://github.com/6102bitcoin/FAQ/blob/master/see
 ## Receive
 
 @[youtube](9i7CceIdFg4)
-:::
 
 :::details Why is it bad to re-use addresses?
 Bitcoin is designed so that for every payment you can use a new address that is not tied to any of your previous addresses.
@@ -71,7 +69,7 @@ Take good care to whom you tell your addresses, and every time, tell someone a d
 
 Because you have all the private keys, for all these addresses, you can produce a valid signature for any of them.
 So you can proof that these are your bitcoin, without relying on reputation that you have any other coins.
-You can easily generate and store many billions of private keys and addresses in a convenient [BIP 44 multi-account hierarchy for deterministic wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) so that you can backup everything in your 12 word mnemonic phrase. 
+You can easily generate and store many billions of private keys and addresses in a convenient [BIP 44 multi-account hierarchy for deterministic wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) so that you can backup everything in your 12 word mnemonic phrase.
 
 This is what is used in Wasabi, you have on mnemonic backup, and unlimited numbers of new addresses.
 Everytime you a coin is received, then the address is removed from the GUI so that you are not tempted to use it again.
@@ -92,10 +90,8 @@ Be careful, if you send all your coins from an old wallet to a new wallet (from 
 @[youtube](PRlAAxunmdU)
 
 @[youtube](AdmlM-Qvco0)
-:::
 
 :::details Why does Wasabi choose a new random node every time I send a transaction?
-
 When you broadcast a transaction from a full node, that transaction is flooded into the network.
 Essentially, all nearby nodes are passed your transaction, and those nodes will pass to all of their nearby nodes, etc.
 However, if a malicious adversary were to get enough relay nodes in the network, they could pretty easily connect the initial location of a transaction by simply observing from which node the transaction appeared first.
@@ -107,7 +103,6 @@ This reduces the risk of a passive bystander being able to link two transactions
 :::
 
 ## History
-
 
 ## CoinJoin
 
@@ -129,13 +124,13 @@ In this case, the difference is split between the active outputs of the mix.
 :::
 
 :::details What is the anonymity set?
-The anonymity set is effectively the size of the group you are hiding in. 
+The anonymity set is effectively the size of the group you are hiding in.
 
 If 3 people take part in a CoinJoin (with equal size inputs) and there are 3 outputs then each of those output coins has an anonymity set of 3.
 
 ```
 0.1 BTC (Alice)       0.1 BTC (Anon set 3)
-0.3 BTC (Bob) 	  ->  0.1 BTC (Anon set 3)
+0.3 BTC (Bob)     ->  0.1 BTC (Anon set 3)
 0.4 BTC (Charlie)     0.1 BTC (Anon set 3)
                       0.2 BTC (Change Coin Bob)
                       0.3 BTC (Change Coin Charlie)
@@ -150,7 +145,6 @@ With Wasabi we are trying to do lower estimations, rather than higher ones.
 :::
 
 :::details Can I mix more than the round's minimum?
-
 Yes.
 
 In a round with a ~0.1 BTC minimum, you could mix ~0.3 BTC and get a ~0.1 BTC output & a ~ 0.2 BTC output.
@@ -164,9 +158,8 @@ The possible values of equal output that can be created are 0.1 x 2^n where n is
 :::
 
 :::details Why are the denominations such an odd number?
-
 The output value changes each round to ensure that you can enqueue a coin and have it remix (mix over and over again - increasing the anonymity set, improving privacy).
-As a result the round mixing amount will often be a specific number which generally decreases as the rounds proceed, with a reset once a lower bound is reached. 
+As a result the round mixing amount will often be a specific number which generally decreases as the rounds proceed, with a reset once a lower bound is reached.
 :::
 
 :::details What is happening in the input registration phase?
@@ -228,7 +221,7 @@ Now that all inputs and outputs are registered, the Wasabi coordinator can start
 He sends this transaction to all the Alice's of this round.
 Each Alice verifies that: [i] the committed round Hash is equal to the hash of all the inputs in the proposed transaction; and [ii] her inputs and outputs are correctly included.
 Then she signs the transaction with the private keys of her inputs.
-Alice sends the uniqueld, the signature and the input index to the coordinator, who then verifies this information. 
+Alice sends the uniqueld, the signature and the input index to the coordinator, who then verifies this information.
 
 The signing phase ends when the coordinator has all the valid signatures for all the registered inputs.
 :::
@@ -283,12 +276,11 @@ The finalized transaction (xxx-final.txn) can now be broadcasted by Wasabi Walle
 :::details How can I import and broadcast a final transaction from ColdCard?
 In the Wallet Explorer you go to ```YourWallet>Advanced>Broadcast Transaction``` and click ```Import Transaction```, now you can select the previously finalized (and signed) transaction file from the MicroSD card.
 If this fails you can manually type the path to this file in Wasabi Wallet to load the transaction.
-Now click ```Broadcast Transaction``` to send it off over Tor to a random Bitcoin node so it can flood over to the miners for confirmation in a block. 
+Now click ```Broadcast Transaction``` to send it off over Tor to a random Bitcoin node so it can flood over to the miners for confirmation in a block.
 :::
 
 :::details Can I CoinJoin the bitcoin on my hardware wallet?
 You can't do that directly, so send them (in small portions >0.1BTC if needed) to a ''hot'' Wasabi Wallet for CoinJoin and then send them back to a new address on the Hardware wallet for cold-storage.
-:::
 
 ## Settings
 
@@ -298,7 +290,7 @@ The server will still send you [BIP 158 block filters](https://github.com/bitcoi
 One attack vector could be that Wasabi lies to you and gives you wrong filters that exclude your transaction, thus you would see in the wallet less coins than you actually control. [BIP 157 solves this](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki).
 
 When your full node is on the same hardware [computer, laptop] as your Wasabi Wallet, then it will automatically recognize it and pull blocks from there.
-If your node is on a remote device [raspberry pi, nodl, server], then you can specify your local IP in the Settings tab, or in line 11 of the config file. 
+If your node is on a remote device [raspberry pi, nodl, server], then you can specify your local IP in the Settings tab, or in line 11 of the config file.
 
 @[youtube](gWo2RAkIVrE)
 :::
@@ -312,7 +304,7 @@ In the second case, if you happen to broadcast a transaction of yours to a full 
 
 :::details How can I change the anonset target?
 In the Settings tab at the bottom you can change the three `PrivacyLevelX` values of the desired anon set of the yellow, green, and checkmark shield button in the GUI.
-The `MixUntilAnonymitySet` is the last selected value from previous use. 
+The `MixUntilAnonymitySet` is the last selected value from previous use.
 
 Alternatively, open the config file from the wallet GUI, go to `File`>`Open`>`Config File` and in the last 4 lines you see:
 
@@ -349,7 +341,7 @@ If you would like to dive into the details of this topic, you can [read more her
 :::details How can I send my anonset coins to my hardware wallet?
 Most hardware wallets communicate with servers to provide you with your balance.
 This reveals your public key to the server, which damages your privacy - the hardware company can now theoretically link together all your addresses.
-As a result **it is not recommended** that you send your mixed coins to an address associated with your hardware wallet unless you are confident that you have set up your hardware wallet in a way that it does not communicate with a 3rd party server (see below). 
+As a result **it is not recommended** that you send your mixed coins to an address associated with your hardware wallet unless you are confident that you have set up your hardware wallet in a way that it does not communicate with a 3rd party server (see below).
 
 You can, however, manage your hardware wallet with the Wasabi interface.
 Alternatively, you can use your hardware wallet with Electrum, which connects to your Bitcoin Core full node through [Electrum Personal Server](https://github.com/chris-belcher/electrum-personal-server).
@@ -387,32 +379,33 @@ It is wise to assume that every one knows what the coordinator knows.
 So consolidating in a CoinJoin is better, but it might still reveal the common ownership of the coins.
 
 **Your Options**
+
 - If you do not care about linking the history of the coins because they are all from the same source then you could combine them in a mix (queue all the change from the same source until you reach the minimum input required to mix, currently ~ 0.1 BTC).
 - Mix with [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver).
 - Donate them (e.g. [to the EFF](https://www.eff.org/))
 - Spend them on something that is not a particular privacy risk (eg. gift cards).
-- Open a lightning channel. 
-- The ultimate solution is to 'close the loop' i.e. spend a change coin without merging it with other coins, do not generate it in the first place by sending whole coins. 
+- Open a lightning channel.
+- The ultimate solution is to 'close the loop' i.e. spend a change coin without merging it with other coins, do not generate it in the first place by sending whole coins.
 :::
 
----
-
-#### Further Questions
-
+### Further Questions
 
 Wallet Manager
+
 - What password should I use?
 - Can I spend my bitcoin without the password?
 - How do I backup my wallet?
 - What's up with the Chinese characters?
 
 Synchronization
+
 - What are BIP-158 block filters?
 - How does Wasabi download a relevant block?
 - How long does the initial, and a subsequent synchronization take?
 - How do I know if the synchronization is finished?
 
 Receive
+
 - How do I generate a new receiving address?
 - Why do I have to label my address?
 - How can I change the label of my address?
@@ -421,6 +414,7 @@ Receive
 - Are there privacy concerns regarding whom I send my address?
 
 Send
+
 - What are coins?
 - Why is coin control so important?
 - How do I select coins for spending?
@@ -432,10 +426,12 @@ Send
 - How is the tansaction broadcasted?
 
 History
+
 - How can I check the history of transactions?
 - Can I export a list of transaction?
 
 CoinJoin
+
 - How can I select UTXOs for CoinJoin?
 - What are the denominations created in one round?
 - How much anonymity set do I need?
@@ -444,6 +440,7 @@ CoinJoin
 - Why are the denominations such an odd number?
 
 Hardware Wallet
+
 - Why does Wasabi use the Hardware Wallet Interface?
 - What specific hardware wallets does Wasabi support?
 - How can I type in the PIN of my Trezor One?
@@ -451,5 +448,6 @@ Hardware Wallet
 - Can I use the passphrase of my Trezor One?
 
 Coin Control Best Practices
+
 - Which coins can I select for CoinJoins?
 - How can I mix large amounts?

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -60,8 +60,9 @@ Please see [this great guide](https://github.com/6102bitcoin/FAQ/blob/master/see
 ## Receive
 
 @[youtube](9i7CceIdFg4)
+:::
 
-### Why is it bad to re-use addresses?
+:::details Why is it bad to re-use addresses?
 Bitcoin is designed so that for every payment you can use a new address that is not tied to any of your previous addresses.
 When you use a new address for every coin, then it becomes much much more difficult to find out that these coins are from you.
 However, when you use the same address for every coin, then everyone knows that they all can be spend by one individual who has knowledge of the private key - you!
@@ -76,22 +77,24 @@ This is what is used in Wasabi, you have on mnemonic backup, and unlimited numbe
 Everytime you a coin is received, then the address is removed from the GUI so that you are not tempted to use it again.
 
 Remember: ***NEVER RE-USE ADDRESSES***
+:::
 
-### Why does Wasabi only use SegWit bech32 addresses?
+:::details Why does Wasabi only use SegWit bech32 addresses?
 Wasabi generates Bech32 addresses only, also known as bc1 addresses or native SegWit addresses.
 These addresses start with the characters `bc1...` Some wallets/exchanges do not yet support this type of address and may give an error message (e.g. "unknown bitcoin address").
 The solution is to manage your funds with a wallet which does support Bech32, [see list](https://en.bitcoin.it/wiki/Bech32_adoption).
 
 Be careful, if you send all your coins from an old wallet to a new wallet (from the table above) in one transaction then you will merge all your coins which is bad for privacy - instead, **send the coins individually** or if possible **import the seed in the new wallet**.
-
+:::
 
 ## Send
 
 @[youtube](PRlAAxunmdU)
 
 @[youtube](AdmlM-Qvco0)
+:::
 
-### Why does Wasabi choose a new random node every time I send a transaction?
+:::details Why does Wasabi choose a new random node every time I send a transaction?
 
 When you broadcast a transaction from a full node, that transaction is flooded into the network.
 Essentially, all nearby nodes are passed your transaction, and those nodes will pass to all of their nearby nodes, etc.
@@ -101,7 +104,7 @@ For this reason, broadcasting transaction through your own node may reveal your 
 So to fix this Wasabi broadcasts your transactions to a random node, and messages that node through TOR, so the node cannot detect your IP address.
 When you want to subsequently send another transaction on the network, Wasabi destroys the original TOR bridge and connection to the node and established a new TOR bridge and connection with a brand new node.
 This reduces the risk of a passive bystander being able to link two transactions together that appear from the same location.
-
+:::
 
 ## History
 
@@ -110,7 +113,7 @@ This reduces the risk of a passive bystander being able to link two transactions
 
 @[youtube](ypfZT9GlqTw)
 
-### What are the fees for the CoinJoin?
+:::details What are the fees for the CoinJoin?
 You currently pay a fee of 0.003% * anonymity set.
 If the anonymity set of a coin is 50 then you pay 0.003% * 50 (=0.15%).
 If you set the target anonymity set to 53 then Wasabi will continue mixing until this is reached, so you may end up with an anonymity set of say 60, and you will pay 0.003% * 60 (=0.18%).
@@ -123,8 +126,9 @@ Currently the minimum change amount to be paid out is 0.7% of the base denominat
 It is also possible that you get more back from mixing than you put in.
 This happens when network fees go down between the start of the round and its end.
 In this case, the difference is split between the active outputs of the mix.
+:::
 
-### What is the anonymity set?
+:::details What is the anonymity set?
 The anonymity set is effectively the size of the group you are hiding in. 
 
 If 3 people take part in a CoinJoin (with equal size inputs) and there are 3 outputs then each of those output coins has an anonymity set of 3.
@@ -143,8 +147,9 @@ All an observer knows is that a specific anon set output coin is owned by one of
 
 Your Wasabi software has limited information on what the anonymity set should be, so the anonymity set that the software presents you is just an estimation, not an accurate value.
 With Wasabi we are trying to do lower estimations, rather than higher ones.
+:::
 
-### Can I mix more than the round's minimum?
+:::details Can I mix more than the round's minimum?
 
 Yes.
 
@@ -156,14 +161,15 @@ The possible values of equal output that can be created are 0.1 x 2^n where n is
 @[youtube](PKtxzSLPWFU)
 
 @[youtube](3Ezru07J674)
+:::
 
-### Why are the denominations such an odd number?
+:::details Why are the denominations such an odd number?
 
 The output value changes each round to ensure that you can enqueue a coin and have it remix (mix over and over again - increasing the anonymity set, improving privacy).
 As a result the round mixing amount will often be a specific number which generally decreases as the rounds proceed, with a reset once a lower bound is reached. 
+:::
 
-
-### What is happening in the input registration phase?
+:::details What is happening in the input registration phase?
 During the [input registration](https://github.com/nopara73/zerolink#1-input-registration-phase), you select which coins you want to register for CoinJoin.
 These coins need to be confirmed on the Bitcoin timechain, unless they are from a Wasabi CoinJoin and you re-register them.
 In the background, Wasabi generates an input proof so that the coordinator can verify that you actually own this coin.
@@ -188,8 +194,9 @@ The input registration phase ends when either, the number of registered inputs e
 @[youtube](v1fIjFR6e5Q)
 
 [missing: explanation of uniqueld]
+:::
 
-### What is happening in the connection confirmation phase?
+:::details What is happening in the connection confirmation phase?
 There are many Alice's registering their inputs in the first phase, and the connection confirmation phase makes sure that all of them are still online.
 The coordinator verifies the uniqueld from all the Alice's, and when everyone is still communicating, then he returns the round hash of all the registered inputs.
 The round is abandoned and re-started if too many Alice's have dropped, for example when Wasabi is shut down, or when the tor connection is temporarily broken.
@@ -199,8 +206,9 @@ The connection confirmation phase ends when all Alice's have provided their inpu
 @[youtube](hhkL0QvIaGY)
 
 [missing: explanation of uniqueld]
+:::
 
-### What is happening in the output registration phase?
+:::details What is happening in the output registration phase?
 Now that all peers are online, we are ready to proceed with the [output registration phase](https://github.com/nopara73/zerolink#2-output-registration-phase) of the round.
 Wasabi generates a completely new tor identity Bob, he is in no way tied to Alice.
 Bob sends to the Wasabi coordinator: [i] the clear-text address for the anonset CoinJoin output; [ii] the coordinator signature over that output; and [iii] the round Hash of all the inputs.
@@ -213,8 +221,9 @@ Because Alice commits to the output by sending it blinded, and because Bob is a 
 
 The output registration phase ends when the value of clear-text outputs plus change outputs is equal to the the value of inputs.
 If after a timeout not all outputs are registered, then this round is abandoned, the missing peers are banned, and a new round is started.
+:::
 
-### What is happening in the signing phase?
+:::details What is happening in the signing phase?
 Now that all inputs and outputs are registered, the Wasabi coordinator can start the [signing phase](https://github.com/nopara73/zerolink#3-signing-phase) by building the CoinJoin transaction with all the registered inputs, the anonset outputs, and the change outputs.
 He sends this transaction to all the Alice's of this round.
 Each Alice verifies that: [i] the committed round Hash is equal to the hash of all the inputs in the proposed transaction; and [ii] her inputs and outputs are correctly included.
@@ -222,11 +231,13 @@ Then she signs the transaction with the private keys of her inputs.
 Alice sends the uniqueld, the signature and the input index to the coordinator, who then verifies this information. 
 
 The signing phase ends when the coordinator has all the valid signatures for all the registered inputs.
+:::
 
-### What is happening in the broadcasting phase?
+:::details What is happening in the broadcasting phase?
 The CoinJoin transaction is successfully built and signed, and it is now ready to be [broadcasted](https://github.com/nopara73/zerolink#transaction-broadcasting) to the peers of the Bitcoin network.
 The coordinator sends this transaction over the tor network to a random full node, and from there it is gossiped to other nodes and miners.
 Wasabi is saving on mining fees by setting a confirmation target of roughly 12 hours, but you can re-register unconfirmed anonset outputs for the next round of CoinJoin.
+:::
 
 ## Hardware Wallet
 
@@ -236,43 +247,52 @@ Wasabi is saving on mining fees by setting a confirmation target of roughly 12 h
 
 @[youtube](sM2uhyROpAQ)
 
-### How can I generate a Wasabi skeleton wallet file in ColdCard?
+:::details How can I generate a Wasabi skeleton wallet file in ColdCard?
 On the ColdCard (Mk2, firmware 2.1.1 and up) you go to ```>Advanced>MicrcoSD Card>Wasabi Wallet``` and it will save a skeleton json-file to the MicroSD card in the hardware wallet.
+:::
 
-### How can I import the Wasabi skeleton wallet file?
+:::details How can I import the Wasabi skeleton wallet file?
 Take the MicroSD card from the ColdCard and plug it in the computer with the Wasabi Wallet software.
 In Wasabi Wallet go to the Wallet Manager, select Hardware Wallet option and in the bottom right corner click ```Import Coldcard```.
 Now select the Wasabi skeleton json-file from the MicroSD card, if this fails you can manually enter the file location in Wasabi Wallet window and load the file.
+:::
 
-### How can I generate a receiving address of my hardware wallet?
+:::details How can I generate a receiving address of my hardware wallet?
 In Wasabi Wallet you load your previously imported wallet (from Wasabi skeleton, or USB detection) and go to the ```Receive``` tab, here you enter a label for the incoming transaction and click ```Generate Receive Address```.
 In the tab below the newly generated receive address can be viewd/copied.
+:::
 
-### How can I sign a transaction with a USB connected hardware wallet?
+:::details How can I sign a transaction with a USB connected hardware wallet?
 To send a transaction you will need to connect your Hardware wallet and unlock the device (using PIN or password), in Wasabi Wallet you go to the ```Send``` tab where you can specify the address to send to, amount of bitcoin to send and which coins to use as input (only use green/private coins here!).
 After filling in all transaction details you click ```Send Transaction``` to sign it with the connected hardware wallet and broadcast on the network.
+:::
 
-### How can I build and export a transaction to ColdCard?
+:::details How can I build and export a transaction to ColdCard?
 In the Wallet Explorer on the right side of the GUI, select ```YourWallet>Advanced>Build Transaction```.
 This brings up the ```Build Transaction``` tab where you can specify the address, amount of bitcoin and coins to use.
 Then by clicking ```Build Transaction``` a new tab will open containing the raw transaction data, here you click ```Export Binary PSBT``` to save the partially signed bitcoin transaction (PSBT) to a file.
 This file should be moved to the MicroSD card that you can then insert in the ColdCard for manual verification and signing.
+:::
 
-### How can I sign a transaction on the ColdCard?
+:::details How can I sign a transaction on the ColdCard?
 On the ColdCard (Mk2, firmware 2.1.1 and up) you enter the PIN code to unlock the hardware wallet and press ```>Ready To Sign``` with the MicroSD card containing the previously generated transaction or PSBT-file.
 Verify the address and amount and the ColdCard will then create a signed.psbt and final.txn file on the MicroSD card.
 The finalized transaction (xxx-final.txn) can now be broadcasted by Wasabi Wallet or even a radio or satelite dish if someone is listening!
+:::
 
-### How can I import and broadcast a final transaction from ColdCard?
+:::details How can I import and broadcast a final transaction from ColdCard?
 In the Wallet Explorer you go to ```YourWallet>Advanced>Broadcast Transaction``` and click ```Import Transaction```, now you can select the previously finalized (and signed) transaction file from the MicroSD card.
 If this fails you can manually type the path to this file in Wasabi Wallet to load the transaction.
 Now click ```Broadcast Transaction``` to send it off over Tor to a random Bitcoin node so it can flood over to the miners for confirmation in a block. 
+:::
 
-### Can I CoinJoin the bitcoin on my hardware wallet?
+:::details Can I CoinJoin the bitcoin on my hardware wallet?
 You can't do that directly, so send them (in small portions >0.1BTC if needed) to a ''hot'' Wasabi Wallet for CoinJoin and then send them back to a new address on the Hardware wallet for cold-storage.
+:::
 
 ## Settings
-### How do I connect my own full node to Wasabi?
+
+:::details How do I connect my own full node to Wasabi?
 There is currently a basic implementation of connecting your full node to Wasabi.
 The server will still send you [BIP 158 block filters](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki), and when you realize that a block contains a transaction of yours, then you pull this block from your own full node, instead of a random P2P node, thus you can verify that this is actually a valid block including your transaction.
 One attack vector could be that Wasabi lies to you and gives you wrong filters that exclude your transaction, thus you would see in the wallet less coins than you actually control. [BIP 157 solves this](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki).
@@ -281,14 +301,16 @@ When your full node is on the same hardware [computer, laptop] as your Wasabi Wa
 If your node is on a remote device [raspberry pi, nodl, server], then you can specify your local IP in the Settings tab, or in line 11 of the config file. 
 
 @[youtube](gWo2RAkIVrE)
+:::
 
-### How can I turn off Tor?
+:::details How can I turn off Tor?
 You can turn off Tor in the Settings.
 Note that in this case you are still private, except when you CoinJoin and when you broadcast a transaction.
 In the first case, the coordinator would know the links between your inputs and outputs based on your IP address.
 In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
+:::
 
-### How can I change the anonset target?
+:::details How can I change the anonset target?
 In the Settings tab at the bottom you can change the three `PrivacyLevelX` values of the desired anon set of the yellow, green, and checkmark shield button in the GUI.
 The `MixUntilAnonymitySet` is the last selected value from previous use. 
 
@@ -304,7 +326,7 @@ Alternatively, open the config file from the wallet GUI, go to `File`>`Open`>`Co
 Remember that you pay a fee proportional to the Anonymity Set.
 
 @[youtube](gWo2RAkIVrE)
-
+:::
 
 ## Coin Control Best Practices
 
@@ -312,7 +334,7 @@ Remember that you pay a fee proportional to the Anonymity Set.
 
 @[youtube](k4VzJ6dUT9I)
 
-### Can I consolidate anonset coins?
+:::details Can I consolidate anonset coins?
 It is advisable to limit the recombining of mixed coins because it can only decrease the privacy of said coins.
 This links all the consolidated UTXOs in one transaction, creating only one output, which then clearly controls all these funds.
 That said, if you combine less than 1 BTC it is less likely to reveal your pre-CoinJoin transaction history.
@@ -322,16 +344,18 @@ As a result it is best not to recombine ALL your mixed change, though you may wi
 If you would like to dive into the details of this topic, you can [read more here](https://old.reddit.com/r/WasabiWallet/comments/avxbjy/combining_mixed_coins_privacy_megathread/) and see more here:
 
 @[youtube](Tk8-N1kHa4g)
+:::
 
-### How can I send my anonset coins to my hardware wallet?
+:::details How can I send my anonset coins to my hardware wallet?
 Most hardware wallets communicate with servers to provide you with your balance.
 This reveals your public key to the server, which damages your privacy - the hardware company can now theoretically link together all your addresses.
 As a result **it is not recommended** that you send your mixed coins to an address associated with your hardware wallet unless you are confident that you have set up your hardware wallet in a way that it does not communicate with a 3rd party server (see below). 
 
 You can, however, manage your hardware wallet with the Wasabi interface.
 Alternatively, you can use your hardware wallet with Electrum, which connects to your Bitcoin Core full node through [Electrum Personal Server](https://github.com/chris-belcher/electrum-personal-server).
+:::
 
-### What can I do with small change?
+:::details What can I do with small change?
 There are no hard and fast rules for what to do with the change.
 Generally try to avoid the change and use the `Max` button extensively to send whole coins.
 The most problematic type of change is what has `anonymity set 1` [red shield] You should treat it as a kind of toxic waste [handled with great care].
@@ -369,6 +393,7 @@ So consolidating in a CoinJoin is better, but it might still reveal the common o
 - Spend them on something that is not a particular privacy risk (eg. gift cards).
 - Open a lightning channel. 
 - The ultimate solution is to 'close the loop' i.e. spend a change coin without merging it with other coins, do not generate it in the first place by sending whole coins. 
+:::
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "[Wasabi](https://wasabiwallet.io) is an open-source, non-custodial, privacy focused Bitcoin wallet for desktop. It implements trustless coin shuffling: [Schnorrian CoinJoin](https://github.com/nopara73/ZeroLink/).",
   "scripts": {
+    "prestart": "rm -rf docs/.vuepress/dist",
     "start": "vuepress dev docs",
     "build": "vuepress build docs",
     "deploy": "./deploy.sh"


### PR DESCRIPTION
As requested in #72 this introduces the custom block `::: details` which can be used to initially hide long-form content and first present a summary. In this case the FAQ leverage it to better structure the questions and answers and provide a better overview than the previously used table of contents.

Thoughts: Even though I really like the output, my concern about this is that we need to use a custom block for that and the authoring of the markdown does not seem intuitive. IMHO the headlines plus plaragraphs feel more natural. Feedback welcome!

If merged, this would close #72.

Signed-off-by: Dennis Reimann <mail@dennisreimann.de>