### PR TITLE
[STRUCTUR] Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -3,11 +3,11 @@ name: Bug Report
 about: Report a bug
 ---
 
-> Please know that you are opening an issue in the [Wasabi documentation](https://docs.wasabiwallet.io) repository. If you have a bug regarding the software specifically, please [open an issue in the main Wasabi repository](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
+> Please know that you are opening an issue in the [Wasabi documentation](https://github.com/zkSNACKs/WasabiDoc) repository. If you have a bug regarding the software specifically, please [open an issue in the main Wasabi repository](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
 
 ### General Description
 
-A clear and concise description of what the bug is.
+A clear and concise description of what the documentation specific bug is. This includes for example broken links, missing files or typos.
 
 ### How To Reproduce?
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -3,11 +3,13 @@ name: Bug Report
 about: Report a bug
 ---
 
-> Please know that you are opening an issue in the [Wasabi documentation](https://github.com/zkSNACKs/WasabiDoc) repository. If you have a bug regarding the software specifically, please [open an issue in the main Wasabi repository](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
+> Please know that you are opening an issue in the [Wasabi documentation](https://github.com/zkSNACKs/WasabiDoc) repository.
+If you have a bug regarding the software specifically, please [open an issue in the main Wasabi repository](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
 
 ### General Description
 
-A clear and concise description of what the documentation specific bug is. This includes for example broken links, missing files or typos.
+A clear and concise description of what the documentation specific bug is.
+This includes for example broken links, missing files or typos.
 
 ### How To Reproduce?
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,19 @@
+---
+name: Bug Report
+about: Report a bug
+---
+
+### General Description
+
+A clear and concise description of what the bug is.
+
+### How To Reproduce?
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Screenshots
+
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -3,6 +3,8 @@ name: Bug Report
 about: Report a bug
 ---
 
+> Please know that you are opening an issue in the [Wasabi documentation](https://docs.wasabiwallet.io) repository. If you have a bug regarding the software specifically, please [open an issue in the main Wasabi repository](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
+
 ### General Description
 
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -3,11 +3,13 @@ name: New Question
 about: A new question yet to be answered in the documentation.
 ---
 
-> Please know that you are opening an issue in the [Wasabi documentation](https://github.com/zkSNACKs/WasabiDoc) repository. If you have an issue regarding the software specifically, please [open an issue in the main Wasabi repository](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
+> Please know that you are opening an issue in the [Wasabi documentation](https://github.com/zkSNACKs/WasabiDoc) repository.
+If you have an issue regarding the software specifically, please [open an issue in the main Wasabi repository](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
 
 ### What is the general context of your question?
 
-Please explain which general pillar your question is about. There are many different topics covered in the Wasabi documentation, so it's good to start with a general description of your question.
+Please explain which general pillar your question is about.
+There are many different topics covered in the Wasabi documentation, so it's good to start with a general description of your question.
 - About general Bitcoin privacy and [why Wasabi](https://docs.wasabiwallet.io/why-wasabi/) is important.
 - About the nuances of how to properly [use Wasabi](https://docs.wasabiwallet.io/using-wasabi/) and privacy best practices.
 - About how to [contribute to Wasabi](https://docs.wasabiwallet.io/building-wasabi/) and to help the project grow.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -3,11 +3,11 @@ name: New Question
 about: A new question yet to be answered in the documentation.
 ---
 
-> Please know that you are opening an issue in the [Wasabi documentation](https://docs.wasabiwallet.io) repository. If you have an issue regarding the software specifically, please [open an issue in the main Wasabi repository](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
+> Please know that you are opening an issue in the [Wasabi documentation](https://github.com/zkSNACKs/WasabiDoc) repository. If you have an issue regarding the software specifically, please [open an issue in the main Wasabi repository](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
 
-### In what context is your question?
+### What is the general context of your question?
 
-Please explain which general pillar your question is about.
+Please explain which general pillar your question is about. There are many different topics covered in the Wasabi documentation, so it's good to start with a general description of your question.
 - About general Bitcoin privacy and [why Wasabi](https://docs.wasabiwallet.io/why-wasabi/) is important.
 - About the nuances of how to properly [use Wasabi](https://docs.wasabiwallet.io/using-wasabi/) and privacy best practices.
 - About how to [contribute to Wasabi](https://docs.wasabiwallet.io/building-wasabi/) and to help the project grow.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -3,6 +3,8 @@ name: New Question
 about: A new question yet to be answered in the documentation.
 ---
 
+> Please know that you are opening an issue in the [Wasabi documentation](https://docs.wasabiwallet.io) repository. If you have an issue regarding the software specifically, please [open an issue in the main Wasabi repository](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
+
 ### In what context is your question?
 
 Please explain which general pillar your question is about.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,15 @@
+---
+name: New Question
+about: A new question yet to be answered in the documentation.
+---
+
+### In what context is your question?
+
+Please explain which general pillar your question is about.
+- About general Bitcoin privacy and [why Wasabi](https://docs.wasabiwallet.io/why-wasabi/) is important.
+- About the nuances of how to properly [use Wasabi](https://docs.wasabiwallet.io/using-wasabi/) and privacy best practices.
+- About how to [contribute to Wasabi](https://docs.wasabiwallet.io/building-wasabi/) and to help the project grow.
+
+### What is your question?
+
+Please ask your question here, be precise and focused on exactly what you want to learn more about.


### PR DESCRIPTION
This PR adds [issue templates](https://help.github.com/en/articles/manually-creating-a-single-issue-template-for-your-repository) to help contributors understand how and where to open the issue. The same is implemented in the [main repo](https://github.com/zkSNACKs/WalletWasabi/tree/master/.github/ISSUE_TEMPLATE).

This is a first PR WIP,  so feedback welcome.

Closes #130.