### PR TITLE
Add tip about PGP and add data folder link

### DIFF
--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -63,10 +63,16 @@ If you have already imported zkSNACKs' PGP public key, then jump to step 7.
 
 ![](/InstallWindowsKleopatraValidSig.png)
 
+:::tip
+The output from the verify command may contain a warning that the "key is not certified with a trusted signature". 
+You can ignore this, but if you want to fully verify your download, you need to ask people you trust to confirm that the key fingerprint belongs to zkSNACKs.
+:::
+
 9. You can install Wasabi by double clicking the `.msi` and following the GUI instructions.
 
 Wasabi will be installed to your `C:\Program Files\WasabiWallet\` folder.
-You will also have an icon in your Start Menu and on your Desktop. After the first run, a working directory will be created: `%appdata%\WalletWasabi\`.
+You will also have an icon in your Start Menu and on your Desktop. 
+After the first run, a [working directory](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created. 
 Among others, here is where your wallet files and your logs reside.
 
 ### Manual PGP public key import
@@ -113,10 +119,15 @@ Verify that the fingerprint is `${zksnacksPublicKeyFingerprint}`.
 3. Verify the signature in the Download repository with `gpg --verify Wasabi-${currentVersion}.deb.asc`.
 If the message returned says `Good signature from zkSNACKs` and that it was signed with `Primary key fingerprint: ${zksnacksPublicKeyFingerprint}`, then the software was not tampered with since the developer signed it.
 
+:::tip
+The output from the verify command may contain a warning that the "key is not certified with a trusted signature". 
+You can ignore this, but if you want to fully verify your download, you need to ask people you trust to confirm that the key fingerprint belongs to zkSNACKs.
+:::
+
 4. [GUI] Install by double clicking and follow the GUI Instruction. </br>
    [CLI] In the Download repository, run the command `sudo dpkg -i Wasabi-${currentVersion}.deb`.
 
-After the first run, a working directory will be created: `~/.walletwasabi/`.
+After the first run, a [working directory](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
 Among others, here is where your wallet files and your logs reside.
 
 ## Other Linux
@@ -141,11 +152,16 @@ Verify that the fingerprint is `${zksnacksPublicKeyFingerprint}`.
 3. In the Download folder, run `gpg2 --verify Wasabi.${currentVersion}.tar.gz.asc`.
 If the message returned says `Good signature from zkSNACKs` and that it was signed with `Primary key fingerprint: ${zksnacksPublicKeyFingerprint}`, then the software was not tampered with since the developer signed it.
 
+:::tip
+The output from the verify command may contain a warning that the "key is not certified with a trusted signature". 
+You can ignore this, but if you want to fully verify your download, you need to ask people you trust to confirm that the key fingerprint belongs to zkSNACKs.
+:::
+
 4. Extract the archive while keeping the file permissions: `tar -pxzf WasabiLinux-${currentVersion}.tar.gz`.
 
 5. Run Wasabi by executing `./wassabee`.
 
-After the first run, a working directory will be created: `~/.walletwasabi/`.
+After the first run, a [working directory](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
 Among others, here is where your wallet files and your logs reside.
 
 ## OSX
@@ -172,6 +188,11 @@ This should return the output: `key 856348328949861E: public key "zkSNACKs <zksn
 5. In the Download folder, run `sudo gpg2 --verify Wasabi-${currentVersion}.dmg.asc`.
 If the message returned says `Good signature from zkSNACKs` and that it was signed with `Primary key fingerprint: ${zksnacksPublicKeyFingerprint}`, then the software was not tampered with since the developer signed it.
 
+:::tip
+The output from the verify command may contain a warning that the "key is not certified with a trusted signature". 
+You can ignore this, but if you want to fully verify your download, you need to ask people you trust to confirm that the key fingerprint belongs to zkSNACKs.
+:::
+
 6. Double click `.dmg` to open it.
 
 7. Install Wasabi by dragging it into your `Applications` folder.
@@ -185,3 +206,6 @@ Another way is to go to System Preferences / Security & Privacy, where you shoul
 Click the button and confirm by entering your Mac user password.
 
 ![](/InstallMacConfirmOpen.png)
+
+After the first run, a [working directory](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
+Among others, here is where your wallet files and your logs reside.

--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -64,7 +64,7 @@ If you have already imported zkSNACKs' PGP public key, then jump to step 7.
 ![](/InstallWindowsKleopatraValidSig.png)
 
 :::tip
-The output from the verify command may contain a warning that the "key is not certified with a trusted signature". 
+The output from the verify command may contain `WARNING: This key is not certified with a trusted signature!`.
 You can ignore this, but if you want to fully verify your download, you need to ask people you trust to confirm that the key fingerprint belongs to zkSNACKs.
 :::
 
@@ -72,7 +72,7 @@ You can ignore this, but if you want to fully verify your download, you need to 
 
 Wasabi will be installed to your `C:\Program Files\WasabiWallet\` folder.
 You will also have an icon in your Start Menu and on your Desktop. 
-After the first run, a [working directory](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created. 
+After the first run, a [data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created. 
 Among others, here is where your wallet files and your logs reside.
 
 ### Manual PGP public key import
@@ -120,14 +120,14 @@ Verify that the fingerprint is `${zksnacksPublicKeyFingerprint}`.
 If the message returned says `Good signature from zkSNACKs` and that it was signed with `Primary key fingerprint: ${zksnacksPublicKeyFingerprint}`, then the software was not tampered with since the developer signed it.
 
 :::tip
-The output from the verify command may contain a warning that the "key is not certified with a trusted signature". 
+The output from the verify command may contain `WARNING: This key is not certified with a trusted signature!`.
 You can ignore this, but if you want to fully verify your download, you need to ask people you trust to confirm that the key fingerprint belongs to zkSNACKs.
 :::
 
 4. [GUI] Install by double clicking and follow the GUI Instruction. </br>
    [CLI] In the Download repository, run the command `sudo dpkg -i Wasabi-${currentVersion}.deb`.
 
-After the first run, a [working directory](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
+After the first run, a [data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
 Among others, here is where your wallet files and your logs reside.
 
 ## Other Linux
@@ -153,7 +153,7 @@ Verify that the fingerprint is `${zksnacksPublicKeyFingerprint}`.
 If the message returned says `Good signature from zkSNACKs` and that it was signed with `Primary key fingerprint: ${zksnacksPublicKeyFingerprint}`, then the software was not tampered with since the developer signed it.
 
 :::tip
-The output from the verify command may contain a warning that the "key is not certified with a trusted signature". 
+The output from the verify command may contain `WARNING: This key is not certified with a trusted signature!`.
 You can ignore this, but if you want to fully verify your download, you need to ask people you trust to confirm that the key fingerprint belongs to zkSNACKs.
 :::
 
@@ -161,7 +161,7 @@ You can ignore this, but if you want to fully verify your download, you need to 
 
 5. Run Wasabi by executing `./wassabee`.
 
-After the first run, a [working directory](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
+After the first run, a [data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
 Among others, here is where your wallet files and your logs reside.
 
 ## OSX
@@ -189,7 +189,7 @@ This should return the output: `key 856348328949861E: public key "zkSNACKs <zksn
 If the message returned says `Good signature from zkSNACKs` and that it was signed with `Primary key fingerprint: ${zksnacksPublicKeyFingerprint}`, then the software was not tampered with since the developer signed it.
 
 :::tip
-The output from the verify command may contain a warning that the "key is not certified with a trusted signature". 
+The output from the verify command may contain `WARNING: This key is not certified with a trusted signature!`.
 You can ignore this, but if you want to fully verify your download, you need to ask people you trust to confirm that the key fingerprint belongs to zkSNACKs.
 :::
 
@@ -207,5 +207,5 @@ Click the button and confirm by entering your Mac user password.
 
 ![](/InstallMacConfirmOpen.png)
 
-After the first run, a [working directory](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
+After the first run, a [data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
 Among others, here is where your wallet files and your logs reside.


### PR DESCRIPTION
Following a recent question on telegram, this PR adds a tip about the "key is not certified with a trusted signature" warning. It's based on the [Bitcoin Core one](https://bitcoincore.org/en/download/) that you can find at the end of the verification instructions.

It also adds the relative link to the data folder FAQ, which.I think could be valuable as it includes the exact path instead of a simplification, the tip about "show hidden files", the `File > Open > Data Folder` option and could be easier to mantain. 
I also added it entirely in the OSX section, since it was the only one without it. 