### PR TITLE
[USING] Move Change FAQ to separate chapter

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -152,6 +152,7 @@ module.exports = {
           sidebarDepth: 2,
           children: [
             "/using-wasabi/AddressReuse.md",
+            "/using-wasabi/ChangeCoins.md",
             "/using-wasabi/LostPassword.md",
             "/using-wasabi/NetworkLevelPrivacy.md",
             "/using-wasabi/Deanonimization.md",

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1222,7 +1222,7 @@ You can spend the change to the same entity as the initial transaction, without 
 Only spend the change to another entity, if these two won't make you trouble knowing you interact with both of them.
 If needed, you can consolidate several change coins, but we advise you to do it in a CoinJoin.
 In JoinMarket you can specify the exact amount of CoinJoin, so it can be exactly the amount of the change.
-Or open a new Lightning Network node, create a channel and route the funds back to you.
+Or open a new Lightning Network node (not your main Lightning node), create a channel to a random peer on the network and route the funds back to you.
 
 :::tip
 For more information, see this [dedicated chapter](/using-wasabi/ChangeCoins.md).

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1222,7 +1222,7 @@ You can spend the change to the same entity as the initial transaction, without 
 Only spend the change to another entity, if these two won't make you trouble knowing you interact with both of them.
 If needed, you can consolidate several change coins, but we advise you to do it in a CoinJoin.
 In Joinmarket you can join mixes worth exactly the amount of the change.
-Or open a new lightning network node and channel and route the funds back to you.
+Or open a new Lightning Network node, create a channel and route the funds back to you.
 
 :::tip
 For more information, see this [dedicated chapter](/using-wasabi/ChangeCoins.md).

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1220,7 +1220,7 @@ Generally try to avoid the change and use the `Max` button extensively to send w
 The most problematic type of change is what has `anonymity set 1` [red shield] You should treat it as a kind of toxic waste [handled with great care].
 You can spend the change to the same entity as the initial transaction, without loosing any privacy.
 Only spend the change to another entity, if these two won't make you trouble knowing you interact with both of them.
-If you need to, you can consolidate several change coins, but it is more private to do in a CoinJoin directly.
+If needed, you can consolidate several change coins, but we advise you to do it in a CoinJoin.
 In Joinmarket you can buy mixes worth exactly the amount of the change.
 Or open a new lightning network node and channel and route the funds back to you.
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1225,7 +1225,7 @@ In Joinmarket you can buy mixes worth exactly the amount of the change.
 Or open a new lightning network node and channel and route the funds back to you.
 
 :::tip
-For more information, see this [dedicated chapter](/using-wasabi/ChangeCoins.md/).
+For more information, see this [dedicated chapter](/using-wasabi/ChangeCoins.md).
 :::
 ::::
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1221,7 +1221,7 @@ The most problematic type of change is what has `anonymity set 1` [red shield] Y
 You can spend the change to the same entity as the initial transaction, without loosing any privacy.
 Only spend the change to another entity, if these two won't make you trouble knowing you interact with both of them.
 If needed, you can consolidate several change coins, but we advise you to do it in a CoinJoin.
-In Joinmarket you can join mixes worth exactly the amount of the change.
+In JoinMarket you can specify the exact amount of CoinJoin, so it can be exactly the amount of the change.
 Or open a new Lightning Network node, create a channel and route the funds back to you.
 
 :::tip

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1221,7 +1221,7 @@ The most problematic type of change is what has `anonymity set 1` [red shield] Y
 You can spend the change to the same entity as the initial transaction, without loosing any privacy.
 Only spend the change to another entity, if these two won't make you trouble knowing you interact with both of them.
 If needed, you can consolidate several change coins, but we advise you to do it in a CoinJoin.
-In Joinmarket you can buy mixes worth exactly the amount of the change.
+In Joinmarket you can join mixes worth exactly the amount of the change.
 Or open a new lightning network node and channel and route the funds back to you.
 
 :::tip

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1212,81 +1212,22 @@ You can, however, manage your hardware wallet with the Wasabi interface.
 Alternatively, you can use your hardware wallet with Electrum, which connects to your Bitcoin Core full node through [Electrum Personal Server](https://github.com/chris-belcher/electrum-personal-server), [ElectrumX](https://github.com/kyuupichan/electrumx) or [Electrs](https://github.com/romanz/electrs).
 :::
 
-:::details
+::::details
 ### What can I do with small change?
 
 There are no hard and fast rules for what to do with the change.
 Generally try to avoid the change and use the `Max` button extensively to send whole coins.
 The most problematic type of change is what has `anonymity set 1` [red shield] You should treat it as a kind of toxic waste [handled with great care].
+You can spend the change to the same entity as the initial transaction, without loosing any privacy.
+Only spend the change to another entity, if these two won't make you trouble knowing you interact with both of them.
+If you need to, you can consolidate several change coins, but it is more private to do in a CoinJoin directly.
+In Joinmarket you can buy mixes worth exactly the amount of the change.
+Or open a new lightning network node and channel and route the funds back to you.
 
-#### Warning
-
-You want to avoid merging `anonymity set 1 coins` with `anonymity set > 1 coins` wherever possible, because this will link your `anonymity set > 1 coin` to the coin you merge it with.
-Note that, this is also true if you merge them in a mix, however that is slightly less problematic, because some blockchain analysis techniques become [computationally infeasible](https://www.comsys.rwth-aachen.de/fileadmin/papers/2017/2017-maurer-trustcom-coinjoin.pdf).
-
-It is also important that you do not send different coins to the same receiving address (even if performed as separate transactions) as this will also link the coins together, damaging your privacy.
-
-There are two different types of zero link change:
-
-When you have a KYC coin with red anonset 1 and you register it for CoinJoin, then you get one anonset 100 green coin and one red anonset 1 change.
-This change is very clearly tied to your KYC input coin, but the CoinJoin output is pretty good with anonset 100.
-If you combine that red coin with the green, then it's clear that both of them belong to you, and thus the anonset of the output in this transaction becomes the lowest common denominator, in this case anonset 1.
-
-When you take a 100 anonset coin, and you register it again for CoinJoin, then you get one coin with anonset 200, and one change with anonset 100.
-This change has anonset 100 because it can be linked to the input of the second CoinJoin, but this coin has anonset 100 already.
-This change can still reveal premix history which is another CoinJoin, therefore you cannot go further back.
-So, it might be ok to send this second change output to some place, or even consolidate it, because it still has anonset.
-
-When you consolidate several small change coins in a regular transaction, then every outside observer knows that they belong to the same cluster.
-However, you can consolidate within a CoinJoin by simply selecting all these coins in the `CoinJoin` tab.
-Because the Wasabi CoinJoin transaction shuffles inputs, for an outside observer it is not clear which inputs belong to the same Alice.
-However, the coordinator gets the input proof of **ALL** the coins that Alice has provided during the input registration phase.
-Thus the coordinator knows that this is a consolidation transaction.
-It is wise to assume that every one knows what the coordinator knows.
-So consolidating in a CoinJoin is better, but it might still reveal the common ownership of the coins.
-
-#### Your Options
-
-#### Avoid change in the first place.
-Whenever possible, send transactions where the destination addresses receive the entire value, and you don't get any change back.
-This can easily be done by clicking the `Max` button in the `Send` tab, which will automatically deduct the mining fee and send the highest amount possible to the destination.
-This might not be possible in some cases where you have to pay a specific value of a payment request.
-However, in other cases it is possible, for example donations or when depositing to an exchange.
-Consider supporting invaluable projects like [the tor project](https://donate.torproject.org/cryptocurrency) or [the electronic frontier foundation](https://supporters.eff.org/donate/donate), you can find a list of organizations that accept bitcoin donations [here](https://en.bitcoin.it/wiki/Donation-accepting_organizations_and_projects).
-
-#### Spend the change to the same entity as the initial transaction, but always use a new address.
-So if in the first transaction you have 0.1 bitcoin and send Alice 0.04 bitcoin, you get 0.06 bitcoin back as change.
-Now in the second transaction where you want to send Alice 0.05 bitcoin, you can select that 0.06 bitcoin change coin without loosing any privacy, because Alice already knows this is your coin.
-In this second transaction you will get back 0.01 bitcoin as change.
-If in a third transaction you want to send Alice 0.02 bitcoin, then you can consolidate the 0.01 bitcoin change with a new 0.1 bitcoin mixed coin, thus getting 0.09 bitcoin change.
-Now Alice will know that you owned that 0.1 bitcoin and the 0.09 bitcoin change, but she cannot find out about your premix transaction history.
-
-#### Spend the change to another entity, if these two won't make you trouble knowing you interact with both of them.
-For example when with a 0.1 bitcoin mixed coin you buy coffee from Alice for 0.01 bitcoin, you get back 0.09 bitcoin change that Alice knows is yours.
-If in the next transaction you spend the 0.09 bitcoin change in the pizza restaurant of Bob, then Alice might find out that you go to Bob's restaurant, and if she doesn't like that, then she can refuse to serve you coffee the next time, or even worse.
-But if instead you spend the 0.09 bitcoin change in a transaction to Carol, a good friend of Alice, then Alice might not care and will still give you coffee for the next round.
-
-#### Consolidate several change coins, but in a CoinJoin directly.
-If you would consolidate many change coins in a regular non-CoinJoin transaction in the `Send` tab, then any outside observer can easily see that one user controls all these coins.
-Because there are hundreds of randomly ordered inputs in a Wasabi CoinJoin transaction, it is no longer easy to find out which coins belong to one single user.
-However, during the [input registration phase](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-input-registration-phase), your wallet provides an input proof for all the registered coins to the coordinator.
-Thus the coordinator knows that you control all these coins, and although zkSNACKs claims to not keep any logs, it is a reasonable assumption that everyone knows what the coordinator knows.
-In this CoinJoin you get an equal value mixed coin, which is no longer tied to any of your change coins, and a change output that can be tied to these inputs.
-So consolidating your change in a CoinJoin is strictly better than consolidating in a regular sending transaction, but it still leaks sensitive information to the coordinator.
-
-#### Mix with Joinmarket.
-In [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver) as a market taker you can specify exactly what denomination of equal value outputs are generated in the CoinJoin.
-So you can send the Wasabi change to your Joinmarket wallet and take an offer to mix for some rounds.
-The coin you will receive after the tumbling algorithm can have sufficient anonymity set, and you can use it for spending again.
-
-#### Open a lightning network channel.
-The lightning network can be a very private way of sending bitcoin, and you can choose the channel size to be exactly the size of your change coin.
-However, it is very important that you do not link this non-private coin to your main lightning node public key.
-So a good strategy is to create a new lightning node and public key, send the whole change coin into this fresh wallet, and open a channel of this amount to a random peer on the network.
-Then route a payment either to a merchant for goods and services, or to your own main lightning node for further use.
-After the balance of the channel is entirely on the other side, cooperatively close the channel with your peer, so that he gets the only output in the closing transaction.
-Since Wasabi does not yet support lightning network functionality, you must use a different wallet for this task.
+:::tip
+For more information, see this [dedicated chapter](/using-wasabi/ChangeCoins.md/).
 :::
+::::
 
 :::details
 ### How can I mix large amounts?

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -75,7 +75,7 @@ After the balance of the channel is entirely on the other side, cooperatively cl
 Since Wasabi does not yet support Lightning Network functionality, you must use a different wallet for this task.
 
 ### Atomic swap into Lightning Network
-There are some services who provide an atomic swap where you send the whole change coin to a multisignature hashed time locked contract on-chain.
+There are some services that provide an atomic swap where you send the whole change coin to a multisignature hashed time locked contract on-chain.
 In exchange you receive a payment routed through the Lightning Network into one of your payment channels.
 The swap is atomic, meaning either you receive the lightning payment, or you get the bitcoin back on-chain, so the service provider cannot steal from you.
 If you use a regular lightning invoice to receive the funds, then the service provider knows your node public key and the channel he sends the bitcoin to.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -37,7 +37,7 @@ So, it is ok to send this change output to some place, or even consolidate it, b
 
 Change is not inherently bad, it's a fundamental part of how Bitcoin and the UTXO model works.
 However, when spending a change coin, then the receiver can easily deduce that the sender was also part of the previous transaction that generated the change.
-You want to avoid merging `anonymity set 1 coins` with `anonymity set > 1 coins` wherever possible, because this will link your `anonymity set > 1 coin` to the coin you merge it with.
+You want to avoid merging `anonymity set 1` coin with `anonymity set > 1` coin whenever possible, because this will link your `anonymity set > 1` coin to the coin you merge it with.
 
 ## Your options to use change privately
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -9,35 +9,37 @@
 
 [[toc]]
 
-## Why change is an issue
-
-You want to avoid merging `anonymity set 1 coins` with `anonymity set > 1 coins` wherever possible, because this will link your `anonymity set > 1 coin` to the coin you merge it with.
-Note that, this is also true if you merge them in a mix, however that is slightly less problematic, because some blockchain analysis techniques become [computationally infeasible](https://www.comsys.rwth-aachen.de/fileadmin/papers/2017/2017-maurer-trustcom-coinjoin.pdf).
-
-It is also important that you do not send different coins to the same receiving address (even if performed as separate transactions) as this will also link the coins together, damaging your privacy.
 
 ## Types of change
 
-There are two different types of zero link change:
+### Non CoinJoin change
+
+When you want to buy some coffee from Alice, then in the `Send` tab you select one or more of your own coins, and they are the input of the transaction, for example one redshield `anonymity set 1` coin worth 2 bitcoin.
+You put Alice's address in the `Receiving Address` field, and set the spending `Amount`, for example 0.5 bitcoin, this will make the first output of the transaction.
+The left over amount of 1.5 bitcoin will automatically go back to an address of you, and this is the change output.
+This change coin can easily be tied to the input of the transaction, and thus also has `anonymity set 1`.
+So when you send this change coin in a next transaction, this receiver knows that you were part of the transaction to Alice.
+
+### First round CoinJoin change
 
 When you have a KYC coin with red anonset 1 and you register it for CoinJoin, then you get one anonset 100 green coin and one red anonset 1 change.
 This change is very clearly tied to your KYC input coin, but the CoinJoin output is pretty good with anonset 100.
 If you combine that red coin with the green, then it's clear that both of them belong to you, and thus the anonset of the output in this transaction becomes the lowest common denominator, in this case anonset 1.
+
+### Second round CoinJoin change
 
 When you take a 100 anonset coin, and you register it again for CoinJoin, then you get one coin with anonset 200, and one change with anonset 100.
 This change has anonset 100 because it can be linked to the input of the second CoinJoin, but this coin has anonset 100 already.
 This change can still reveal premix history which is another CoinJoin, therefore you cannot go further back.
 So, it might be ok to send this second change output to some place, or even consolidate it, because it still has anonset.
 
-When you consolidate several small change coins in a regular transaction, then every outside observer knows that they belong to the same cluster.
-However, you can consolidate within a CoinJoin by simply selecting all these coins in the `CoinJoin` tab.
-Because the Wasabi CoinJoin transaction shuffles inputs, for an outside observer it is not clear which inputs belong to the same Alice.
-However, the coordinator gets the input proof of **ALL** the coins that Alice has provided during the input registration phase.
-Thus the coordinator knows that this is a consolidation transaction.
-It is wise to assume that every one knows what the coordinator knows.
-So consolidating in a CoinJoin is better, but it might still reveal the common ownership of the coins.
+## Why change is an issue
 
-## Your options
+Change is not inherently bad, it's a fundamental part of how Bitcoin and the UTXO model works.
+However, when spending a change coin, then the receiver can easily deduce that the sender was also part of the previous transaction that generated the change.
+You want to avoid merging `anonymity set 1 coins` with `anonymity set > 1 coins` wherever possible, because this will link your `anonymity set > 1 coin` to the coin you merge it with.
+
+## Your options to use change privately
 
 ### Avoid change in the first place.
 Whenever possible, send transactions where the destination addresses receive the entire value, and you don't get any change back.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -37,7 +37,8 @@ So, it is ok to send this change output to some place, or even consolidate it, b
 
 Change is not inherently bad, it's a fundamental part of how Bitcoin and the UTXO model works.
 However, when spending a change coin, then the receiver can easily deduce that the sender was also part of the previous transaction that generated the change.
-You want to avoid merging `anonymity set 1` coin with `anonymity set > 1` coin whenever possible, because this will link your `anonymity set > 1` coin to the coin you merge it with.
+When ever you are merging coins in one transaction, it becomes clear to any outside observer that these coins belong to the same entity, thus linking the previous transaction history.
+You want to avoid merging `anonymity set 1` coin with `anonymity set > 1` mixed coin whenever possible, because this will link these coins and negate the privacy gained through the CoinJoin.
 
 ## Your options to use change privately
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -80,4 +80,4 @@ However, a well resourced attacker can perform [CoinJoin sudoku](/FAQ/FAQ-Genera
 Further, during the [input registration phase](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-input-registration-phase), your wallet provides an input proof for all the registered coins to the coordinator.
 Thus the coordinator knows that you control all these coins, and although zkSNACKs claims to not keep any logs, it is a reasonable assumption that everyone knows what the coordinator knows.
 In this CoinJoin you get an equal value mixed coin, which is no longer tied to any of your change coins, and a change output that can be tied to these inputs.
-So consolidating your change in a CoinJoin is strictly more private and efficient than consolidating in a regular sending transaction, but it still leaks sensitive information to the coordinator.
+So consolidating your change in a CoinJoin is strictly more private and efficient than consolidating in a regular sending transaction, but it still leaks sensitive information.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -38,7 +38,7 @@ So, it is ok to send this change output to some place, or even consolidate it, b
 Change is not inherently bad, it's a fundamental part of how Bitcoin and the UTXO model works.
 However, when spending a change coin, then the receiver can easily deduce that the sender was also part of the previous transaction that generated the change.
 Whenever you are merging coins in one transaction, it becomes clear to any outside observer that these coins belong to the same entity, thus linking the previous transaction history.
-You want to avoid merging `anonymity set 1` coin with `anonymity set > 1` mixed coin whenever possible, because this will link these coins and negate the privacy gained through the CoinJoin.
+You want to avoid merging `anonymity set 1` coins with `anonymity set > 1` mixed coins whenever possible, because this will link these coins and negate the privacy of the mixed coins gained through the CoinJoin.
 
 ## Your options to use change privately
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -53,7 +53,7 @@ So if in the first transaction you have 0.1 bitcoin and send Alice 0.04 bitcoin,
 Now in the second transaction where you want to send Alice 0.05 bitcoin, you can select that 0.06 bitcoin change coin without loosing any privacy, because Alice already knows this is your coin.
 In this second transaction you will get back 0.01 bitcoin as change.
 If in a third transaction you want to send Alice 0.02 bitcoin, then you can consolidate the 0.01 bitcoin change with a new 0.1 bitcoin mixed coin, thus getting 0.09 bitcoin change.
-Now Alice will know that you owned that 0.1 bitcoin and the 0.09 bitcoin change, but she cannot find out about your premix transaction history.
+Now Alice knows that you owned the 0.1 bitcoin and and that you currently own the 0.09 bitcoin change, but she cannot find out about your premix transaction history.
 
 ### Spend the change to another entity, if these two won't make you trouble knowing you interact with both of them.
 For example when with a 0.1 bitcoin mixed coin you buy coffee from Alice for 0.01 bitcoin, you get back 0.09 bitcoin change that Alice knows is yours.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -31,7 +31,7 @@ If you combine the red coin with the green one in a transaction, then it's clear
 When you take a 100 anonset coin, and you register it again for CoinJoin, then you get one coin with anonset 200, and one change with anonset 100.
 This change still has anonset 100 because it is the change output of a second CoinJoin that used a 100 anonset coin as input.
 This change can still reveal premix history which is another CoinJoin, therefore you cannot go further back.
-So, it might be ok to send this second change output to some place, or even consolidate it, because it still has anonset.
+So, it is ok to send this change output to some place, or even consolidate it, because it still has anonset 100.
 
 ## Why change is an issue
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -24,7 +24,7 @@ So when you send this change coin in a new transaction, the receiver knows that 
 
 When you have a KYC red shield `anonymity set 1` coin and you register it for CoinJoin, you get one green coin `anonymity set 100` and one red shield `anonymity set 1` change coin.
 This change is clearly tied to your KYC input coin, but the green coin is not.
-If you combine that red coin with the green, then it's clear that both of them belong to you, and thus the anonset of the output in this transaction becomes the lowest common denominator, in this case anonset 1.
+If you combine the red coin with the green one in a transaction, then it's clear that both of them belong to you, and thus the anonset of the output in this transaction becomes the lowest common denominator, in this case anonset 1.
 
 ### Second round CoinJoin change
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -14,7 +14,7 @@
 
 ### Non CoinJoin change
 
-When you want to buy some coffee from Alice, then in the `Send` tab you select one or more of your own coins, and they are the input of the transaction, for example one redshield `anonymity set 1` coin worth 2 bitcoin.
+When you want to buy some coffee from Alice, then in the `Send` tab you select one or more of your own coins, and they are the input of the transaction, for example one red shield `anonymity set 1` coin worth 2 bitcoin.
 You put Alice's address in the `Receiving Address` field, and set the spending `Amount`, for example 0.5 bitcoin, this will make the first output of the transaction.
 The left over amount of 1.5 bitcoin will automatically go back to an address of you, and this is the change output.
 This change coin can easily be tied to the input of the transaction, and thus also has `anonymity set 1`.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -63,10 +63,11 @@ But if instead you spend the 0.09 bitcoin change in a transaction to Carol, a go
 ### Consolidate several change coins, but in a CoinJoin directly.
 If you would consolidate many change coins in a regular non-CoinJoin transaction in the `Send` tab, then any outside observer can easily see that one user controls all these coins.
 Because there are hundreds of randomly ordered inputs in a Wasabi CoinJoin transaction, it is no longer easy to find out which coins belong to one single user.
-However, during the [input registration phase](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-input-registration-phase), your wallet provides an input proof for all the registered coins to the coordinator.
+However, a well resourced attacker can perform [CoinJoin sudoku](/FAQ/FAQ-GeneralBitcoinPrivacy.md#what-is-a-coinjoin-sudoku) to find out which several inputs fund the change output.
+Further, during the [input registration phase](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-input-registration-phase), your wallet provides an input proof for all the registered coins to the coordinator.
 Thus the coordinator knows that you control all these coins, and although zkSNACKs claims to not keep any logs, it is a reasonable assumption that everyone knows what the coordinator knows.
 In this CoinJoin you get an equal value mixed coin, which is no longer tied to any of your change coins, and a change output that can be tied to these inputs.
-So consolidating your change in a CoinJoin is strictly better than consolidating in a regular sending transaction, but it still leaks sensitive information to the coordinator.
+So consolidating your change in a CoinJoin is strictly more private and efficient than consolidating in a regular sending transaction, but it still leaks sensitive information to the coordinator.
 
 ### Mix with Joinmarket.
 In [JoinMarket](https://github.com/JoinMarket-Org/joinmarket-clientserver) as a market taker you can specify exactly what denomination of equal value outputs are generated in the CoinJoin.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -60,15 +60,6 @@ For example when you buy coffee with a 0.1 bitcoin mixed coin from Alice for 0.0
 If in the next transaction you spend the 0.09 bitcoin change in the pizza restaurant of Bob, then Alice might find out that you go to Bob's restaurant, and if she doesn't like that, then she can refuse to serve you coffee the next time, or even worse.
 But if instead you spend the 0.09 bitcoin change in a transaction to Carol, a good friend of Alice, then Alice might not care and will still give you coffee for the next round.
 
-### Consolidate several change coins, but in a CoinJoin directly.
-If you would consolidate many change coins in a regular non-CoinJoin transaction in the `Send` tab, then any outside observer can easily see that one user controls all these coins.
-Because there are hundreds of randomly ordered inputs in a Wasabi CoinJoin transaction, it is no longer easy to find out which coins belong to one single user.
-However, a well resourced attacker can perform [CoinJoin sudoku](/FAQ/FAQ-GeneralBitcoinPrivacy.md#what-is-a-coinjoin-sudoku) to find out which several inputs fund the change output.
-Further, during the [input registration phase](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-input-registration-phase), your wallet provides an input proof for all the registered coins to the coordinator.
-Thus the coordinator knows that you control all these coins, and although zkSNACKs claims to not keep any logs, it is a reasonable assumption that everyone knows what the coordinator knows.
-In this CoinJoin you get an equal value mixed coin, which is no longer tied to any of your change coins, and a change output that can be tied to these inputs.
-So consolidating your change in a CoinJoin is strictly more private and efficient than consolidating in a regular sending transaction, but it still leaks sensitive information to the coordinator.
-
 ### Mix with Joinmarket.
 In [JoinMarket](https://github.com/JoinMarket-Org/joinmarket-clientserver) as a market taker you can specify exactly what denomination of equal value outputs are generated in the CoinJoin.
 So you can send the Wasabi change to your JoinMarket wallet and take an offer to mix for some rounds.
@@ -81,3 +72,12 @@ So a good strategy is to create a new lightning node and public key, send the wh
 Then route a payment either to a merchant for goods and services, or to your own main Lightning node for further use.
 After the balance of the channel is entirely on the other side, cooperatively close the channel with your peer, so that he gets the only output in the closing transaction.
 Since Wasabi does not yet support Lightning Network functionality, you must use a different wallet for this task.
+
+### Consolidate several change coins, but in a CoinJoin directly.
+If you would consolidate many change coins in a regular non-CoinJoin transaction in the `Send` tab, then any outside observer can easily see that one user controls all these coins.
+But when consolidating in a CoinJoin directly, because there are hundreds of randomly ordered inputs in a Wasabi CoinJoin transaction, it is no longer easy to find out which coins belong to one single user.
+However, a well resourced attacker can perform [CoinJoin sudoku](/FAQ/FAQ-GeneralBitcoinPrivacy.md#what-is-a-coinjoin-sudoku) to find out which several inputs fund the change output.
+Further, during the [input registration phase](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-input-registration-phase), your wallet provides an input proof for all the registered coins to the coordinator.
+Thus the coordinator knows that you control all these coins, and although zkSNACKs claims to not keep any logs, it is a reasonable assumption that everyone knows what the coordinator knows.
+In this CoinJoin you get an equal value mixed coin, which is no longer tied to any of your change coins, and a change output that can be tied to these inputs.
+So consolidating your change in a CoinJoin is strictly more private and efficient than consolidating in a regular sending transaction, but it still leaks sensitive information to the coordinator.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -37,7 +37,7 @@ So, it is ok to send this change output to some place, or even consolidate it, b
 
 Change is not inherently bad, it's a fundamental part of how Bitcoin and the UTXO model works.
 However, when spending a change coin, then the receiver can easily deduce that the sender was also part of the previous transaction that generated the change.
-When ever you are merging coins in one transaction, it becomes clear to any outside observer that these coins belong to the same entity, thus linking the previous transaction history.
+Whenever you are merging coins in one transaction, it becomes clear to any outside observer that these coins belong to the same entity, thus linking the previous transaction history.
 You want to avoid merging `anonymity set 1` coin with `anonymity set > 1` mixed coin whenever possible, because this will link these coins and negate the privacy gained through the CoinJoin.
 
 ## Your options to use change privately

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -17,7 +17,7 @@
 When you want to buy some coffee from Alice, then in the `Send` tab you select one or more of your own coins, and they are the input of the transaction, for example one red shield `anonymity set 1` coin worth 2 bitcoin.
 You put Alice's address in the `Receiving Address` field, and set the spending `Amount`, for example 0.5 bitcoin, this will be the first output of the transaction.
 The left over amount of 1.5 bitcoin will automatically go to a new address that you control, and this is the change output.
-This change coin can easily be tied to the input of the transaction, and thus also has `anonymity set 1`.
+This change coin is tied to the input of the transaction, and thus also has `anonymity set 1`.
 So when you send this change coin in a new transaction, the receiver knows that you were part of the transaction to Alice.
 
 ### First round CoinJoin change

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -79,5 +79,5 @@ But when consolidating in a CoinJoin directly, because there are hundreds of ran
 However, a well resourced attacker can perform [CoinJoin sudoku](/FAQ/FAQ-GeneralBitcoinPrivacy.md#what-is-a-coinjoin-sudoku) to find out which several inputs fund the change output.
 Further, during the [input registration phase](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-input-registration-phase), your wallet provides an input proof for all the registered coins to the coordinator.
 Thus the coordinator knows that you control all these coins, and although zkSNACKs claims to not keep any logs, it is a reasonable assumption that everyone knows what the coordinator knows.
-In this CoinJoin you get an equal value mixed coin, which is no longer tied to any of your change coins, and a change output that can be tied to these inputs.
+In this CoinJoin you get an equal value mixed coin, which is no longer tied to any of your previous change coins (inputs), and a change output that can be tied to these inputs.
 So consolidating your change in a CoinJoin is strictly more private and efficient than consolidating in a regular sending transaction, but it still leaks sensitive information.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -75,7 +75,7 @@ The coin you will receive after the tumbling algorithm can have sufficient anony
 
 ### Open a Lightning Network channel.
 The Lightning Network can be a very private way of sending bitcoin, and you can choose the channel size to be exactly the size of your change coin.
-However, it is very important that you do not link this non-private coin to your main lightning node public key.
+However, it is very important that you do not link this non-private coin to your main Lightning node public key.
 So a good strategy is to create a new lightning node and public key, send the whole change coin into this fresh wallet, and open a channel of this amount to a random peer on the network.
 Then route a payment either to a merchant for goods and services, or to your own main lightning node for further use.
 After the balance of the channel is entirely on the other side, cooperatively close the channel with your peer, so that he gets the only output in the closing transaction.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -1,0 +1,81 @@
+---
+{
+  "title": "Change Coins",
+  "description": "Details about the privacy of different types of change and strategies how to use them. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+}
+---
+
+# Change coins
+
+[[toc]]
+
+## Why change is an issue
+
+You want to avoid merging `anonymity set 1 coins` with `anonymity set > 1 coins` wherever possible, because this will link your `anonymity set > 1 coin` to the coin you merge it with.
+Note that, this is also true if you merge them in a mix, however that is slightly less problematic, because some blockchain analysis techniques become [computationally infeasible](https://www.comsys.rwth-aachen.de/fileadmin/papers/2017/2017-maurer-trustcom-coinjoin.pdf).
+
+It is also important that you do not send different coins to the same receiving address (even if performed as separate transactions) as this will also link the coins together, damaging your privacy.
+
+## Types of change
+
+There are two different types of zero link change:
+
+When you have a KYC coin with red anonset 1 and you register it for CoinJoin, then you get one anonset 100 green coin and one red anonset 1 change.
+This change is very clearly tied to your KYC input coin, but the CoinJoin output is pretty good with anonset 100.
+If you combine that red coin with the green, then it's clear that both of them belong to you, and thus the anonset of the output in this transaction becomes the lowest common denominator, in this case anonset 1.
+
+When you take a 100 anonset coin, and you register it again for CoinJoin, then you get one coin with anonset 200, and one change with anonset 100.
+This change has anonset 100 because it can be linked to the input of the second CoinJoin, but this coin has anonset 100 already.
+This change can still reveal premix history which is another CoinJoin, therefore you cannot go further back.
+So, it might be ok to send this second change output to some place, or even consolidate it, because it still has anonset.
+
+When you consolidate several small change coins in a regular transaction, then every outside observer knows that they belong to the same cluster.
+However, you can consolidate within a CoinJoin by simply selecting all these coins in the `CoinJoin` tab.
+Because the Wasabi CoinJoin transaction shuffles inputs, for an outside observer it is not clear which inputs belong to the same Alice.
+However, the coordinator gets the input proof of **ALL** the coins that Alice has provided during the input registration phase.
+Thus the coordinator knows that this is a consolidation transaction.
+It is wise to assume that every one knows what the coordinator knows.
+So consolidating in a CoinJoin is better, but it might still reveal the common ownership of the coins.
+
+## Your options
+
+### Avoid change in the first place.
+Whenever possible, send transactions where the destination addresses receive the entire value, and you don't get any change back.
+This can easily be done by clicking the `Max` button in the `Send` tab, which will automatically deduct the mining fee and send the highest amount possible to the destination.
+This might not be possible in some cases where you have to pay a specific value of a payment request.
+However, in other cases it is possible, for example donations or when depositing to an exchange.
+Consider supporting invaluable projects like [the tor project](https://donate.torproject.org/cryptocurrency) or [the electronic frontier foundation](https://supporters.eff.org/donate/donate), you can find a list of organizations that accept bitcoin donations [here](https://en.bitcoin.it/wiki/Donation-accepting_organizations_and_projects).
+
+### Spend the change to the same entity as the initial transaction, but always use a new address.
+So if in the first transaction you have 0.1 bitcoin and send Alice 0.04 bitcoin, you get 0.06 bitcoin back as change.
+Now in the second transaction where you want to send Alice 0.05 bitcoin, you can select that 0.06 bitcoin change coin without loosing any privacy, because Alice already knows this is your coin.
+In this second transaction you will get back 0.01 bitcoin as change.
+If in a third transaction you want to send Alice 0.02 bitcoin, then you can consolidate the 0.01 bitcoin change with a new 0.1 bitcoin mixed coin, thus getting 0.09 bitcoin change.
+Now Alice will know that you owned that 0.1 bitcoin and the 0.09 bitcoin change, but she cannot find out about your premix transaction history.
+
+### Spend the change to another entity, if these two won't make you trouble knowing you interact with both of them.
+For example when with a 0.1 bitcoin mixed coin you buy coffee from Alice for 0.01 bitcoin, you get back 0.09 bitcoin change that Alice knows is yours.
+If in the next transaction you spend the 0.09 bitcoin change in the pizza restaurant of Bob, then Alice might find out that you go to Bob's restaurant, and if she doesn't like that, then she can refuse to serve you coffee the next time, or even worse.
+But if instead you spend the 0.09 bitcoin change in a transaction to Carol, a good friend of Alice, then Alice might not care and will still give you coffee for the next round.
+
+### Consolidate several change coins, but in a CoinJoin directly.
+If you would consolidate many change coins in a regular non-CoinJoin transaction in the `Send` tab, then any outside observer can easily see that one user controls all these coins.
+Because there are hundreds of randomly ordered inputs in a Wasabi CoinJoin transaction, it is no longer easy to find out which coins belong to one single user.
+However, during the [input registration phase](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-input-registration-phase), your wallet provides an input proof for all the registered coins to the coordinator.
+Thus the coordinator knows that you control all these coins, and although zkSNACKs claims to not keep any logs, it is a reasonable assumption that everyone knows what the coordinator knows.
+In this CoinJoin you get an equal value mixed coin, which is no longer tied to any of your change coins, and a change output that can be tied to these inputs.
+So consolidating your change in a CoinJoin is strictly better than consolidating in a regular sending transaction, but it still leaks sensitive information to the coordinator.
+
+### Mix with Joinmarket.
+In [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver) as a market taker you can specify exactly what denomination of equal value outputs are generated in the CoinJoin.
+So you can send the Wasabi change to your Joinmarket wallet and take an offer to mix for some rounds.
+The coin you will receive after the tumbling algorithm can have sufficient anonymity set, and you can use it for spending again.
+
+### Open a lightning network channel.
+The lightning network can be a very private way of sending bitcoin, and you can choose the channel size to be exactly the size of your change coin.
+However, it is very important that you do not link this non-private coin to your main lightning node public key.
+So a good strategy is to create a new lightning node and public key, send the whole change coin into this fresh wallet, and open a channel of this amount to a random peer on the network.
+Then route a payment either to a merchant for goods and services, or to your own main lightning node for further use.
+After the balance of the channel is entirely on the other side, cooperatively close the channel with your peer, so that he gets the only output in the closing transaction.
+Since Wasabi does not yet support lightning network functionality, you must use a different wallet for this task.
+

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -73,6 +73,14 @@ Then route a payment either to a merchant for goods and services, or to your own
 After the balance of the channel is entirely on the other side, cooperatively close the channel with your peer, so that he gets the only output in the closing transaction.
 Since Wasabi does not yet support Lightning Network functionality, you must use a different wallet for this task.
 
+### Atomic swap into Lightning Network
+There are some services who provide an atomic swap where you send the whole change coin to a multisignature hashed time locked contract on-chain.
+In exchange you receive a payment routed through the Lightning Network into one of your payment channels.
+The swap is atomic, meaning either you receive the lightning payment, or you get the bitcoin back on-chain, so the service provider cannot steal from you.
+If you use a regular lightning invoice to receive the funds, then the service provider knows your node public key and the channel he sends the bitcoin to.
+For much superior privacy, use rendezvous routing so that the sender does not gain knowledge of your receiving node.
+Also ensure that the communication with the swap server is done over the tor network.
+
 ### Consolidate several change coins, but in a CoinJoin directly.
 If you would consolidate many change coins in a regular non-CoinJoin transaction in the `Send` tab, then any outside observer can easily see that one user controls all these coins.
 But when consolidating in a CoinJoin directly, because there are hundreds of randomly ordered inputs in a Wasabi CoinJoin transaction, it is no longer easy to find out which coins belong to one single user.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -79,4 +79,4 @@ However, it is very important that you do not link this non-private coin to your
 So a good strategy is to create a new lightning node and public key, send the whole change coin into this fresh wallet, and open a channel of this amount to a random peer on the network.
 Then route a payment either to a merchant for goods and services, or to your own main Lightning node for further use.
 After the balance of the channel is entirely on the other side, cooperatively close the channel with your peer, so that he gets the only output in the closing transaction.
-Since Wasabi does not yet support lightning network functionality, you must use a different wallet for this task.
+Since Wasabi does not yet support Lightning Network functionality, you must use a different wallet for this task.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -29,7 +29,7 @@ If you combine the red coin with the green one in a transaction, then it's clear
 ### Second round CoinJoin change
 
 When you take a 100 anonset coin, and you register it again for CoinJoin, then you get one coin with anonset 200, and one change with anonset 100.
-This change has anonset 100 because it can be linked to the input of the second CoinJoin, but this coin has anonset 100 already.
+This change still has anonset 100 because it is the change output of a second CoinJoin that used a 100 anonset coin as input.
 This change can still reveal premix history which is another CoinJoin, therefore you cannot go further back.
 So, it might be ok to send this second change output to some place, or even consolidate it, because it still has anonset.
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -77,6 +77,6 @@ The coin you will receive after the tumbling algorithm can have sufficient anony
 The Lightning Network can be a very private way of sending bitcoin, and you can choose the channel size to be exactly the size of your change coin.
 However, it is very important that you do not link this non-private coin to your main Lightning node public key.
 So a good strategy is to create a new lightning node and public key, send the whole change coin into this fresh wallet, and open a channel of this amount to a random peer on the network.
-Then route a payment either to a merchant for goods and services, or to your own main lightning node for further use.
+Then route a payment either to a merchant for goods and services, or to your own main Lightning node for further use.
 After the balance of the channel is entirely on the other side, cooperatively close the channel with your peer, so that he gets the only output in the closing transaction.
 Since Wasabi does not yet support lightning network functionality, you must use a different wallet for this task.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -56,7 +56,7 @@ If in a third transaction you want to send Alice 0.02 bitcoin, then you can cons
 Now Alice knows that you owned the 0.1 bitcoin and and that you currently own the 0.09 bitcoin change, but she cannot find out about your premix transaction history.
 
 ### Spend the change to another entity, if these two won't make you trouble knowing you interact with both of them.
-For example when with a 0.1 bitcoin mixed coin you buy coffee from Alice for 0.01 bitcoin, you get back 0.09 bitcoin change that Alice knows is yours.
+For example when you buy coffee with a 0.1 bitcoin mixed coin from Alice for 0.01 bitcoin, you get back 0.09 bitcoin change that Alice knows is yours.
 If in the next transaction you spend the 0.09 bitcoin change in the pizza restaurant of Bob, then Alice might find out that you go to Bob's restaurant, and if she doesn't like that, then she can refuse to serve you coffee the next time, or even worse.
 But if instead you spend the 0.09 bitcoin change in a transaction to Carol, a good friend of Alice, then Alice might not care and will still give you coffee for the next round.
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -23,7 +23,7 @@ So when you send this change coin in a new transaction, the receiver knows that 
 ### First round CoinJoin change
 
 When you have a KYC red shield `anonymity set 1` coin and you register it for CoinJoin, you get one green coin `anonymity set 100` and one red shield `anonymity set 1` change coin.
-This change is very clearly tied to your KYC input coin, but the CoinJoin output is pretty good with anonset 100.
+This change is clearly tied to your KYC input coin, but the green coin is not.
 If you combine that red coin with the green, then it's clear that both of them belong to you, and thus the anonset of the output in this transaction becomes the lowest common denominator, in this case anonset 1.
 
 ### Second round CoinJoin change

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -16,7 +16,7 @@
 
 When you want to buy some coffee from Alice, then in the `Send` tab you select one or more of your own coins, and they are the input of the transaction, for example one red shield `anonymity set 1` coin worth 2 bitcoin.
 You put Alice's address in the `Receiving Address` field, and set the spending `Amount`, for example 0.5 bitcoin, this will be the first output of the transaction.
-The left over amount of 1.5 bitcoin will automatically go back to an address of you, and this is the change output.
+The left over amount of 1.5 bitcoin will automatically go to a new address that you control, and this is the change output.
 This change coin can easily be tied to the input of the transaction, and thus also has `anonymity set 1`.
 So when you send this change coin in a next transaction, this receiver knows that you were part of the transaction to Alice.
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -74,10 +74,9 @@ So you can send the Wasabi change to your Joinmarket wallet and take an offer to
 The coin you will receive after the tumbling algorithm can have sufficient anonymity set, and you can use it for spending again.
 
 ### Open a lightning network channel.
-The lightning network can be a very private way of sending bitcoin, and you can choose the channel size to be exactly the size of your change coin.
+The Lightning Network can be a very private way of sending bitcoin, and you can choose the channel size to be exactly the size of your change coin.
 However, it is very important that you do not link this non-private coin to your main lightning node public key.
 So a good strategy is to create a new lightning node and public key, send the whole change coin into this fresh wallet, and open a channel of this amount to a random peer on the network.
 Then route a payment either to a merchant for goods and services, or to your own main lightning node for further use.
 After the balance of the channel is entirely on the other side, cooperatively close the channel with your peer, so that he gets the only output in the closing transaction.
 Since Wasabi does not yet support lightning network functionality, you must use a different wallet for this task.
-

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -15,7 +15,7 @@
 ### Non CoinJoin change
 
 When you want to buy some coffee from Alice, then in the `Send` tab you select one or more of your own coins, and they are the input of the transaction, for example one red shield `anonymity set 1` coin worth 2 bitcoin.
-You put Alice's address in the `Receiving Address` field, and set the spending `Amount`, for example 0.5 bitcoin, this will make the first output of the transaction.
+You put Alice's address in the `Receiving Address` field, and set the spending `Amount`, for example 0.5 bitcoin, this will be the first output of the transaction.
 The left over amount of 1.5 bitcoin will automatically go back to an address of you, and this is the change output.
 This change coin can easily be tied to the input of the transaction, and thus also has `anonymity set 1`.
 So when you send this change coin in a next transaction, this receiver knows that you were part of the transaction to Alice.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -69,7 +69,7 @@ In this CoinJoin you get an equal value mixed coin, which is no longer tied to a
 So consolidating your change in a CoinJoin is strictly better than consolidating in a regular sending transaction, but it still leaks sensitive information to the coordinator.
 
 ### Mix with Joinmarket.
-In [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver) as a market taker you can specify exactly what denomination of equal value outputs are generated in the CoinJoin.
+In [JoinMarket](https://github.com/JoinMarket-Org/joinmarket-clientserver) as a market taker you can specify exactly what denomination of equal value outputs are generated in the CoinJoin.
 So you can send the Wasabi change to your Joinmarket wallet and take an offer to mix for some rounds.
 The coin you will receive after the tumbling algorithm can have sufficient anonymity set, and you can use it for spending again.
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -22,7 +22,7 @@ So when you send this change coin in a new transaction, the receiver knows that 
 
 ### First round CoinJoin change
 
-When you have a KYC coin with red anonset 1 and you register it for CoinJoin, then you get one anonset 100 green coin and one red anonset 1 change.
+When you have a KYC red shield `anonymity set 1` coin and you register it for CoinJoin, you get one green coin `anonymity set 100` and one red shield `anonymity set 1` change coin.
 This change is very clearly tied to your KYC input coin, but the CoinJoin output is pretty good with anonset 100.
 If you combine that red coin with the green, then it's clear that both of them belong to you, and thus the anonset of the output in this transaction becomes the lowest common denominator, in this case anonset 1.
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -73,7 +73,7 @@ In [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver) as a 
 So you can send the Wasabi change to your Joinmarket wallet and take an offer to mix for some rounds.
 The coin you will receive after the tumbling algorithm can have sufficient anonymity set, and you can use it for spending again.
 
-### Open a lightning network channel.
+### Open a Lightning Network channel.
 The Lightning Network can be a very private way of sending bitcoin, and you can choose the channel size to be exactly the size of your change coin.
 However, it is very important that you do not link this non-private coin to your main lightning node public key.
 So a good strategy is to create a new lightning node and public key, send the whole change coin into this fresh wallet, and open a channel of this amount to a random peer on the network.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -70,7 +70,7 @@ So consolidating your change in a CoinJoin is strictly better than consolidating
 
 ### Mix with Joinmarket.
 In [JoinMarket](https://github.com/JoinMarket-Org/joinmarket-clientserver) as a market taker you can specify exactly what denomination of equal value outputs are generated in the CoinJoin.
-So you can send the Wasabi change to your Joinmarket wallet and take an offer to mix for some rounds.
+So you can send the Wasabi change to your JoinMarket wallet and take an offer to mix for some rounds.
 The coin you will receive after the tumbling algorithm can have sufficient anonymity set, and you can use it for spending again.
 
 ### Open a Lightning Network channel.

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -18,7 +18,7 @@ When you want to buy some coffee from Alice, then in the `Send` tab you select o
 You put Alice's address in the `Receiving Address` field, and set the spending `Amount`, for example 0.5 bitcoin, this will be the first output of the transaction.
 The left over amount of 1.5 bitcoin will automatically go to a new address that you control, and this is the change output.
 This change coin can easily be tied to the input of the transaction, and thus also has `anonymity set 1`.
-So when you send this change coin in a next transaction, this receiver knows that you were part of the transaction to Alice.
+So when you send this change coin in a new transaction, the receiver knows that you were part of the transaction to Alice.
 
 ### First round CoinJoin change
 

--- a/docs/using-wasabi/README.md
+++ b/docs/using-wasabi/README.md
@@ -27,6 +27,7 @@ Further tutorials about the different parts of the wallet, for newbies and power
 - [Supported BIPs](/using-wasabi/BIPs.md)
 #### Privacy Best Practices
 - [Address Reuse](/using-wasabi/AddressReuse.md)
+- [Change Coins](/using-wasabi/ChangeCoins.md)
 - [Lost Password Strategy](/using-wasabi/LostPassword.md)
 - [Network Level Privacy](/using-wasabi/NetworkLevelPrivacy.md)
 - [How you can be de-anonymized using Bitcoin](/using-wasabi/Deanonimization.md)


### PR DESCRIPTION
This is to start out a copy of the incumbent `What can I do with small change?` FAQ into a new chapter `/using-wasabi/ChangeCoins.md`.

I think this is one of the most important privacy best practices in the context of Wasabi, a user error here can nullify all the privacy gains. So we should very carefully and thoroughly document the entire process.

The FAQ section should be shorter and about one specific aspect per question. The incumbent one is too huge and all encompassing.

What I think should be in this chapter:

- [x] an analysis of the privacy issues of change coins
- [x] a definition of different types change 
- [x] options to use change privately