### PR TITLE
Add currentVersion variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ bar
 :::
 ```
 
-
 ### Frequently asked questions
 
 Use this markdown box with the headers to write the FAQ:
@@ -159,6 +158,12 @@ answer answer answer.
 :::
 ::::
 ```
+
+### Variables
+
+To have a single place to maintain universal strings like the current Wasabi version number, we use variables in the Markdown (i.e.  `${currentVersion}`).
+These variables are managed in `docs/.vuepress/variables.js`.
+Occurrences of `${variableName}` get substituted before the Markdown is processed.
 
 ### Thanks goes to the Wasabikas, Osu!
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -26,6 +26,9 @@ module.exports = {
     ["meta", { name: "msapplication-TileColor", content: themeColor }],
     ["meta", { name: "theme-color", content: themeColor }],
   ],
+  extendPageData ($page) {
+    $page.currentVersion = '1.1.9.2'
+  },
   plugins: [
     "@vuepress/back-to-top",
     ["container", {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,3 +1,4 @@
+const { resolve } = require('path')
 const { slugify } = require('@vuepress/shared-utils')
 const customBlock = require('markdown-it-custom-block')
 
@@ -26,9 +27,6 @@ module.exports = {
     ["meta", { name: "msapplication-TileColor", content: themeColor }],
     ["meta", { name: "theme-color", content: themeColor }],
   ],
-  extendPageData ($page) {
-    $page.currentVersion = '1.1.9.2'
-  },
   plugins: [
     "@vuepress/back-to-top",
     ["container", {
@@ -59,6 +57,14 @@ module.exports = {
       }
     }]
   ],
+  chainWebpack (config) {
+    return config.module
+      .rule('md')
+      .test(/\.md$/)
+      .use(resolve(__dirname, './variables'))
+        .loader(resolve(__dirname, './variables'))
+        .end()
+  },
   markdown: {
     extendMarkdown (md) {
       md.use(customBlock, {

--- a/docs/.vuepress/variables.js
+++ b/docs/.vuepress/variables.js
@@ -1,0 +1,13 @@
+// Add custom variables here:
+const variables = {
+  currentVersion: '1.1.9.2'
+}
+
+/**
+ * Replaces all string occurrences of "${variableName}" in Markdown
+ * with the variable value: "${currentVersion}" -> "1.1.9.2"
+ */
+module.exports = source =>
+  Object.keys(variables).reduce((result, variable) =>
+    result.replace(RegExp('\\${'+ variable +'}', 'g'), variables[variable])
+  , source)

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -44,7 +44,7 @@ This protects you against malicious man in the middle attacks where bad guys giv
 
 On the [WasabiWallet.io](https://wasabiwallet.io) website you can download the packages of the latest release.
 Make sure that in addition you also download the separate signature `.asc` file.
-In the terminal, change the directory to the one with the downloaded files, and verify the signature with `gpg --verify Wasabi-{{ $page.currentVersion }}.deb.asc`.
+In the terminal, change the directory to the one with the downloaded files, and verify the signature with `gpg --verify Wasabi-${currentVersion}.deb.asc`.
 Everything is valid if it returns `Good signature from zkSNACKs` and that it was signed with the `Primary key fingerprint: 6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E`.
 
 For an in depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.html#debian-and-ubuntu), [other Linux](/using-wasabi/InstallPackage.html#other-linux), [Windows](/using-wasabi/InstallPackage.html#windows), and [OSX](/using-wasabi/InstallPackage.html#osx) see the main documentation.
@@ -60,7 +60,7 @@ For an in depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.html#
 ![](/DownloadDeb.png)
 
 Verify the signature of the package with `gpg --verify Wasabi-X.X.X.deb` and ensure the software was signed by zkSNACKs' PGP key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
-Now install Wasabi with `sudo dpkg -i Wasabi-{{ $page.currentVersion }}.deb.asc`, and run it with `wassabee`.
+Now install Wasabi with `sudo dpkg -i Wasabi-${currentVersion}.deb.asc`, and run it with `wassabee`.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#debian-and-ubuntu).
 
 @[youtube](mTrClVA_o5A,122)
@@ -176,11 +176,11 @@ On Debian and Ubuntu do
 
 On other Linux do
 <br />
-`git diff --no-index linux-x64/ WasabiLinux-{{ $page.currentVersion }}`.
+`git diff --no-index linux-x64/ WasabiLinux-${currentVersion}`.
 
 And on Mac first unzip with
 <br />
-`7z x Wasabi-{{ $page.currentVersion }}.dmg -oWasabiOsx`.
+`7z x Wasabi-${currentVersion}.dmg -oWasabiOsx`.
 <br />
 and verify with
 <br />

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -44,7 +44,7 @@ This protects you against malicious man in the middle attacks where bad guys giv
 
 On the [WasabiWallet.io](https://wasabiwallet.io) website you can download the packages of the latest release.
 Make sure that in addition you also download the separate signature `.asc` file.
-In the terminal, change the directory to the one with the downloaded files, and verify the signature with `gpg --verify Wasabi-1.1.9.2.deb.asc`.
+In the terminal, change the directory to the one with the downloaded files, and verify the signature with `gpg --verify Wasabi-{{ $page.currentVersion }}.deb.asc`.
 Everything is valid if it returns `Good signature from zkSNACKs` and that it was signed with the `Primary key fingerprint: 6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E`.
 
 For an in depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.html#debian-and-ubuntu), [other Linux](/using-wasabi/InstallPackage.html#other-linux), [Windows](/using-wasabi/InstallPackage.html#windows), and [OSX](/using-wasabi/InstallPackage.html#osx) see the main documentation.
@@ -60,7 +60,7 @@ For an in depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.html#
 ![](/DownloadDeb.png)
 
 Verify the signature of the package with `gpg --verify Wasabi-X.X.X.deb` and ensure the software was signed by zkSNACKs' PGP key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
-Now install Wasabi with `sudo dpkg -i Wasabi-1.1.9.2.deb.asc`, and run it with `wassabee`.
+Now install Wasabi with `sudo dpkg -i Wasabi-{{ $page.currentVersion }}.deb.asc`, and run it with `wassabee`.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.html#debian-and-ubuntu).
 
 @[youtube](mTrClVA_o5A,122)
@@ -176,11 +176,11 @@ On Debian and Ubuntu do
 
 On other Linux do
 <br />
-`git diff --no-index linux-x64/ WasabiLinux-1.1.9.2`.
+`git diff --no-index linux-x64/ WasabiLinux-{{ $page.currentVersion }}`.
 
 And on Mac first unzip with
 <br />
-`7z x Wasabi-1.1.9.2.dmg -oWasabiOsx`.
+`7z x Wasabi-{{ $page.currentVersion }}.dmg -oWasabiOsx`.
 <br />
 and verify with
 <br />

--- a/docs/using-wasabi/DeterministicBuild.md
+++ b/docs/using-wasabi/DeterministicBuild.md
@@ -64,23 +64,20 @@ After installing WSL, just type `wsl` in explorer where your downloaded and buil
 
 #### .deb
 
-```sh
-sudo dpkg -i Wasabi-1.1.9.2.deb
+<pre><code>sudo dpkg -i Wasabi-{{ $page.currentVersion }}.deb
 git diff --no-index linux-x64/ /usr/local/bin/wasabiwallet/
-```
+</code></pre>
 
 #### .tar.gz
 
-```sh
-tar -pxzf WasabiLinux-1.1.9.2.tar.gz
-git diff --no-index linux-x64/ WasabiLinux-1.1.9.2
-```
+<pre><code>tar -pxzf WasabiLinux-{{ $page.currentVersion }}.tar.gz
+git diff --no-index linux-x64/ WasabiLinux-{{ $page.currentVersion }}
+</code></pre>
 
 #### .dmg
 
 You will need to install [7z](https://www.7-zip.org/) (or something else) to extract the `.dmg`: `sudo apt install p7zip-full`
 
-```sh
-7z x Wasabi-1.1.9.2.dmg -oWasabiOsx
+<pre><code>7z x Wasabi-{{ $page.currentVersion }}.dmg -oWasabiOsx
 git diff --no-index osx-x64/ WasabiOsx/Wasabi\ Wallet.App/Contents/MacOS/
-```
+</code></pre>

--- a/docs/using-wasabi/DeterministicBuild.md
+++ b/docs/using-wasabi/DeterministicBuild.md
@@ -55,7 +55,7 @@ git diff --no-index win7-x64 "C:\Program Files\WasabiWallet"
 ### Linux && OSX
 
 You can use the Windows Subsystem for Linux to verify all the packages in one go.
-At the time of writing this guide we provide a `.tar.gz` and a `.deb` package for Linux and .dmg for OSX. 
+At the time of writing this guide we provide a `.tar.gz` and a `.deb` package for Linux and .dmg for OSX.
 Install the `.deb` package and extract the `tar.gz` and `.dmg` packages, then compare them with your build.
 
 After installing WSL, just type `wsl` in explorer where your downloaded and built packages are located.
@@ -64,20 +64,23 @@ After installing WSL, just type `wsl` in explorer where your downloaded and buil
 
 #### .deb
 
-<pre><code>sudo dpkg -i Wasabi-{{ $page.currentVersion }}.deb
+```sh
+sudo dpkg -i Wasabi-${currentVersion}.deb
 git diff --no-index linux-x64/ /usr/local/bin/wasabiwallet/
-</code></pre>
+```
 
 #### .tar.gz
 
-<pre><code>tar -pxzf WasabiLinux-{{ $page.currentVersion }}.tar.gz
-git diff --no-index linux-x64/ WasabiLinux-{{ $page.currentVersion }}
-</code></pre>
+```sh
+tar -pxzf WasabiLinux-${currentVersion}.tar.gz
+git diff --no-index linux-x64/ WasabiLinux-${currentVersion}
+```
 
 #### .dmg
 
 You will need to install [7z](https://www.7-zip.org/) (or something else) to extract the `.dmg`: `sudo apt install p7zip-full`
 
-<pre><code>7z x Wasabi-{{ $page.currentVersion }}.dmg -oWasabiOsx
+```sh
+7z x Wasabi-${currentVersion}.dmg -oWasabiOsx
 git diff --no-index osx-x64/ WasabiOsx/Wasabi\ Wallet.App/Contents/MacOS/
-</code></pre>
+```


### PR DESCRIPTION
This substitutes the `${currentVersion}` with whatever is defined in the variables.js file. The goal is to have a single place to maintain the current Wasabi version number as it is used in multiple places. This could also be extended for other cases, but I'm putting it out here to discuss the idea.

~Note: I haven't found a way to make the substitution work in fenced code blocks yet. that's why this commit uses the `<pre><code>` fallback for code blocks on the Deterministic Builds page. It's ugly, nevertheless worth it imho.~

Feedback appreciated!