### PR TITLE
Update Windows Version

### DIFF
--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -275,7 +275,7 @@ For the complete explanation please read [ZeroLink: The Bitcoin Fungibility Fram
 ### What are the minimal requirements to run Wasabi?
 
 - 64-bit architecture
-- Windows 7 or newer
+- Windows 8 or newer
 - MacOS 10.12 or newer
 - For Linux it depends on the specific OS
 


### PR DESCRIPTION
> Our dependencies are ending Windows 7 support the same day as Microsoft ends Windows 7 extended support: https://home.bt.com/tech-gadgets/computing/windows-7/windows-7-support-end-11364081315419
> 
> So we have no choice but to end the support in January 14, 2020, too. Considering this, fixing this issue could be a waste of time. Sorry about it.