### PR TITLE
Add Data Folder FAQ

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -78,7 +78,7 @@ Please see [this great guide](https://github.com/6102bitcoin/FAQ/blob/master/see
 ::::
 
 ::::details
-### Where is the Wasabi data folder?
+### Where can I find the Wasabi data folder?
 
 * Windows: `/Users/{your username}/AppData/Roaming/WalletWasabi/client`
 * Linux: `/Home/.walletwasabi/client`
@@ -95,7 +95,7 @@ You can also easily reach it from inside Wasabi: `File > Open > Data Folder` :::
 
 Although you can backup your private keys with the mnemonic words and password, this is only a last resort recovery.
 If you want to also secure your address labels, the anonset and additional metadata, then you can do a digital backup.
-Simply copy the `WalletBackups` folder with the `wallet.json` files from your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) onto suitable hardware, for example an encrypted USB stick.
+Simply copy the `WalletBackups` folder with the `wallet.json` files from your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) onto suitable hardware, for example an encrypted USB stick.
 Note that this file has the encrypted private keys, meaning that you only need the password to spend the bitcoin.
 This also contains the unencrypted extended public keys and address labels, meaning that it completely links all the coins, both pre and post mix, with clear proof.
 
@@ -143,7 +143,7 @@ It’s part of BIP39.
 ### I forgot my lockscreen PIN, what should I do?
 
 As described in the settings, you can just delete it.
-Open the `UiConfig.json` file inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) and set these entries as follows:
+Open the `UiConfig.json` file inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) and set these entries as follows:
 
 ```
 "LockScreenActive": false,
@@ -274,7 +274,7 @@ E.g., Wasabi will not generate address `m/84'/0'/0'/0/21` with label: "address n
 
 To increase the number of freshly new generated addresses, you have to increase the `MinGapLimit` json property of your `wallet.json` file.
 
-* Go to `File/Open/Wallets Folder` or navigate into the `Wallets` folder inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) and open your wallet file.
+* Go to `File/Open/Wallets Folder` or navigate into the `Wallets` folder inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) and open your wallet file.
 * Close Wasabi Wallet.
 * Edit the `MinGapLimit` json property in the wallet file.
 :::
@@ -1062,7 +1062,7 @@ The check mark indicates that the transaction is confirmed in the longest proof-
 ### Can I export a list of transactions?
 
 There is currently no convenient way to export a list with transaction details.
-However, you can see the `wallet.json` files inside the `WalletBackups` folder (you can find it in your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder)) which contains all the public keys, labels and anonset.
+However, you can see the `wallet.json` files inside the `WalletBackups` folder (you can find it in your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder)) which contains all the public keys, labels and anonset.
 :::
 
 ## Settings
@@ -1131,7 +1131,7 @@ In the top left menu `File > Open` you can see there are several logs available.
 
 ![](/MenuFileOpen.png)
 
-Alternatively, you can find the logs inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) :::
+Alternatively, you can find the logs inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) :::
 
 :::details
 ### How to activate Lurking Wife Mode?

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -80,15 +80,16 @@ Please see [this great guide](https://github.com/6102bitcoin/FAQ/blob/master/see
 ::::details
 ### Where can I find the Wasabi data folder?
 
-* Windows: `/Users/{your username}/AppData/Roaming/WalletWasabi/client`
+* Windows: `/Users/{your username}/AppData/Roaming/WalletWasabi/Client`
 * Linux: `/Home/.walletwasabi/client`
 * MacOS: `/Users/{your username}/.walletwasabi/client`
 
 :::tip
-You need to mark the “show hidden files” setting to see it
+You need to mark the “show hidden files” setting to see it.
 :::
 
-You can also easily reach it from inside Wasabi: `File > Open > Data Folder` ::::
+You can also easily reach it from inside Wasabi: `File > Open > Data Folder`.
+::::
 
 ::::details
 ### How do I backup my wallet file?
@@ -1126,7 +1127,7 @@ When you set it to `0.0000 5000 bitcoin`, and when you receive a coin worth `0.0
 ### Where can I find the logs?
 
 In the top left menu `File > Open` you can see there are several logs available.
-* The `Log File` shows you the general information about Wasabi wallet.
+* The `Log File` shows you the general information about Wasabi Wallet.
 * The `Tor Log File` shows the Tor specific logs.
 
 ![](/MenuFileOpen.png)

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -274,7 +274,7 @@ E.g., Wasabi will not generate address `m/84'/0'/0'/0/21` with label: "address n
 
 To increase the number of freshly new generated addresses, you have to increase the `MinGapLimit` json property of your `wallet.json` file.
 
-* Go to `File/Open/Wallets Folder` or navigate into `Wallets` folder inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) and open your wallet file.
+* Go to `File/Open/Wallets Folder` or navigate into the `Wallets` folder inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) and open your wallet file.
 * Close Wasabi Wallet.
 * Edit the `MinGapLimit` json property in the wallet file.
 :::

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -78,11 +78,24 @@ Please see [this great guide](https://github.com/6102bitcoin/FAQ/blob/master/see
 ::::
 
 ::::details
+### Where is the Wasabi data folder?
+
+* Windows: `/Users/{your username}/AppData/Roaming/WalletWasabi/client`
+* Linux: `/Home/.walletwasabi/client`
+* MacOS: `/Users/{your username}/.walletwasabi/client`
+
+:::tip
+You need to mark the “show hidden files” setting to see it
+:::
+
+You can also easily reach it from inside Wasabi: `File > Open > Data Folder` ::::
+
+::::details
 ### How do I backup my wallet file?
 
 Although you can backup your private keys with the mnemonic words and password, this is only a last resort recovery.
 If you want to also secure your address labels, the anonset and additional metadata, then you can do a digital backup.
-Simply copy the `.walletwasabi/client/WalletBackups` folder with the `wallet.json` files onto suitable hardware, for example an encrypted USB stick.
+Simply copy the `WalletBackups` folder with the `wallet.json` files from your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) onto suitable hardware, for example an encrypted USB stick.
 Note that this file has the encrypted private keys, meaning that you only need the password to spend the bitcoin.
 This also contains the unencrypted extended public keys and address labels, meaning that it completely links all the coins, both pre and post mix, with clear proof.
 
@@ -130,7 +143,7 @@ It’s part of BIP39.
 ### I forgot my lockscreen PIN, what should I do?
 
 As described in the settings, you can just delete it.
-Open the `UiConfig.json` and set these entries as follows:
+Open the `UiConfig.json` file inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) and set these entries as follows:
 
 ```
 "LockScreenActive": false,
@@ -261,7 +274,7 @@ E.g., Wasabi will not generate address `m/84'/0'/0'/0/21` with label: "address n
 
 To increase the number of freshly new generated addresses, you have to increase the `MinGapLimit` json property of your `wallet.json` file.
 
-* Go to `File/Open/Wallet Folder` or navigate into `/Home/.walletwasabi/client/Wallets` and open your wallet file.
+* Go to `File/Open/Wallets Folder` or navigate into `Wallets` folder inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) and open your wallet file.
 * Close Wasabi Wallet.
 * Edit the `MinGapLimit` json property in the wallet file.
 :::
@@ -1049,7 +1062,7 @@ The check mark indicates that the transaction is confirmed in the longest proof-
 ### Can I export a list of transactions?
 
 There is currently no convenient way to export a list with transaction details.
-However, you can see the `wallet.json` files in the `.walletwasabi/client/WalletBackups/` folder which contains all the public keys, labels and anonset.
+However, you can see the `wallet.json` files inside the `WalletBackups` folder (you can find it in your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder)) which contains all the public keys, labels and anonset.
 :::
 
 ## Settings
@@ -1113,10 +1126,12 @@ When you set it to `0.0000 5000 bitcoin`, and when you receive a coin worth `0.0
 ### Where can I find the logs?
 
 In the top left menu `File > Open` you can see there are several logs available.
-The `Log File` shows you the general information about Wasabi wallet.
-The `Tor Log File` shows the Tor specific logs.
+* The `Log File` shows you the general information about Wasabi wallet.
+* The `Tor Log File` shows the Tor specific logs.
+
 ![](/MenuFileOpen.png)
-:::
+
+Alternatively, you can find the logs inside your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) :::
 
 :::details
 ### How to activate Lurking Wife Mode?

--- a/docs/using-wasabi/WalletRecovery.md
+++ b/docs/using-wasabi/WalletRecovery.md
@@ -30,5 +30,5 @@ The gap limit is about how far Wasabi will check the HD wallet structure for add
 
 ## Backup Wallet File
 
-Wasabi Wallet creates a backup of your wallet file at `~/.walletwasabi/client/WalletBackup/`.
-If you have done a backup of this file, then you can copy it to `~/.walletwasabi/client/Wallets/`, and upon the next restart of Wasabi, it will show this wallet in the `Wallet Manager`, from where you can open it as usual.
+Wasabi Wallet creates a backup of your wallet file inside `WalletBackups` in your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) .
+If you have done a backup of this file, then you can copy it to the `Wallets` folder, and upon the next restart of Wasabi, it will show this wallet in the `Wallet Manager`, from where you can open it as usual.

--- a/docs/using-wasabi/WalletRecovery.md
+++ b/docs/using-wasabi/WalletRecovery.md
@@ -30,5 +30,5 @@ The gap limit is about how far Wasabi will check the HD wallet structure for add
 
 ## Backup Wallet File
 
-Wasabi Wallet creates a backup of your wallet file inside `WalletBackups` in your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#Where-is-the-Wasabi-data-folder) .
+Wasabi Wallet creates a backup of your wallet file inside `WalletBackups` in your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) .
 If you have done a backup of this file, then you can copy it to the `Wallets` folder, and upon the next restart of Wasabi, it will show this wallet in the `Wallet Manager`, from where you can open it as usual.

--- a/docs/using-wasabi/WalletRecovery.md
+++ b/docs/using-wasabi/WalletRecovery.md
@@ -30,5 +30,5 @@ The gap limit is about how far Wasabi will check the HD wallet structure for add
 
 ## Backup Wallet File
 
-Wasabi Wallet creates a backup of your wallet file inside `WalletBackups` in your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) .
+Wasabi Wallet creates a backup of your wallet file inside `WalletBackups` in your [Wasabi data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder).
 If you have done a backup of this file, then you can copy it to the `Wallets` folder, and upon the next restart of Wasabi, it will show this wallet in the `Wallet Manager`, from where you can open it as usual.

--- a/docs/using-wasabi/WasabiSetupTails.md
+++ b/docs/using-wasabi/WasabiSetupTails.md
@@ -45,7 +45,7 @@ You can now save your `Wasabi-${currentVersion}.deb` into the persistent storage
 
 As of version 1.1.9 Wasabi doesn’t offer easy ways, especially without command line, to change install directory. There is though a quick workaround.
 
-Wasabi saves session files in `/Home/.walletwasabi/client`, you need to mark the “show hidden files” setting to see it.
+Wasabi [saves session files](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) in `/Home/.walletwasabi/client`, you need to mark the “show hidden files” setting to see it.
 
 Create a directory in your persistent with the same hierarchical structure, like this:
 


### PR DESCRIPTION
This PR adds an explanation about where to find the Wasabi data folder (either Win, Linux or Mac) and adds the relative link to it in a bunch of other FAQs.

I think this could be useful, both as a unique reference easier to mantain for every OS and as an extra explanation of how to reach the data folder when you cannot open Wasabi. 

It's based on a recent question on the Telegram group and on questions like [this](https://www.reddit.com/r/WasabiWallet/comments/dg5mat/mac_wasabi_log_file/).
