### PR TITLE
[BUILDING] Rewrite Contribution Game

### DIFF
--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -19,7 +19,7 @@ The first contribution game took place between 25th June and the 25th July of 20
 Anyone could have participated and the metric of success was the numbers of lines added and removed to the code base in pull requests that were ultimately merged.
 The total bounty was `1 bitcoin`, which ended up being distributed to 15 contributors, see the full results [here](https://github.com/zkSNACKs/WalletWasabi/issues/2016).
 There were special bonuses for critical bugs discovered, as well as for the creation of this documentation repository.
-Over all, this was a great success, as several new peers started to contribute to Wasabi, specifically [@Yahiheb](https://github.com/yahiheb) and [@JMacato](https://github.com/jmacato) who stuck around for the long term.
+Over all, this was a great success, as several new peers started to contribute to Wasabi, specifically [@yahiheb](https://github.com/yahiheb) and [@JMacato](https://github.com/jmacato) who stuck around for the long term.
 
 ## Monthly contribution game for the documentation
 

--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -17,15 +17,15 @@ For some occasions there is a **Wasabi contribution game**, where the zkSNACKs c
 
 The first contribution game was in between the 25th of June and the 25th of July in 2019.
 Anyone could participate and the metric of success was the numbers of lines added and removed to the code base in pull requests that were ultimately merged.
-The total bounty was `1 bitcoin`, that ended up being distributed to 15 contributors, see the full results [here](https://github.com/zkSNACKs/WalletWasabi/issues/2016).
+The total bounty was `1 bitcoin`, which ended up being distributed to 15 contributors, see the full results [here](https://github.com/zkSNACKs/WalletWasabi/issues/2016).
 There were special boni for critical bugs discovered, as well as for the creation of this documentation.
-Over all this was a great success, as several new peers started to contribute to Wasabi, specifically [@Yahiheb](https://github.com/yahiheb) and [@JMacato](https://github.com/jmacato) who stuck around for the long term.
+Over all, this was a great success, as several new peers started to contribute to Wasabi, specifically [@Yahiheb](https://github.com/yahiheb) and [@JMacato](https://github.com/jmacato) who stuck around for the long term.
 
 ## Monthly contribution game for the documentation
 
 Having a well educated user base is essential for any complex software such as Wasabi.
 In order to create and maintain this top notch documentation, there is an ongoing contribution game for any supporter of this archive of knowledge.
-The metric of success is a combination of number of pull requests, lines added and removed, and effort in review of the changes.
+The metric of success is a combination of number of pull requests, lines added and removed, as well as review of the changes.
 The bounty of `1000 US Dollars` worth of bitcoin is paid out every month on the 25th.
 The depth, quality and continuous maintenance of this documentation is proof of the success of this contribution game!
 
@@ -33,6 +33,6 @@ The depth, quality and continuous maintenance of this documentation is proof of 
 
 After the release of v1.1.9.2 a monumental amount of work has gone into Wasabi, introducing many new features, upgrading dependencies and fixing many bugs.
 In order to ensure rigorous peer review of such a complex change, two methods were introduced for the first time.
-The publishing of release candidate packages for all operating systems, so that testers do not need to compile the software from source.
+The publishing of release candidate packages for all operating systems, so that testers don't need to compile the software from source.
 This enabled many more reviewers to check out the latest additions to the software so to test for bugs and instabilities.
 Also there was a [contribution game](https://github.com/zkSNACKs/WalletWasabi/issues/2631) where any reviewer who provided a thorough report and notified the developers of bugs was eligible for a bounty of in total `0.5 bitcoin`.

--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -15,7 +15,7 @@ For some occasions there is a **Wasabi contribution game**, where the zkSNACKs c
 
 ## Contribution game of July 2019
 
-The first contribution game was in between the 25th of June and the 25th of July in 2019.
+The first contribution game took place between 25th June and the 25th July of 2019.
 Anyone could participate and the metric of success was the numbers of lines added and removed to the code base in pull requests that were ultimately merged.
 The total bounty was `1 bitcoin`, which ended up being distributed to 15 contributors, see the full results [here](https://github.com/zkSNACKs/WalletWasabi/issues/2016).
 There were special boni for critical bugs discovered, as well as for the creation of this documentation.

--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -27,7 +27,7 @@ Having a well educated user base is essential for any complex software such as W
 In order to create and maintain this top notch documentation, there is an ongoing contribution game for any supporter of this archive of knowledge.
 The metric of success is a combination of number of pull requests, lines added and removed, as well as review of the changes.
 The bounty of `1000 US Dollars` worth of bitcoin is paid out every month on the 25th.
-The depth, quality and continuous maintenance of this documentation is proof of the success of this contribution game!
+The depth, quality and continuous maintenance of this documentation is a proof of the success of this contribution game!
 
 ## Contribution game to review v1.1.10
 

--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -7,40 +7,16 @@
 
 # Contribution Game
 
-We are happy to announce an experiment, called: **The Wasabi Contribution Game**, where we will be distributing 1 BTC among contributors of this repository in proportion to their contributions.
+[[toc]]
+
+For some occasions there is a **Wasabi Contribution Game**, where the zkSNACKs company is distributing a bounty among contributors of the Wasabi repository in proportion to their contributions.
 
 ![](/ContributionGame.png)
 
+## Contribution Game of July 2019
 
-## Update (2019-07-25)
-
-[The Resolution Of The First Wasabi Contribution Game](https://github.com/zkSNACKs/WalletWasabi/issues/2016)
-
-## Update (2019-07-08)
-
-In PR [link](https://github.com/zkSNACKs/WalletWasabi/pull/1850) nopara73 implemented @NicolasDorier's changes, so 17+217=234 points added to Nicolas's score.
-
-## Update (2019-06-28)
-
-PR [link](https://github.com/zkSNACKs/WalletWasabi/pull/1661) moved around large files.
-49+154+50 lines have been removed and added, so 506 lines will come down from @jmacato's score.
-
-## Update (2019-06-28)
-
-- The originally posted links on additions and deletions do not work, due to a GitHub bug.
-It seems like the timeframe specified is lagging behind 5 days, so it may appear that nobody contributed, yet it is 28 already and there were many contributions, so the adjusted links are:
-- For additions: [link](https://github.com/zkSNACKs/WalletWasabi/graphs/contributors?from=2019-06-20&to=2019-07-20&type=a)
-- For deletions: [link](https://github.com/zkSNACKs/WalletWasabi/graphs/contributors?from=2019-06-20&to=2019-07-20&type=d)
-- nopara73 is disqualified from this game.
-
-## Rules
-
-- Checking the current status of the game: [additions](https://github.com/zkSNACKs/WalletWasabi/graphs/contributors?from=2019-06-25&to=2019-07-25&type=d) and [deletions](https://github.com/zkSNACKs/WalletWasabi/graphs/contributors?from=2019-06-25&to=2019-07-25&type=a)
-- The game starts at **2019-06-25** and ends at **2019-07-25**.
-- Anyone can participate. 
-- Number of commits DO NOT count.
-- The sum of additions and deletions DO count.
-- Only merged pull requests count.
-- Merges of the maintainer (nopara73) may skew the results. We will investigate this and if we find this to be the case, the maintainer's merges will either be discounted or the maintainer will be disqualified.
-- If someone is found intentionally manipulating the results, she or he will be disqualified. We do not plan to actively look for reasons to disqualify anyone, we would like to trust in the honesty of all contributors.
-- Keep checking your GitHub bells, because at the end of the game we will open an issue, in that tagging all the contributors, describing where they should send their BTC addresses for the payouts.
+The first contribution game was in between the 25th of June and the 25th of July in 2019.
+Anyone could participate and the metric of success was the numbers of lines added and removed to the code base in pull requests that were ultimately merged.
+The total bounty was `1 bitcoin`, that ended up being distributed to 15 contributors, see the full results [here](https://github.com/zkSNACKs/WalletWasabi/issues/2016).
+There were special boni for critical bugs discovered, as well as for the creation of this documentation.
+Over all this was a great success, as several new peers started to contribute to Wasabi, specifically [@Yahiheb](https://github.com/yahiheb) and [@JMacato](https://github.com/jmacato) who stuck around for the long term.

--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -18,7 +18,7 @@ For some occasions there is a **Wasabi contribution game**, where the zkSNACKs c
 The first contribution game took place between 25th June and the 25th July of 2019.
 Anyone could have participated and the metric of success was the numbers of lines added and removed to the code base in pull requests that were ultimately merged.
 The total bounty was `1 bitcoin`, which ended up being distributed to 15 contributors, see the full results [here](https://github.com/zkSNACKs/WalletWasabi/issues/2016).
-There were special boni for critical bugs discovered, as well as for the creation of this documentation.
+There were special bonuses for critical bugs discovered, as well as for the creation of this documentation repository.
 Over all, this was a great success, as several new peers started to contribute to Wasabi, specifically [@Yahiheb](https://github.com/yahiheb) and [@JMacato](https://github.com/jmacato) who stuck around for the long term.
 
 ## Monthly contribution game for the documentation

--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -9,14 +9,22 @@
 
 [[toc]]
 
-For some occasions there is a **Wasabi Contribution Game**, where the zkSNACKs company is distributing a bounty among contributors of the Wasabi repository in proportion to their contributions.
+For some occasions there is a **Wasabi contribution game**, where the zkSNACKs company is distributing a bounty among contributors of the Wasabi repository in proportion to their contributions.
 
 ![](/ContributionGame.png)
 
-## Contribution Game of July 2019
+## Contribution game of July 2019
 
 The first contribution game was in between the 25th of June and the 25th of July in 2019.
 Anyone could participate and the metric of success was the numbers of lines added and removed to the code base in pull requests that were ultimately merged.
 The total bounty was `1 bitcoin`, that ended up being distributed to 15 contributors, see the full results [here](https://github.com/zkSNACKs/WalletWasabi/issues/2016).
 There were special boni for critical bugs discovered, as well as for the creation of this documentation.
 Over all this was a great success, as several new peers started to contribute to Wasabi, specifically [@Yahiheb](https://github.com/yahiheb) and [@JMacato](https://github.com/jmacato) who stuck around for the long term.
+
+## Monthly contribution game for the documentation
+
+Having a well educated user base is essential for any complex software such as Wasabi.
+In order to create and maintain this top notch documentation, there is an ongoing contribution game for any supporter of this archive of knowledge.
+The metric of success is a combination of number of pull requests, lines added and removed, and effort in review of the changes.
+The bounty of `1000 US Dollars` worth of bitcoin is paid out every month on the 25th.
+The depth, quality and continuous maintenance of this documentation is proof of the success of this contribution game!

--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -16,7 +16,7 @@ For some occasions there is a **Wasabi contribution game**, where the zkSNACKs c
 ## Contribution game of July 2019
 
 The first contribution game took place between 25th June and the 25th July of 2019.
-Anyone could participate and the metric of success was the numbers of lines added and removed to the code base in pull requests that were ultimately merged.
+Anyone could have participated and the metric of success was the numbers of lines added and removed to the code base in pull requests that were ultimately merged.
 The total bounty was `1 bitcoin`, which ended up being distributed to 15 contributors, see the full results [here](https://github.com/zkSNACKs/WalletWasabi/issues/2016).
 There were special boni for critical bugs discovered, as well as for the creation of this documentation.
 Over all, this was a great success, as several new peers started to contribute to Wasabi, specifically [@Yahiheb](https://github.com/yahiheb) and [@JMacato](https://github.com/jmacato) who stuck around for the long term.

--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -28,3 +28,11 @@ In order to create and maintain this top notch documentation, there is an ongoin
 The metric of success is a combination of number of pull requests, lines added and removed, and effort in review of the changes.
 The bounty of `1000 US Dollars` worth of bitcoin is paid out every month on the 25th.
 The depth, quality and continuous maintenance of this documentation is proof of the success of this contribution game!
+
+## Contribution game to review v1.1.10
+
+After the release of v1.1.9.2 a monumental amount of work has gone into Wasabi, introducing many new features, upgrading dependencies and fixing many bugs.
+In order to ensure rigorous peer review of such a complex change, two methods were introduced for the first time.
+The publishing of release candidate packages for all operating systems, so that testers do not need to compile the software from source.
+This enabled many more reviewers to check out the latest additions to the software so to test for bugs and instabilities.
+Also there was a [contribution game](https://github.com/zkSNACKs/WalletWasabi/issues/2631) where any reviewer who provided a thorough report and notified the developers of bugs was eligible for a bounty of in total `0.5 bitcoin`.

--- a/docs/building-wasabi/ContributionGame.md
+++ b/docs/building-wasabi/ContributionGame.md
@@ -9,7 +9,7 @@
 
 [[toc]]
 
-For some occasions there is a **Wasabi contribution game**, where the zkSNACKs company is distributing a bounty among contributors of the Wasabi repository in proportion to their contributions.
+For some occasions there is a **Wasabi contribution game**, where the zkSNACKs company is distributing a bounty among contributors to the [Wasabi Wallet repository](https://github.com/zkSNACKs/WalletWasabi) in proportion to their contributions.
 
 ![](/ContributionGame.png)
 


### PR DESCRIPTION
This changes `/building-wasabi/ContributionGame.md` to be a chronicle time line of all the contribution games that were sponsored by zkSNACKs.

The incumbent explanation of the initial review game were almost completely rewritten, as it previously was not beautiful.
Also the addition of the monthly documentation bounty.
And finally the [upcoming contribution game of v1.1.10](https://github.com/zkSNACKs/WalletWasabi/issues/2631), which is written in past tense so to decrease maintenance effort in the future.

Ready for review.