### PR TITLE
[BUILDING] Add summary of license

### DIFF
--- a/docs/building-wasabi/LICENSE.md
+++ b/docs/building-wasabi/LICENSE.md
@@ -13,7 +13,6 @@ Wasabi Wallet and Wasabi documentation is licensed under the MIT License.
 
 A short and simple permissive license with conditions only requiring preservation of copyright and license notices.
 Licensed works, modifications, and larger works may be distributed under different terms and without source code.
-Permissions
 
 | Permissions    | Limitations  | Conditions                   |
 |----------------|--------------|------------------------------|

--- a/docs/building-wasabi/LICENSE.md
+++ b/docs/building-wasabi/LICENSE.md
@@ -9,22 +9,25 @@
 
 # MIT License
 
+Wasabi Wallet and Wasabi documentation is licensed under the MIT License.
+
+A short and simple permissive license with conditions only requiring preservation of copyright and license notices.
+Licensed works, modifications, and larger works may be distributed under different terms and without source code.
+Permissions
+
+| Permissions    | Limitations  | Conditions                   |
+|----------------|--------------|------------------------------|
+| Commercial use | Liability    | License and copyright notice |
+| Modification   | Warranty     |                              |
+| Distribution   |              |                              |
+| Private use    |              |                              |
+
+
 Copyright (c) 2019 zkSNACKs
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This is a copy of the [GitHub summary](https://github.com/zkSNACKs/WasabiDoc/blob/master/LICENSE) of the MIT license. It's a nice and short explanation of what is later explained in a bit of lawyer speak. Also the table makes everything easy to understand at one glance.

I also fixed the one line per sentence writing convention.

Ready for review and merge. I didn't change any wording, so it should be a no-brainer.