### PR TITLE
Fix links 10Commandments.md

### DIFF
--- a/docs/why-wasabi/10Commandments.md
+++ b/docs/why-wasabi/10Commandments.md
@@ -23,10 +23,10 @@ Clear-net: [wasabiwallet.io](https://wasabiwallet.io)
 
 Tor hidden service: [wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion)
 
-Please [check signatures](InstallPackage.md) after completing downloads.
+Please [check signatures](/using-wasabi/InstallPackage.md) after completing downloads.
 The concern here is that you may accidentally fall for a phishing attempt and be on a malicious site downloading a malicious piece of software.
 
-Alternatively, as Wasabi is [libre and open source software](https://github.com/zkSNACKs/WalletWasabi), you may also [build the code from source](BuildSource.md).
+Alternatively, as Wasabi is [libre and open source software](https://github.com/zkSNACKs/WalletWasabi), you may also [build the code from source](/using-wasabi/BuildSource.md).
 
 ## 3. Keep your mnemonic words and password safely stored (BOTH!)
 


### PR DESCRIPTION
I changed it following [260](https://github.com/zkSNACKs/WasabiDoc/pull/260), but every Github link is broken without `/docs`.

Does `/docs` break the website? 