### PR TITLE
[WIP] Codechain

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -181,6 +181,7 @@ module.exports = {
             "/building-wasabi/DemoGuide.md",
             "/building-wasabi/ContributionGame.md",
             "/building-wasabi/Security.md",
+            "/building-wasabi/CodeChain.md",
             "/building-wasabi/CodeCoverage.md",
             "/building-wasabi/HardwareWalletTestingGuide.md",
             "/building-wasabi/HowToDebug.md",

--- a/docs/building-wasabi/CodeChain.md
+++ b/docs/building-wasabi/CodeChain.md
@@ -19,7 +19,7 @@ However, users do not verify the git commit signatures, and only a few verify th
 Packages are distributed on the Wasabi website, with no verification of what the most recent version is.
 
 There are several problems with such an approach:
-- The PGP keys can be very and this long validity time makes stolen keys disastrous.
+- The PGP keys can be very old and long validity time makes stolen keys disastrous.
 - They are stored on a network server and thus easily stolen.
 - There is no method for key rotation.
 - Only one key signs the package, this is a single point of failure.

--- a/docs/building-wasabi/CodeChain.md
+++ b/docs/building-wasabi/CodeChain.md
@@ -29,7 +29,7 @@ There are several problems with such an approach:
 The main attacks of such a signing and distribution process are:
 - Key compromise (attacker can produce valid signatures).
 - Developer coercion (wrench attack, blackmailing or bribing).
-- Regression (supression of updates).
+- Regression (suppression of updates).
 
 :::danger
 This is far from optimal.

--- a/docs/building-wasabi/CodeChain.md
+++ b/docs/building-wasabi/CodeChain.md
@@ -1,0 +1,38 @@
+---
+{
+  "title": "CodeChain",
+  "description": "A guide on how to use Code Chain to sign and distribute the Wasabi source and package. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+}
+---
+
+# CodeChain
+
+[[toc]]
+
+## Rational
+
+### The Problem
+
+For high security software like Wasabi, we need to take extra care that the code is well reviewed by different peers, and that users run exactly that software, and are not victim of a targeted backdoor attack.
+Current best practice is to have PGP signatures of the developers on the individual code commits, as well as by the maintainers on every released compiled package.
+However, users do not verify the git commit signatures, and only a few verify the build signatures.
+Packages are distributed on the Wasabi website, with no verification of what the most recent version is.
+
+There are several problems with such an approach:
+- The PGP keys can be very and this long validity time makes stolen keys disastrous.
+- They are stored on a network server and thus easily stolen.
+- There is no method for key rotation.
+- Only one key signs the package, this is a single point of failure.
+- The verification is rather combersom, especially for commit signatures.
+- Users cannot verify which version of the package is the most recent one.
+
+The main attacks of such a signing and distribution process are:
+- Key compromise (attacker can produce valid signatures).
+- Developer coersion (wrench attack, blackmailing or bribing).
+- Regression (supression of updates).
+
+:::danger
+This is far from optimal.
+We can and must do better.
+:::
+

--- a/docs/building-wasabi/CodeChain.md
+++ b/docs/building-wasabi/CodeChain.md
@@ -36,3 +36,14 @@ This is far from optimal.
 We can and must do better.
 :::
 
+### The Proposed Solution
+
+CodChain is about secure multi-party code reviews with threshold signatures and unmodifiable hash chains, which prevents any single developer from including a generic backdoor in the software.
+A single source of truth mechanism is used to ensure that every user runs the same version of the software, which prevents targeted backdoors and the suppression of updates.
+It is a design for secure software distribution and development, and includes a verifiable build process.
+
+:::tip
+The user can verify that he is running the same version as all other users, and that the code is claimed to be reviewed by m-of-n developers.
+:::
+
+

--- a/docs/building-wasabi/CodeChain.md
+++ b/docs/building-wasabi/CodeChain.md
@@ -28,7 +28,7 @@ There are several problems with such an approach:
 
 The main attacks of such a signing and distribution process are:
 - Key compromise (attacker can produce valid signatures).
-- Developer coersion (wrench attack, blackmailing or bribing).
+- Developer coercion (wrench attack, blackmailing or bribing).
 - Regression (supression of updates).
 
 :::danger

--- a/docs/building-wasabi/CodeChain.md
+++ b/docs/building-wasabi/CodeChain.md
@@ -1,7 +1,7 @@
 ---
 {
   "title": "CodeChain",
-  "description": "A guide on how to use Code Chain to sign and distribute the Wasabi source and package. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+  "description": "A guide on how to use CodeChain to sign and distribute the Wasabi source and package. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
 }
 ---
 

--- a/docs/building-wasabi/README.md
+++ b/docs/building-wasabi/README.md
@@ -22,6 +22,7 @@ And all the necessary information you need to quickly start with your invaluable
 - [Demo Guide](/building-wasabi/DemoGuide.md)
 - [Contribution Game](/building-wasabi/ContributionGame.md)
 - [Security Policy](/building-wasabi/Security.md)
+- [CodeChain](/building-wasabi/CodeChain.md)
 - [Code Coverage](/building-wasabi/CodeCoverage.md)
 - [Hardware Wallet Integration Testing](/building-wasabi/HardwareWalletTestingGuide.md)
 - [Developers debugging Guide](/building-wasabi/HowToDebug.md)


### PR DESCRIPTION
This is a work in progress branch of documentation about code chain, a tool to prevent targeted backdoors, with a way to sign and distribute source code and compiled packages with m-of-n review signatures in key rotation and single source of truth.

TODO:
- [x] rational with the perceived problem and proposed solution
- [ ] summary of the protocol design
- [ ] step by step tutorial for code signers
- [ ] step by step guide for users
- [ ] FAQ

This should only be merged if we end up using codechain in Wasabi. If not, then it might be forked to another repo to keep the information for other projects who might use it. 