### PR TITLE
[STRUCTURE] using sidebar submenu

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -96,21 +96,34 @@ module.exports = {
       ],
       "/using-wasabi/": [
         {
-          title: "Using Wasabi",
+          title: "Installing Wasabi",
           collapsable: false,
           sidebarDepth: 2,
           children: [
             "/using-wasabi/InstallPackage.md",
             "/using-wasabi/BuildSource.md",
             "/using-wasabi/DeterministicBuild.md",
+          ]
+        },
+	{
+          title: "Using Wasabi",
+          collapsable: false,
+          sidebarDepth: 2,
+          children: [
             "/using-wasabi/WalletGeneration.md",
-            "/using-wasabi/AddressReuse.md",
-            "/using-wasabi/NetworkLevelPrivacy.md",
-            "/using-wasabi/BIP.md",
-            "/using-wasabi/LostPassword.md",
             "/using-wasabi/PasswordFinder.md",
             "/using-wasabi/Daemon.md",
-            "/using-wasabi/PayToEndPoint.md"
+            "/using-wasabi/BIP.md",
+          ]
+        },
+	{
+          title: "Privacy Best Practices",
+          collapsable: false,
+          sidebarDepth: 2,
+          children: [
+            "/using-wasabi/AddressReuse.md",
+            "/using-wasabi/LostPassword.md",
+            "/using-wasabi/NetworkLevelPrivacy.md",
           ]
         }
       ],


### PR DESCRIPTION
This PR adds a submenu structure to the `using-wasabi` pillar.

`installing wasabi` with the different install options.
`using wasabi` with step by step guide for each aspect of the wallet.
`privacy best practices` with general advice for all types in regards to privacy, and wasabi specifically.

I think this differentiation makes sense, but open for suggestions and feedback!