### PR TITLE
Add OSX video guide

### DIFF
--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -154,9 +154,9 @@ Among others, here is where your wallet files and your logs reside.
 
 ## OSX
 
-Check out this video guide:
-
 @[youtube](_Zmc54XYzBA)
+
+@[youtube](UZ9z5COXaG0)
 
 If you have already imported Ádám Ficsor's public key, then jump to step 4.
 


### PR DESCRIPTION
- Removed the "check out..." part, because it made no grammatical sense in this case and it'd be consistent with how we did in the Windows part.
- Added OSX guide by oceans4all (https://twitter.com/oceans4all/status/1160894308205023233)