### PR TITLE
Add Wasabi glossary

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -209,7 +209,9 @@ module.exports = {
             "/FAQ/FAQ-UseWasabi.md",
             "/FAQ/FAQ-GeneralBitcoinPrivacy.md",
             "/FAQ/FAQ-Contribution.md"
-          ],
+          ]
+        }
+      ],
       "/glossary/": [
         {
           title: "Glossary",

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -209,7 +209,12 @@ module.exports = {
             "/FAQ/FAQ-UseWasabi.md",
             "/FAQ/FAQ-GeneralBitcoinPrivacy.md",
             "/FAQ/FAQ-Contribution.md"
-          ]
+          ],
+      "/glossary/": [
+        {
+          title: "Glossary",
+          collapsable: false,
+          sidebarDepth: 2,
         }
       ]
     }

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -105,6 +105,10 @@ module.exports = {
       {
         text: "FAQ",
         link: "/FAQ/"
+      },
+      {
+        text: "Glossary",
+        link: "/glossary/"
       }
     ],
     sidebar: {

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -110,7 +110,8 @@ Read more: [How can I select UTXOs for CoinJoin?](/FAQ/FAQ-UseWasabi.md#how-can-
 ### Address reuse
 
 Address reuse is a serious privacy leak.
-If an output address has been reused it is very likely to be a payment output, not a change output.
+If an output address has been reused the same private key can spend now several coins, thus it is clear that all of these coins belong to one entity.
+Further, it is very likely to be a payment output, not a change output.
 This is because change addresses are created automatically by wallet software but payment addresses are manually sent between humans.
 Read more: [Address reuse](/using-wasabi/AddressReuse.md)
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -76,7 +76,7 @@ Output, transaction output, or TxOut is an output in a transaction which contain
 :::details
 ### Pay-to-Witness-Public-Key-Hash (P2WPKH)
 
-The signature of a P2WPKH (Pay-to-Witness-Public-Key-Hash) contains the same information as a P2PKH spending, but is located in the witness field instead of the scriptSig field.
+The signature of a P2WPKH contains the same information as a Pay-to-Public-Key-Hash (P2PKH) spending, but is located in the witness field instead of the scriptSig field.
 The scriptPubKey is also modified.
 Read more: [BIP 84 derivation scheme for P2WPKH based accounts](/using-wasabi/BIPs.md#bip-84-derivation-scheme-for-p2wpkh-based-accounts)
 :::

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -40,7 +40,7 @@ Read more: [What fee should I select?](/FAQ/FAQ-UseWasabi.md#what-fee-should-i-s
 
 :::details
 ### Hardware Wallet
-A hardware wallet is a special type of Bitcoin wallet which generates stores the user’s private keys in a tailor made hardware device.
+A hardware wallet is a special type of Bitcoin wallet which generates and stores the user’s private keys in a tailor made hardware device.
 Read more: [Hardware Wallet FAQs](/FAQ/FAQ-UseWasabi.md#hardware-wallet)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -162,7 +162,7 @@ Read more: [Wasabi Wallet under the hood](/FAQ/FAQ-UseWasabi.md#how-does-my-wall
 ### Dust
 
 Dust is an UTXO that is uneconomical to spend.
-Also, small portion of bitcoins can lead to serious consequences about one's privacy.
+Also, small portions of bitcoin can lead to serious consequences about one's privacy.
 An example would be the so called 'forced address reuse attack'.
 Read more: [What is the dust threshold](/FAQ/FAQ-UseWasabi.html#what-is-the-dust-threshold)
 :::

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -134,7 +134,7 @@ Read more: [Change coins](/using-wasabi/ChangeCoins.md)
 :::details
 ### CoinJoin
 
-CoinJoin is a trustless method for combining multiple Bitcoin payments from multiple spenders into a single transaction to make it more difficult for outside parties to determine which spender paid which recipient or recipients. 
+CoinJoin is a trustless method for combining multiple Bitcoin payments from multiple spenders into a single transaction to make it more difficult for outside parties to determine which spender paid which recipient.
 Read more: [What is a CoinJoin?](/FAQ/FAQ-Introduction.md#what-is-a-coinjoin)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -114,7 +114,7 @@ Address reuse refers to the use of the same address for multiple transactions, t
 Read more: [Address reuse](/using-wasabi/AddressReuse.md)
 
 :::details
-### Anonimity Set (or anonset)
+### Anonymity Set (anonset)
 
 The anonymity set is effectively the size of the group you are hiding in during a CoinJoin.
 It's the quantity of equal value outputs of one CoinJoin transaction.

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -1,0 +1,188 @@
+---
+{
+  "title": "Glossary",
+  "description": "Explanations of common words used in Wasabi and regarding Bitcoin Privacy with links to the docs for more details. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+}
+---
+
+# Glossary
+
+This glossary contains the explanations of common words used in Wasabi and regarding Bitcoin Privacy in general.
+Every voice contains a link to the respective full document for more details.
+
+## Bitcoin in general
+
+:::details
+### BIP
+
+Bitcoin Improvement Proposals.
+A set of proposals that members of the bitcoin community have submitted to improve bitcoin.
+Read more: [Wasabi Supported BIPs](/using-wasabi/BIPs.md)
+:::
+
+:::details
+### Cold Storage
+
+Refers to keeping a reserve of bitcoin offline.
+Cold storage is achieved when Bitcoin private keys are created and stored in a secure offline environment.
+Cold storage is important for anyone with bitcoin holdings.
+Online computers are vulnerable to hackers and should not be used to store a significant amount of bitcoin.
+Read more: [Cold Wasabi Protocol](/using-wasabi/ColdWasabi.md)
+:::
+
+:::details
+### Fees
+
+The sender of a transaction often includes a fee to the network for processing the requested transaction.
+Most transactions require a minimum fee of 0.5 mBTC.
+Read more: [What fee should I select?](/FAQ/FAQ-UseWasabi.md#what-fee-should-i-select)
+:::
+
+:::details
+### Hardware Wallet
+A hardware wallet is a special type of bitcoin wallet which stores the user’s private keys in a secure hardware device.
+Read more: [Hardware Wallet FAQs](/FAQ/FAQ-UseWasabi.md#hardware-wallet)
+:::
+
+:::details
+### Lightning Network
+
+Lightning Network is a proposed implementation of Hashed Timelock Contracts (HTLCs) with bi-directional payment channels which allows payments to be securely routed across multiple peer-to-peer payment channels.
+This allows the formation of a network where any peer on the network can pay any other peer even if they don’t directly have a channel open between each other.
+Read more: [Use Lightning](/why-wasabi/10Commandments.md#_10-use-lightning)
+:::
+
+:::details
+### Mempool
+
+The bitcoin Mempool (memory pool) is a collection of all transaction data in a block that have been verified by bitcoin nodes, but are not yet confirmed.
+Read more: [How does Wasabi know of incoming transactions to the mempool?](/FAQ/FAQ-UseWasabi.html#how-does-wasabi-know-of-incoming-transactions-to-the-mempool)
+:::
+
+:::details
+### Multisignature
+
+Multisignature (multisig) refers to requiring more than one key to authorize a bitcoin transaction.
+Read more: [Can I generate a multi signature script?](/FAQ/FAQ-UseWasabi.md#can-i-generate-a-multi-signature-script)
+:::
+
+:::details
+### Output
+
+Output, transaction output, or TxOut is an output in a transaction which contains two fields: a value field for transferring zero or more satoshis and a pubkey script for indicating what conditions must be fulfilled for those satoshis to be further spent.
+:::
+
+:::details
+### P2WPKH
+
+The signature of a P2WPKH (Pay-to-Witness-Public-Key-Hash) contains the same information as a P2PKH spending, but is located in the witness field instead of the scriptSig field.
+The scriptPubKey is also modified.
+Read more: [BIP 84 derivation scheme for P2WPKH based accounts](/using-wasabi/BIPs.md#bip-84-derivation-scheme-for-p2wpkh-based-accounts)
+:::
+
+:::details
+### satoshi
+
+A satoshi (sat) is the smallest denomination of bitcoin that can be recorded on the blockchain.
+It is the equivalent of 0.00000001 bitcoin and is named after the creator of Bitcoin, Satoshi Nakamoto.
+Read more: [How can I display the fee in satoshi per byte?](/FAQ/FAQ-UseWasabi.md#how-can-i-display-the-fee-in-satoshis-per-byte)
+:::
+
+:::details
+### Simplified Payment Verification (SPV)
+
+SPV or simplified payment verification is a method for verifying particular transactions were included in a block without downloading the entire block.
+The method is used by some lightweight Bitcoin clients.
+Read more: [Wasabi Wallet under the hood](/building-wasabi/TechnicalOverview.md#wasabi-wallet-under-the-hood)
+:::
+
+:::details
+### Unspent Transaction Output (UTXO)
+
+UTXO is an unspent transaction output that can be spent as an input in a new transaction.
+Read more: [How can I select UTXOs for CoinJoin?](/FAQ/FAQ-UseWasabi.md#how-can-i-select-utxos-for-coinjoin)
+:::
+
+
+## Privacy and Wasabi
+
+:::details
+### Address reuse
+
+Address reuse is a serious privacy leak.
+If an output address has been reused it is very likely to be a payment output, not a change output.
+This is because change addresses are created automatically by wallet software but payment addresses are manually sent between humans.
+Read more: [Address reuse](/using-wasabi/AddressReuse.md)
+
+:::details
+### Anonimity Set (or anonset)
+
+The anonymity set is effectively the size of the group you are hiding in during a CoinJoin.
+Read more: [What is the anonimity set?](/FAQ/FAQ-UseWasabi.md#what-is-the-anonymity-set)
+:::
+
+:::details
+### Change address detection
+
+Many bitcoin transactions have change outputs.
+It would be a serious privacy leak if the change address can be somehow found, as it would link the ownership of the (now spent) inputs with a new output.
+Read more: [Change coins](/using-wasabi/ChangeCoins.md)
+:::
+
+:::details
+### CoinJoin
+
+CoinJoin is a trustless method for combining multiple Bitcoin payments from multiple spenders into a single transaction to make it more difficult for outside parties to determine which spender paid which recipient or recipients. 
+Read more: [What is a CoinJoin?](/FAQ/FAQ-Introduction.md#what-is-a-coinjoin)
+:::
+
+:::details
+### Coin Control
+
+Coin control is a must learn if you care about your privacy in Bitcoin.
+As can be understood from the name, this is a proper control of one's coins.
+Read more: [Coin Control Best Practices](/FAQ/FAQ-UseWasabi.md#coin-control-best-practices)
+:::
+
+:::details
+### Common-input-ownership heuristic
+
+This is a heuristic or assumption which says that if a transaction has more than one input then all those inputs are owned by the same entity.
+Read more: [Wasabi Wallet under the hood](/building-wasabi/TechnicalOverview.md#wasabi-wallet-under-the-hood)
+:::
+
+:::details
+### Coordinator
+
+The coordinator is zkSNACKs' server which creates CoinJoins and accepts UTXOs in the mix.
+Read more: [Wasabi Wallet under the hood](/FAQ/FAQ-UseWasabi.md#how-does-my-wallet-communicate-with-the-wasabi-coordinator-server)
+:::
+
+:::details
+### Dust
+
+Dust is a small portion of bitcoins which can lead to serious consequences about one's privacy.
+Read more: [What is the dust threshold](/FAQ/FAQ-UseWasabi.html#what-is-the-dust-threshold)
+:::
+
+:::details
+### KYC
+
+Know your customer (KYC) is the process of a business, identifying and verifying the identity of its clients.
+The term is also used to refer to the bank regulation which governs these activities.
+Read more: [AML/KYC Information](/why-wasabi/TransactionSurveillanceCompanies.md#aml-kyc-information)
+:::
+
+:::details
+### XPUB (or Extended Public Key)
+
+An xpub, also know as Extended Public Key, is a part of BIP-32 that will allow you to observe your wallet without the private key (xpriv).
+Read more: [Wasabi's Solution](/why-wasabi/BitcoinPrivacy.md#wasabi-s-solution-4)
+:::
+
+:::details
+### Wallet fingerprinting
+
+A careful analyst sometimes deduce which software created a certain transaction, because the many different wallet softwares don't always create transactions in exactly the same way.
+Read more: [Technical Overview of Wasabi Wallet](/building-wasabi/TechnicalOverview.md)
+:::

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -185,6 +185,15 @@ Read more: [Wasabi's Solution](/why-wasabi/BitcoinPrivacy.md#wasabi-s-solution-4
 :::
 
 :::details
+### #twoweeks
+
+The #twoweeks is a fun inside joke often used in the Wasabu documentation and, more generally, in the Internet community.
+In the case of Wasabi documentation, it usually indicates the arrival of a new function or update, to which the future date is still uncertain.
+
+Eg. "Lightning Network is coming to Wasabi in #twoweeks"
+:::
+
+:::details
 ### Wallet fingerprinting
 
 A careful analyst sometimes deduce which software created a certain transaction, because the many different wallet softwares don't always create transactions in exactly the same way.

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -40,7 +40,7 @@ Read more: [What fee should I select?](/FAQ/FAQ-UseWasabi.md#what-fee-should-i-s
 
 :::details
 ### Hardware Wallet
-A hardware wallet is a special type of bitcoin wallet which generates stores the user’s private keys in a tailor made hardware device.
+A hardware wallet is a special type of Bitcoin wallet which generates stores the user’s private keys in a tailor made hardware device.
 Read more: [Hardware Wallet FAQs](/FAQ/FAQ-UseWasabi.md#hardware-wallet)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -176,7 +176,7 @@ Read more: [AML/KYC Information](/why-wasabi/TransactionSurveillanceCompanies.md
 :::
 
 :::details
-### XPUB (or Extended Public Key)
+### XPUB (Extended Public Key)
 
 An xpub, also know as Extended Public Key, is a part of BIP-32 that will allow you to observe your wallet without the private key (xpriv).
 Read more: [Wasabi's Solution](/why-wasabi/BitcoinPrivacy.md#wasabi-s-solution-4)

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -73,7 +73,7 @@ Output, transaction output, or TxOut is an output in a transaction which contain
 :::
 
 :::details
-### P2WPKH
+### Pay-to-Witness-Public-Key-Hash (P2WPKH)
 
 The signature of a P2WPKH (Pay-to-Witness-Public-Key-Hash) contains the same information as a P2PKH spending, but is located in the witness field instead of the scriptSig field.
 The scriptPubKey is also modified.

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -15,7 +15,7 @@ Every voice contains a link to the respective full document for more details.
 :::details
 ### BIP
 
-Bitcoin Improvement Proposals.
+Bitcoin Improvement Proposal.
 A set of proposals that members of the bitcoin community have submitted to improve bitcoin.
 Read more: [Wasabi Supported BIPs](/using-wasabi/BIPs.md)
 :::

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -163,7 +163,9 @@ Read more: [Wasabi Wallet under the hood](/FAQ/FAQ-UseWasabi.md#how-does-my-wall
 :::details
 ### Dust
 
-Dust is a small portion of bitcoins which can lead to serious consequences about one's privacy.
+Dust is a is an UTXO that is uneconomical to spend.
+Also, small portion of bitcoins can lead to serious consequences about one's privacy.
+An example would be the so called 'forced address reuse attack'.
 Read more: [What is the dust threshold](/FAQ/FAQ-UseWasabi.html#what-is-the-dust-threshold)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -92,7 +92,7 @@ Read more: [How can I display the fee in satoshi per byte?](/FAQ/FAQ-UseWasabi.m
 :::details
 ### Simplified Payment Verification (SPV)
 
-SPV or simplified payment verification is a method for verifying particular transactions were included in a block without downloading the entire block.
+SPV is a method for verifying particular transactions were included in a block without downloading the entire block.
 The method is used by some lightweight Bitcoin clients.
 Read more: [Wasabi Wallet under the hood](/building-wasabi/TechnicalOverview.md#wasabi-wallet-under-the-hood)
 :::
@@ -110,10 +110,7 @@ Read more: [How can I select UTXOs for CoinJoin?](/FAQ/FAQ-UseWasabi.md#how-can-
 :::details
 ### Address reuse
 
-Address reuse is a serious privacy leak.
-If an output address has been reused the same private key can spend now several coins, thus it is clear that all of these coins belong to one entity.
-Further, it is very likely to be a payment output, not a change output.
-This is because change addresses are created automatically by wallet software but payment addresses are manually sent between humans.
+Address reuse refers to the use of the same address for multiple transactions, this is very bad for privacy.
 Read more: [Address reuse](/using-wasabi/AddressReuse.md)
 
 :::details

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -34,7 +34,7 @@ Read more: [Cold Wasabi Protocol](/using-wasabi/ColdWasabi.md)
 ### Fees
 
 The sender of a transaction often includes a fee to the network for processing the requested transaction.
-Most transactions require a minimum fee of 0.5 mBTC.
+Most transactions require a minimum fee.
 Read more: [What fee should I select?](/FAQ/FAQ-UseWasabi.md#what-fee-should-i-select)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -40,7 +40,7 @@ Read more: [What fee should I select?](/FAQ/FAQ-UseWasabi.md#what-fee-should-i-s
 
 :::details
 ### Hardware Wallet
-A hardware wallet is a special type of Bitcoin wallet which generates and stores the user’s private keys in a tailor made hardware device.
+A hardware wallet is a special type of Bitcoin wallet which generates and stores the user's private keys in a tailor made hardware device.
 Read more: [Hardware Wallet FAQs](/FAQ/FAQ-UseWasabi.md#hardware-wallet)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -1,7 +1,7 @@
 ---
 {
   "title": "Glossary",
-  "description": "Explanations of common words used in Wasabi and regarding Bitcoin Privacy with links to the docs for more details. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+  "description": "Explanations of common words used in Wasabi and regarding Bitcoin privacy with links to the docs for more details. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
 }
 ---
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -23,7 +23,7 @@ Read more: [Wasabi Supported BIPs](/using-wasabi/BIPs.md)
 :::details
 ### Cold Storage
 
-Refers to keeping a reserve of bitcoin offline.
+Refers to keeping a reserve of important Bitcoin secrets offline.
 Cold storage is achieved when Bitcoin private keys are created and stored in a secure offline environment.
 Cold storage is important for anyone with bitcoin holdings.
 Online computers are vulnerable to hackers and should not be used to store a significant amount of bitcoin.

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -8,7 +8,7 @@
 # Glossary
 
 This glossary contains the explanations of common words used in Wasabi and regarding Bitcoin Privacy in general.
-Every voice contains a link to the respective full document for more details.
+Every item contains a link to the respective full document for more details.
 
 ## Bitcoin in general
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -82,7 +82,7 @@ Read more: [BIP 84 derivation scheme for P2WPKH based accounts](/using-wasabi/BI
 :::
 
 :::details
-### satoshi
+### satoshi (sat)
 
 A satoshi is the smallest denomination of bitcoin that can be recorded on the blockchain.
 It is the equivalent of 0.00000001 bitcoin and is named after the creator of Bitcoin, Satoshi Nakamoto.

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -194,6 +194,6 @@ Eg. "Lightning Network is coming to Wasabi in #twoweeks"
 :::details
 ### Wallet fingerprinting
 
-A careful analyst sometimes deduce which software created a certain transaction, because the many different wallet softwares don't always create transactions in exactly the same way.
+A careful analyst sometimes deduces which software created a certain transaction, because many different wallet softwares don't always create transactions in exactly the same way.
 Read more: [Technical Overview of Wasabi Wallet](/building-wasabi/TechnicalOverview.md)
 :::

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -63,7 +63,7 @@ Read more: [How does Wasabi know of incoming transactions to the mempool?](/FAQ/
 ### Multisignature
 
 Multisignature (m-of-n multisig) refers to requiring more than one key to authorize a Bitcoin transaction.
-Only with `m` signatures of `n` public keys can the bitcoin be spend.
+Only with `m` signatures of `n` public keys can the bitcoin be spent.
 Read more: [Can I generate a multi signature script?](/FAQ/FAQ-UseWasabi.md#can-i-generate-a-multi-signature-script)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -84,7 +84,7 @@ Read more: [BIP 84 derivation scheme for P2WPKH based accounts](/using-wasabi/BI
 :::details
 ### satoshi
 
-A satoshi (sat) is the smallest denomination of bitcoin that can be recorded on the blockchain.
+A satoshi is the smallest denomination of bitcoin that can be recorded on the blockchain.
 It is the equivalent of 0.00000001 bitcoin and is named after the creator of Bitcoin, Satoshi Nakamoto.
 Read more: [How can I display the fee in satoshi per byte?](/FAQ/FAQ-UseWasabi.md#how-can-i-display-the-fee-in-satoshis-per-byte)
 :::

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -119,6 +119,7 @@ Read more: [Address reuse](/using-wasabi/AddressReuse.md)
 ### Anonimity Set (or anonset)
 
 The anonymity set is effectively the size of the group you are hiding in during a CoinJoin.
+It's the quantity of equal value outputs of one CoinJoin transaction.
 Read more: [What is the anonimity set?](/FAQ/FAQ-UseWasabi.md#what-is-the-anonymity-set)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -16,7 +16,7 @@ Every item contains a link to the respective full document for more details.
 ### BIP
 
 Bitcoin Improvement Proposal.
-A proposal that members of the Bitcoin community have submitted to improve Bitcoin.
+A design document for introducing features or information to Bitcoin.
 Read more: [Wasabi Supported BIPs](/using-wasabi/BIPs.md)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -16,7 +16,7 @@ Every voice contains a link to the respective full document for more details.
 ### BIP
 
 Bitcoin Improvement Proposal.
-A set of proposals that members of the bitcoin community have submitted to improve bitcoin.
+A proposal that members of the bitcoin community have submitted to improve bitcoin.
 Read more: [Wasabi Supported BIPs](/using-wasabi/BIPs.md)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -62,7 +62,7 @@ Read more: [How does Wasabi know of incoming transactions to the mempool?](/FAQ/
 :::details
 ### Multisignature
 
-Multisignature (m-of-n multisig) refers to requiring more than one key to authorize a bitcoin transaction.
+Multisignature (m-of-n multisig) refers to requiring more than one key to authorize a Bitcoin transaction.
 Only with `m` signatures of `n` public keys can the bitcoin be spend.
 Read more: [Can I generate a multi signature script?](/FAQ/FAQ-UseWasabi.md#can-i-generate-a-multi-signature-script)
 :::

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -154,7 +154,7 @@ Read more: [Wasabi Wallet under the hood](/building-wasabi/TechnicalOverview.md#
 :::details
 ### Coordinator
 
-The coordinator is zkSNACKs' server which creates CoinJoins and accepts UTXOs in the mix.
+The coordinator is a server which creates CoinJoins and accepts UTXOs in the mix.
 Read more: [Wasabi Wallet under the hood](/FAQ/FAQ-UseWasabi.md#how-does-my-wallet-communicate-with-the-wasabi-coordinator-server)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -40,7 +40,7 @@ Read more: [What fee should I select?](/FAQ/FAQ-UseWasabi.md#what-fee-should-i-s
 
 :::details
 ### Hardware Wallet
-A hardware wallet is a special type of bitcoin wallet which stores the user’s private keys in a secure hardware device.
+A hardware wallet is a special type of bitcoin wallet which generates stores the user’s private keys in a tailor made hardware device.
 Read more: [Hardware Wallet FAQs](/FAQ/FAQ-UseWasabi.md#hardware-wallet)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -126,7 +126,7 @@ Read more: [What is the anonimity set?](/FAQ/FAQ-UseWasabi.md#what-is-the-anonym
 :::details
 ### Change address detection
 
-Many bitcoin transactions have change outputs.
+Many Bitcoin transactions have change outputs.
 It would be a serious privacy leak if the change address can be somehow found, as it would link the ownership of the (now spent) inputs with a new output.
 Read more: [Change coins](/using-wasabi/ChangeCoins.md)
 :::

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -55,7 +55,7 @@ Read more: [Use Lightning](/why-wasabi/10Commandments.md#_10-use-lightning)
 :::details
 ### Mempool
 
-The bitcoin Mempool (memory pool) is a collection of all transaction data in a block that have been verified by bitcoin nodes, but are not yet confirmed.
+The Bitcoin Mempool (memory pool) is a collection of all transaction data in a block that have been verified by Bitcoin nodes, but are not yet confirmed.
 Read more: [How does Wasabi know of incoming transactions to the mempool?](/FAQ/FAQ-UseWasabi.html#how-does-wasabi-know-of-incoming-transactions-to-the-mempool)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -163,7 +163,7 @@ Read more: [Wasabi Wallet under the hood](/FAQ/FAQ-UseWasabi.md#how-does-my-wall
 :::details
 ### Dust
 
-Dust is a is an UTXO that is uneconomical to spend.
+Dust is an UTXO that is uneconomical to spend.
 Also, small portion of bitcoins can lead to serious consequences about one's privacy.
 An example would be the so called 'forced address reuse attack'.
 Read more: [What is the dust threshold](/FAQ/FAQ-UseWasabi.html#what-is-the-dust-threshold)

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -62,7 +62,8 @@ Read more: [How does Wasabi know of incoming transactions to the mempool?](/FAQ/
 :::details
 ### Multisignature
 
-Multisignature (multisig) refers to requiring more than one key to authorize a bitcoin transaction.
+Multisignature (m-of-n multisig) refers to requiring more than one key to authorize a bitcoin transaction.
+Only with `m` signatures of `n` public keys can the bitcoin be spend.
 Read more: [Can I generate a multi signature script?](/FAQ/FAQ-UseWasabi.md#can-i-generate-a-multi-signature-script)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -16,7 +16,7 @@ Every item contains a link to the respective full document for more details.
 ### BIP
 
 Bitcoin Improvement Proposal.
-A proposal that members of the bitcoin community have submitted to improve bitcoin.
+A proposal that members of the Bitcoin community have submitted to improve Bitcoin.
 Read more: [Wasabi Supported BIPs](/using-wasabi/BIPs.md)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -163,7 +163,7 @@ Read more: [Wasabi Wallet under the hood](/FAQ/FAQ-UseWasabi.md#how-does-my-wall
 
 Dust is an UTXO that is uneconomical to spend.
 Also, small portions of bitcoin can lead to serious consequences about one's privacy.
-An example would be the so called 'forced address reuse attack'.
+An example would be the so called `forced address reuse attack`.
 Read more: [What is the dust threshold](/FAQ/FAQ-UseWasabi.html#what-is-the-dust-threshold)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -48,7 +48,7 @@ Read more: [Hardware Wallet FAQs](/FAQ/FAQ-UseWasabi.md#hardware-wallet)
 ### Lightning Network
 
 Lightning Network is a proposed implementation of Hashed Timelock Contracts (HTLCs) with bi-directional payment channels which allows payments to be securely routed across multiple peer-to-peer payment channels.
-This allows the formation of a network where any peer on the network can pay any other peer even if they don’t directly have a channel open between each other.
+This allows the formation of a network where any peer on the network can pay any other peer even if they don't directly have a channel open between each other.
 Read more: [Use Lightning](/why-wasabi/10Commandments.md#_10-use-lightning)
 :::
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -170,7 +170,7 @@ Read more: [What is the dust threshold](/FAQ/FAQ-UseWasabi.html#what-is-the-dust
 :::details
 ### KYC
 
-Know your customer (KYC) is the process of a business, identifying and verifying the identity of its clients.
+Know your customer (KYC) is the process of a business being forced to identify and verify the identity of its clients, and to share this information with a government.
 The term is also used to refer to the bank regulation which governs these activities.
 Read more: [AML/KYC Information](/why-wasabi/TransactionSurveillanceCompanies.md#aml-kyc-information)
 :::

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -170,7 +170,7 @@ Read more: [What is the dust threshold](/FAQ/FAQ-UseWasabi.html#what-is-the-dust
 :::details
 ### KYC
 
-Know your customer (KYC) is the process of a business being forced to identify and verify the identity of its clients, and to share this information with a government.
+KYC (Know Your Customer) is the process of a business being forced to identify and verify the identity of its clients, and to share this information with a government.
 The term is also used to refer to the bank regulation which governs these activities.
 Read more: [AML/KYC Information](/why-wasabi/TransactionSurveillanceCompanies.md#aml-kyc-information)
 :::

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -188,7 +188,7 @@ Read more: [Wasabi's Solution](/why-wasabi/BitcoinPrivacy.md#wasabi-s-solution-4
 :::details
 ### #twoweeks
 
-The #twoweeks is a fun inside joke often used in the Wasabu documentation and, more generally, in the Internet community.
+The #twoweeks is a fun inside joke often used in the Wasabi documentation and, more generally, in the Internet community.
 In the case of Wasabi documentation, it usually indicates the arrival of a new function or update, to which the future date is still uncertain.
 
 Eg. "Lightning Network is coming to Wasabi in #twoweeks"

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -60,7 +60,7 @@ Read more: [How does Wasabi know of incoming transactions to the mempool?](/FAQ/
 :::
 
 :::details
-### Multisignature
+### Multisignature (multisig)
 
 Multisignature (m-of-n multisig) refers to requiring more than one key to authorize a Bitcoin transaction.
 Only with `m` signatures of `n` public keys can the bitcoin be spent.

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -7,7 +7,7 @@
 
 # Glossary
 
-This glossary contains the explanations of common words used in Wasabi and regarding Bitcoin Privacy in general.
+This glossary contains the explanations of common words used in Wasabi and regarding Bitcoin privacy in general.
 Every item contains a link to the respective full document for more details.
 
 ## Bitcoin in general

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -33,7 +33,7 @@ Read more: [Cold Wasabi Protocol](/using-wasabi/ColdWasabi.md)
 :::details
 ### Fees
 
-The sender of a transaction often includes a fee to the network for processing the requested transaction.
+The sender of a transaction includes a fee to the network for processing the requested transaction.
 Most transactions require a minimum fee.
 Read more: [What fee should I select?](/FAQ/FAQ-UseWasabi.md#what-fee-should-i-select)
 :::


### PR DESCRIPTION
Following #136 proposal:

> I'm also thinking of a separate list of explanations of common words, in only one or two sentences, with links to the docs for more details.

Here's a list of common words used in Bitcoin, Privacy and Wasabi.
I did not enter the bases specifically and in my opinion we shouldn't do it.

Every voice contains a link to the respective full document for more details.