### PR TITLE
Edit title and description

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -15,8 +15,8 @@ const youtubeEmbed = (id, path) => `
 const themeColor = "#211b24"
 
 module.exports = {
-  title: "Wasabi",
-  description: "This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop.",
+  title: "Wasabi Docs",
+  description: "This is the Wasabi documentation, an archive of knowledge about Wassabi Wallet, the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop.",
   head: [
     ["link", { rel: "icon", href: "/favicon.ico" }],
     ["link", { rel: "apple-touch-icon", href: "/apple-touch-icon.png", sizes: "180x180" }],


### PR DESCRIPTION
I think we should say wasabi docs on the main page of the docs website.

![wasabi docs](https://user-images.githubusercontent.com/52379387/65177057-43bccc80-da56-11e9-810e-a0049fac1d18.JPG)