### PR TITLE
Properly display diagrams in ColdWasabi

### DIFF
--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -10,7 +10,7 @@
 This is how you can safely eat cold Wasabi, or store your coins on a hardware wallet after one or more rounds of CoinJoin using Wasabi Wallet.
 Both a 'Hot'(CoinJoin) and a 'Cold'(Storage) Wasabi Wallet instances will be running side-by-side, label them accordingly so you don't mix them up.
 
-![](https://docs.wasabiwallet.io/ColdWasabiGeneral.png)
+![](/ColdWasabiGeneral.png)
 
 ## Detailed walkthrough
 
@@ -47,4 +47,4 @@ You are now eating Cold Wasabi!
 When you want to safely spend some of those Cold-Wasabi funds from the hardware wallet, you could use the Partially Signed Bitcoin Transaction for offline/airgapped signing of transactions for an extra layer of defense.
 
 ## Workflow diagram
-![](https://docs.wasabiwallet.io/ColdWasabiPSBTWorkflow.png)
+![](/ColdWasabiPSBTWorkflow.png)

--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -1,7 +1,7 @@
 ---
 {
   "title": "Cold-Wasabi protocol",
-  "description": "A step by step guide on how to CoinJoin and send bitcoin to a hardware wallet for cold storage using WasabiWallet only."
+  "description": "A step by step guide on how to CoinJoin and send bitcoin to a hardware wallet for cold storage using WasabiWallet only. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
 }
 ---
 

--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -3,7 +3,7 @@
 This is how you can safely eat cold Wasabi, or store your coins on a hardware wallet after one or more rounds of CoinJoin using Wasabi Wallet.
 Both a 'Hot'(CoinJoin) and a 'Cold'(Storage) Wasabi Wallet instances will be running side-by-side, label them accordingly so you don't mix them up.
 
-![](/docs/.vuepress/public/ColdWasabiGeneral.png)
+![](https://docs.wasabiwallet.io/ColdWasabiGeneral.png)
 
 ## Detailed walkthrough
 
@@ -40,4 +40,4 @@ You are now eating Cold Wasabi!
 When you want to safely spend some of those Cold-Wasabi funds from the hardware wallet, you could use the Partially Signed Bitcoin Transaction for offline/airgapped signing of transactions for an extra layer of defense.
 
 ## Workflow diagram
-![](/docs/.vuepress/public/ColdWasabiPSBTWorkflow.png)
+![](https://docs.wasabiwallet.io/ColdWasabiPSBTWorkflow.png)

--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -1,3 +1,10 @@
+---
+{
+  "title": "Cold-Wasabi protocol",
+  "description": "A step by step guide on how to CoinJoin and send bitcoin to a hardware wallet for cold storage using WasabiWallet only."
+}
+---
+
 # Cold-Wasabi protocol
 
 This is how you can safely eat cold Wasabi, or store your coins on a hardware wallet after one or more rounds of CoinJoin using Wasabi Wallet.


### PR DESCRIPTION
Directory on Github and docs.wasabiwallet.io are different, now specified the correct location of the images.