### PR TITLE
Use PGP public key consistently

### DIFF
--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -16,7 +16,7 @@ It's always best to download software directly from the official source acknowle
 You can find the recent version of the compiled packages for Linux, Windows and Mac available on the official [wasabiwallet.io](https://wasabiwallet.io).
 In order to preserve your network level privacy from the very first step on, please consider visiting the tor hidden service [wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 The old versions of the software can be found in the [releases](https://github.com/zksnacks/walletwasabi/releases) of the GitHub repository, [here](https://github.com/zksnacks/walletwasabi) you also find the libre & open source code for when you want to [build it yourself](/using-wasabi/BuildSource.md).
-Please take special care to verify the PGP signatures of zkSNACKs' PGP key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) over the software packages and code commits.
+Please take special care to verify the PGP signatures of zkSNACKs' PGP public key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) over the software packages and code commits.
 :::
 
 ::::details
@@ -32,8 +32,8 @@ Wasabi is tailor made so that you do **not** have to trust anyone, but you have 
 
 With PGP signatures you can verify that the software package you download is actually the one by the developers.
 Every release of Wasabi is signed by [zkSNACKs](https://zksnacks.com/), the company behind Wasabi.
-You can verify that the PGP key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) is actually the one of [zkSNACKs](https://pgp.key-server.io/search/zksnacks) by exploring the [web of trust](https://en.wikipedia.org/wiki/Web_of_trust).
-When you have a software package that was signed by this key, then you can be sure that this is an official release approved by zkSNACKs.
+You can verify that the PGP public key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) is actually the one of [zkSNACKs](https://pgp.key-server.io/search/zksnacks) by exploring the [web of trust](https://en.wikipedia.org/wiki/Web_of_trust).
+When you have a software package that was signed by this PGP public key, then you can be sure that this is an official release approved by zkSNACKs.
 This protects you against malicious man in the middle attacks where bad guys give you a fake version of Wasabi with malicious code.
 
 @[youtubePlaylist](PLPj3KCksGbSZkVpgAZjAFfFp4D0SHLnFw,psl35MisYxo)
@@ -59,7 +59,7 @@ For an in depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.md#de
 
 ![](/DownloadDeb.png)
 
-Verify the signature of the package with `gpg --verify Wasabi-X.X.X.deb` and ensure the software was signed by zkSNACKs' PGP key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+Verify the signature of the package with `gpg --verify Wasabi-X.X.X.deb` and ensure the software was signed by zkSNACKs' PGP public key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 
 Now install Wasabi with `sudo dpkg -i Wasabi-${currentVersion}.deb.asc`, and run it with `wassabee`.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#debian-and-ubuntu).
@@ -74,7 +74,7 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 
 ![](/DownloadTar.png)
 
-Verify the signature of the package with `gpg --verify Wasabi-X.X.X.tar.gz.asc` and ensure the software was signed by zkSNACKs' PGP key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+Verify the signature of the package with `gpg --verify Wasabi-X.X.X.tar.gz.asc` and ensure the software was signed by zkSNACKs' PGP public key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi with `sudo tar -pxzf Wasabi-X.X.X.tar.gz`, and run it with `./wassabee`.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#other-linux).
 :::
@@ -86,7 +86,7 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 
 ![](/DownloadWindows.png)
 
-Verify the signature of the package with with `right click on the signature file > More GpgEX options > Verify` and ensure the software was signed by zkSNACKs' PGP key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+Verify the signature of the package with with `right click on the signature file > More GpgEX options > Verify` and ensure the software was signed by zkSNACKs' PGP public key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi with double clicking the `.msi` file.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#windows).
 :::
@@ -98,7 +98,7 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 
 ![](/DownloadMac.png)
 
-Verify the signature of the package with with `sudo gpg2 --verify Wasabi-X.X.X.dmg.asc` and ensure the software was signed by zkSNACKs' PGP key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+Verify the signature of the package with with `sudo gpg2 --verify Wasabi-X.X.X.dmg.asc` and ensure the software was signed by zkSNACKs' PGP public key [6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi with double clicking the `.dmg` file.
 Checkout the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#mac).
 
@@ -125,7 +125,7 @@ It will also be announced on [Twitter](https://twitter.com/wasabiwallet), [Reddi
 ### How do I securely upgrade Wasabi?
 
 You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
-Make sure you also download the signatures of the build and verify them for [zkSNACKs' public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+Make sure you also download the signatures of the build and verify them with [zkSNACKs' PGP public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 For step by step instructions, follow [this guide](/using-wasabi/InstallPackage.md) or [see this video](https://youtu.be/DUc9A76rwX4).
 :::
 

--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -18,7 +18,7 @@ Download the packages either from the official [WasabiWallet.io](https://wasabiw
 
 ![](/DownloadAll.png)
 
-If you have personally verified zkSNACKs' PGP key and you are familiar with the [Web Of Trust](https://security.stackexchange.com/questions/147447/gpg-why-is-my-trusted-key-not-certified-with-a-trusted-signature), please consider also [signing it](https://www.gnupg.org/gph/en/manual/x334.html).
+If you have personally verified zkSNACKs' PGP public key and you are familiar with the [Web Of Trust](https://security.stackexchange.com/questions/147447/gpg-why-is-my-trusted-key-not-certified-with-a-trusted-signature), please consider also [signing it](https://www.gnupg.org/gph/en/manual/x334.html).
 
 ---
 
@@ -28,7 +28,7 @@ If you have personally verified zkSNACKs' PGP key and you are familiar with the 
 
 @[youtube](D8U53PFEsVk)
 
-If you have already imported zkSNACKs' public key, then jump to step 7.
+If you have already imported zkSNACKs' PGP public key, then jump to step 7.
 
 1. [Download](https://www.gnupg.org/download/index.html) and install Gpg4win
 
@@ -46,12 +46,12 @@ If you have already imported zkSNACKs' public key, then jump to step 7.
 
 ![](/InstallWindowsKleopatraSearchPGP.png)
 
-5. `Import` the public key of zkSNACKs [zksnacks@gmail.com]. Who are they? The company behind Wasabi [zkSNACKs Ltd.](https://zksnacks.com/)
+5. `Import` zkSNACKs' PGP public key [zksnacks@gmail.com]. Who are they? The company behind Wasabi [zkSNACKs Ltd.](https://zksnacks.com/)
 
 ![](/InstallWindowsKleopatraImportPGP.png)
 
-6. Confirm to import zkSNACKs' public key by clicking `Yes`.
-[Next time you can skip previous steps because the public key is already imported.]
+6. Confirm to import zkSNACKs' PGP public key by clicking `Yes`.
+[Next time you can skip previous steps because the PGP public key is already imported.]
 
 ![](/InstallWindowsKleopatraPGPConfirm.png)
 
@@ -69,9 +69,9 @@ Wasabi will be installed to your `C:\Program Files\WasabiWallet\` folder.
 You will also have an icon in your Start Menu and on your Desktop. After the first run, a working directory will be created: `%appdata%\WalletWasabi\`.
 Among others, here is where your wallet files and your logs reside.
 
-### Manual public key import
+### Manual PGP public key import
 
-If you get an error upon the import of zkSNACKs' PGP key, then you can manually import it.
+If you get an error upon the import of zkSNACKs' PGP public key, then you can manually import it.
 
 1. Copy zkSNACKs' PGP public key from [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 
@@ -90,7 +90,7 @@ In the context menu navigate to `More GpgEx options/Import keys`.
 
 ![](/InstallWindowsImportPGPManualImport.png)
 
-6. Kleopatra pops up and zkSNACKs' key is imported.
+6. Kleopatra pops up and zkSNACKs' PGP public key is imported.
 Press `OK` and close Kleopatra.
 
 ![](/InstallWindowsImportPGPManualKleopatra.png)
@@ -100,11 +100,11 @@ Press `OK` and close Kleopatra.
 
 @[youtube](DUc9A76rwX4)
 
-If you have already imported zkSNACKs' public key, then jump to step 2.
+If you have already imported zkSNACKs' PGP public key, then jump to step 2.
 
 1. Download zkSNACKs' PGP public key [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt), and then import it with `gpg --import PGP.txt`.
 Verify that the fingerprint is `6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E`.
-[Next time you can skip previous steps because the public key is already imported.]
+[Next time you can skip previous steps because the PGP public key is already imported.]
 
 2. [Download](https://wasabiwallet.io) the latest Wasabi release, both the `.deb` package and the corresponding `.asc` signature file.
 
@@ -127,12 +127,12 @@ Among others, here is where your wallet files and your logs reside.
 
 @[youtube](zPKpC9cRcZo)
 
-If you have already imported zkSNACKs' public key, then jump to step 2.
+If you have already imported zkSNACKs' PGP public key, then jump to step 2.
 
 1. Download zkSNACKs' PGP public key [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt), and then import it with `gpg --import PGP.txt`.
 
 Verify that the fingerprint is `6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E`.
-[Next time you can skip previous steps because the public key is already imported.]
+[Next time you can skip previous steps because the PGP public key is already imported.]
 
 2. [Download](https://wasabiwallet.io) the latest Wasabi release, both the `.tar.gz` archive and the corresponding `.asc` signature file.
 
@@ -154,16 +154,16 @@ Among others, here is where your wallet files and your logs reside.
 
 @[youtube](UZ9z5COXaG0)
 
-If you have already imported zkSNACKs' public key, then jump to step 4.
+If you have already imported zkSNACKs' PGP public key, then jump to step 4.
 
 1. [Get GnuPG](https://www.gnupg.org/download/index.html).
 
 2. Copy [zkSNACKs' PGP public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) into a new `TextEdit` document and saving it as `PGP.txt`.
 Before saving, you need to go to `Format / Make Plain Text` (otherwise TextEdit will not be able to save it as a .txt file).
 
-3. Open Terminal and go to the folder in which you saved the `PGP.txt` file and import the public key with `sudo gpg2 --import PGP.txt`.
+3. Open Terminal and go to the folder in which you saved the `PGP.txt` file and import the PGP public key with `sudo gpg2 --import PGP.txt`.
 This should return the output: `key 856348328949861E: public key "zkSNACKs <zksnacks@gmail.com>" imported`.
-[Next time you can skip previous steps because the public key is already imported.]
+[Next time you can skip previous steps because the PGP public key is already imported.]
 
 4. [Download](https://wasabiwallet.io) the latest Wasabi release, both the `.dmg` package and the corresponding `.asc` signature file.
 


### PR DESCRIPTION
Use `PGP public key` instead of `key` or `PGP key` or `public key`.