### PR TITLE
Fix folder structure display in Tails guide

### DIFF
--- a/docs/using-wasabi/WasabiSetupTails.md
+++ b/docs/using-wasabi/WasabiSetupTails.md
@@ -33,10 +33,12 @@ Verify the PGP signature of the downloaded package, the zkSNACKs' PGP key finger
 
 You can now save your `Wasabi-X.X.X.deb` into the persistent storage, which should look like this:
 
-`/Persistent`  
-&emsp; `/bitcoin-0.18.1` (Bitcoin Core launcher folder)  
-&emsp; `/Bitcoin` (Bitcoin Core data folder)  
-&emsp; `/Wasabi-X.X.X.deb` (Wasabi installer)
+```
+/Persistent  
+|__ /bitcoin-0.18.1    # Bitcoin Core launcher folder
+|__ /Bitcoin           # Bitcoin Core data folder  
+|__ /Wasabi-X.X.X.deb  # Wasabi installer
+```
 
 ## WASABI DATA FOLDER
 
@@ -46,12 +48,14 @@ Wasabi saves session files in `/Home/.walletwasabi/client`, you need to mark the
 
 Create a directory in your persistent with the same hierarchical structure, like this:
 
-`/Persistent`  
- &emsp; `/bitcoin-0.18.1` (Bitcoin Core launcher folder)  
- &emsp; `/Bitcoin` (Bitcoin Core data folder)  
- &emsp; `/Wasabi-X.X.X.deb` (Wasabi installer)  
- &emsp; `/.walletwasabi`  
- &emsp; &emsp; `/client` (here we save our wallet files, filters and blocks)
+```
+/Persistent
+|__ /bitcoin-0.18.1    # Bitcoin Core launcher folder
+|__ /Bitcoin           # Bitcoin Core data folder  
+|__ /Wasabi-X.X.X.deb  # Wasabi installer
+|__ /.walletwasabi
+    |__ /client        # wallet files, filters and blocks
+```
 
 After every session, when you’re done, navigate into `/Home/.walletwasabi/client` and copy the desired folders into your persistent directory.
 
@@ -86,41 +90,45 @@ Wasabi will show as a normal application in your activities overview menu, ready
 
 After the first time you save a Wasabi session, your persistent storage will look like:
 
-`/Persistent`  
-&emsp; `/bitcoin-0.18.1` (Bitcoin Core launcher folder)  
-&emsp; `/Bitcoin` (Bitcoin Core data folder)  
-&emsp; `/Wasabi-X.X.X.deb` (Wasabi installer)  
-&emsp; `/.walletwasabi`  
-&emsp; &emsp; `/client` (here we save our wallet files, filters and blocks)  
-&emsp; &emsp; &emsp; `/Wallets` (wallet files)  
-&emsp; &emsp; &emsp; `/Blocks` (blocks)  
-&emsp; &emsp; &emsp; `/BitcoinStore` (filters)
+```
+/Persistent
+|__ /bitcoin-0.18.1        # Bitcoin Core launcher folder
+|__ /Bitcoin               # Bitcoin Core data folder  
+|__ /Wasabi-X.X.X.deb      # Wasabi installer
+|__ /.walletwasabi
+    |__ /client
+        |__ /Wallets       # wallet files
+        |__ /Blocks        # blocks
+        |__ /BitcoinStore  # filters
+```
 
 To load your saved session, drop the `.walletwasabi` folder into `/Home` before starting Wasabi.
 
 You can save multiple copies of `.walletwasabi` in your persistent, each with different data:
 
-`/Persistent`  
-&emsp; `/bitcoin-0.18.1` (Bitcoin Core launcher folder)  
-&emsp; `/Bitcoin` (Bitcoin Core data folder)  
-&emsp; `/Wasabi`  
-&emsp; &emsp; `/Wasabi-X.X.X.deb` (Wasabi installer)  
-&emsp; &emsp; `/BitcoinStore` (No need to keep multiple copies of same filters)  
-&emsp; &emsp; `/CoinJoin wallet`  
-&emsp; &emsp; &emsp; `/.walletwasabi`  
-&emsp; &emsp; &emsp; &emsp; `/client` (here we save our wallet files, filters and blocks)  
-&emsp; &emsp; &emsp; &emsp; &emsp; `/Wallets` (wallet files)  
-&emsp; &emsp; &emsp; &emsp; &emsp; `/Blocks` (blocks)  
-&emsp; &emsp; `/watch-only coldstorage A`  
-&emsp; &emsp; &emsp; `/.walletwasabi`  
-&emsp; &emsp; &emsp; &emsp; `/client` (here we save our wallet files, filters and blocks)  
-&emsp; &emsp; &emsp; &emsp; &emsp; `/Wallets` (wallet files)  
-&emsp; &emsp; &emsp; &emsp; &emsp; `/Blocks` (blocks)  
-&emsp; &emsp; `/watch-only coldstorage B`  
-&emsp; &emsp; &emsp; `/.walletwasabi`  
-&emsp; &emsp; &emsp; &emsp; `/client` (here we save our wallet files, filters and blocks)  
-&emsp; &emsp; &emsp; &emsp; &emsp; `/Wallets` (wallet files)  
-&emsp; &emsp; &emsp; &emsp; &emsp; `/Blocks` (blocks)
+```
+/Persistent
+|__ /bitcoin-0.18.1        # Bitcoin Core launcher folder
+|__ /Bitcoin               # Bitcoin Core data folder  
+|__ /Wasabi                # General Wasabi folder
+    |__ /Wasabi-X.X.X.deb  # Wasabi installer
+    |__ /BitcoinStore      # No need to keep multiple copies of same filters
+    |__ /CoinJoin wallet   
+    |   |__ /.walletwasabi
+    |       |__ /client    # Here we save our wallet files, filters and blocks
+    |           |__ /Wallets
+    |           |__ /Blocks
+    |__ /watch-only coldstorage A
+    |   |__ /.walletwasabi
+    |       |__ /client    # Here we save our wallet files, filters and blocks
+    |           |__ /Wallets
+    |           |__ /Blocks
+    |__ /watch-only coldstorage B
+        |__ /.walletwasabi
+            |__ /client    # Here we save our wallet files, filters and blocks
+                |__ /Wallets
+                |__ /Blocks
+```
 
 This is only a minor example, tune it to your own needs.
 

--- a/docs/using-wasabi/WasabiSetupTails.md
+++ b/docs/using-wasabi/WasabiSetupTails.md
@@ -54,7 +54,7 @@ Create a directory in your persistent with the same hierarchical structure, like
 |__ /Bitcoin           # Bitcoin Core data folder
 |__ /Wasabi-X.X.X.deb  # Wasabi installer
 |__ /.walletwasabi
-    |__ /client        # wallet files, filters and blocks
+    |__ /client        # Here we save our wallet files, filters and blocks
 ```
 
 After every session, when you’re done, navigate into `/Home/.walletwasabi/client` and copy the desired folders into your persistent directory.
@@ -96,10 +96,10 @@ After the first time you save a Wasabi session, your persistent storage will loo
 |__ /Bitcoin               # Bitcoin Core data folder
 |__ /Wasabi-X.X.X.deb      # Wasabi installer
 |__ /.walletwasabi
-    |__ /client
-        |__ /Wallets       # wallet files
-        |__ /Blocks        # blocks
-        |__ /BitcoinStore  # filters
+    |__ /client            # Here we save our wallet files, blocks and filters
+        |__ /Wallets
+        |__ /Blocks
+        |__ /BitcoinStore
 ```
 
 To load your saved session, drop the `.walletwasabi` folder into `/Home` before starting Wasabi.
@@ -112,20 +112,20 @@ You can save multiple copies of `.walletwasabi` in your persistent, each with di
 |__ /Bitcoin               # Bitcoin Core data folder
 |__ /Wasabi                # General Wasabi folder
     |__ /Wasabi-X.X.X.deb  # Wasabi installer
-    |__ /BitcoinStore      # No need to keep multiple copies of same filters
+    |__ /BitcoinStore      # Filters (No need to keep multiple copies of them)
     |__ /CoinJoin wallet
     |   |__ /.walletwasabi
-    |       |__ /client    # Here we save our wallet files, filters and blocks
+    |       |__ /client
     |           |__ /Wallets
     |           |__ /Blocks
     |__ /watch-only coldstorage A
     |   |__ /.walletwasabi
-    |       |__ /client    # Here we save our wallet files, filters and blocks
+    |       |__ /client
     |           |__ /Wallets
     |           |__ /Blocks
     |__ /watch-only coldstorage B
         |__ /.walletwasabi
-            |__ /client    # Here we save our wallet files, filters and blocks
+            |__ /client
                 |__ /Wallets
                 |__ /Blocks
 ```

--- a/docs/using-wasabi/WasabiSetupTails.md
+++ b/docs/using-wasabi/WasabiSetupTails.md
@@ -21,12 +21,12 @@ You need sudo privileges to install Wasabi, at “Tails Greeter” create your a
 
 ## DOWNLOAD
 
-Download for Debian/Ubuntu from:  
-http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion (tor hidden service)  
-or  
+Download for Debian/Ubuntu from:
+http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion (tor hidden service)
+or
 https://www.wasabiwallet.io/#download
 
-Verify the PGP signature of the downloaded package, the zkSNACKs' PGP key fingerprint is:  
+Verify the PGP signature of the downloaded package, the zkSNACKs' PGP key fingerprint is:
 `6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E`
 
 `gpg -v Wasabi-X.X.X.deb` (For more details check this [guide](https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#debian-and-ubuntu))
@@ -34,9 +34,9 @@ Verify the PGP signature of the downloaded package, the zkSNACKs' PGP key finger
 You can now save your `Wasabi-X.X.X.deb` into the persistent storage, which should look like this:
 
 ```
-/Persistent  
+/Persistent
 |__ /bitcoin-0.18.1    # Bitcoin Core launcher folder
-|__ /Bitcoin           # Bitcoin Core data folder  
+|__ /Bitcoin           # Bitcoin Core data folder
 |__ /Wasabi-X.X.X.deb  # Wasabi installer
 ```
 
@@ -51,7 +51,7 @@ Create a directory in your persistent with the same hierarchical structure, like
 ```
 /Persistent
 |__ /bitcoin-0.18.1    # Bitcoin Core launcher folder
-|__ /Bitcoin           # Bitcoin Core data folder  
+|__ /Bitcoin           # Bitcoin Core data folder
 |__ /Wasabi-X.X.X.deb  # Wasabi installer
 |__ /.walletwasabi
     |__ /client        # wallet files, filters and blocks
@@ -93,7 +93,7 @@ After the first time you save a Wasabi session, your persistent storage will loo
 ```
 /Persistent
 |__ /bitcoin-0.18.1        # Bitcoin Core launcher folder
-|__ /Bitcoin               # Bitcoin Core data folder  
+|__ /Bitcoin               # Bitcoin Core data folder
 |__ /Wasabi-X.X.X.deb      # Wasabi installer
 |__ /.walletwasabi
     |__ /client
@@ -109,11 +109,11 @@ You can save multiple copies of `.walletwasabi` in your persistent, each with di
 ```
 /Persistent
 |__ /bitcoin-0.18.1        # Bitcoin Core launcher folder
-|__ /Bitcoin               # Bitcoin Core data folder  
+|__ /Bitcoin               # Bitcoin Core data folder
 |__ /Wasabi                # General Wasabi folder
     |__ /Wasabi-X.X.X.deb  # Wasabi installer
     |__ /BitcoinStore      # No need to keep multiple copies of same filters
-    |__ /CoinJoin wallet   
+    |__ /CoinJoin wallet
     |   |__ /.walletwasabi
     |       |__ /client    # Here we save our wallet files, filters and blocks
     |           |__ /Wallets

--- a/docs/using-wasabi/WasabiSetupTails.md
+++ b/docs/using-wasabi/WasabiSetupTails.md
@@ -22,11 +22,15 @@ You need sudo privileges to install Wasabi, at “Tails Greeter” create your a
 ## DOWNLOAD
 
 Download for Debian/Ubuntu from:
+<br>
 http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion (tor hidden service)
+<br>
 or
+<br>
 https://www.wasabiwallet.io/#download
 
 Verify the PGP signature of the downloaded package, the zkSNACKs' PGP key fingerprint is:
+<br>
 `6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E`
 
 `gpg -v Wasabi-X.X.X.deb` (For more details check this [guide](https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#debian-and-ubuntu))
@@ -108,14 +112,14 @@ You can save multiple copies of `.walletwasabi` in your persistent, each with di
 
 ```sh
 /Persistent
-|__ /bitcoin-0.18.1        # Bitcoin Core launcher folder
-|__ /Bitcoin               # Bitcoin Core data folder
-|__ /Wasabi                # General Wasabi folder
-    |__ /Wasabi-X.X.X.deb  # Wasabi installer
-    |__ /BitcoinStore      # Filters (No need to keep multiple copies of them)
+|__ /bitcoin-0.18.1                # Bitcoin Core launcher folder
+|__ /Bitcoin                       # Bitcoin Core data folder
+|__ /Wasabi                        # General Wasabi folder
+    |__ /Wasabi-X.X.X.deb          # Wasabi installer
+    |__ /BitcoinStore              # Filters (No need to keep multiple copies of them)
     |__ /CoinJoin wallet
     |   |__ /.walletwasabi
-    |       |__ /client
+    |       |__ /client            # Here we save our wallet files and blocks
     |           |__ /Wallets
     |           |__ /Blocks
     |__ /watch-only coldstorage A

--- a/docs/using-wasabi/WasabiSetupTails.md
+++ b/docs/using-wasabi/WasabiSetupTails.md
@@ -33,7 +33,7 @@ Verify the PGP signature of the downloaded package, the zkSNACKs' PGP key finger
 
 You can now save your `Wasabi-X.X.X.deb` into the persistent storage, which should look like this:
 
-```
+```sh
 /Persistent
 |__ /bitcoin-0.18.1    # Bitcoin Core launcher folder
 |__ /Bitcoin           # Bitcoin Core data folder
@@ -48,7 +48,7 @@ Wasabi saves session files in `/Home/.walletwasabi/client`, you need to mark the
 
 Create a directory in your persistent with the same hierarchical structure, like this:
 
-```
+```sh
 /Persistent
 |__ /bitcoin-0.18.1    # Bitcoin Core launcher folder
 |__ /Bitcoin           # Bitcoin Core data folder
@@ -71,7 +71,7 @@ Drop the `Wasabi-X.X.X.deb` file from `/Home/Persistent` into desktop.
 
 Open the terminal and run:
 
-```
+```sh
 cd Desktop
 sudo dpkg -i Wasabi-X.X.X.deb
 ```
@@ -90,7 +90,7 @@ Wasabi will show as a normal application in your activities overview menu, ready
 
 After the first time you save a Wasabi session, your persistent storage will look like:
 
-```
+```sh
 /Persistent
 |__ /bitcoin-0.18.1        # Bitcoin Core launcher folder
 |__ /Bitcoin               # Bitcoin Core data folder
@@ -106,7 +106,7 @@ To load your saved session, drop the `.walletwasabi` folder into `/Home` before 
 
 You can save multiple copies of `.walletwasabi` in your persistent, each with different data:
 
-```
+```sh
 /Persistent
 |__ /bitcoin-0.18.1        # Bitcoin Core launcher folder
 |__ /Bitcoin               # Bitcoin Core data folder


### PR DESCRIPTION
This way the folder structure gets displayed correctly on the docs website.
Here on github it is displayed ok, nevertheless imho this improves it and makes it even clearer.

Currently the structure on the docs site looks like this, which is very confusing:

<img width="583" alt="tails-folder-stricture-current" src="https://user-images.githubusercontent.com/886/66259222-b0ea9480-e7ae-11e9-8ba1-f78068c493ca.png">
