### PR TITLE
Remove 'What do you need to get the keys?' section

### DIFF
--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -144,17 +144,3 @@ Wasabi uses [BIP 38: Password-Protected Private Key](/using-wasabi/BIPs.md#bip-3
                   +--------------------+
 
 ```
-
-## What do you need to get the keys?
-
-This is needed to backup and recover your wallet:
-
-| Data | Does it need password to recover? |
-|----------------------|--------------------------------|
-| entropy |  No, this is unencrypted |
-| mnemonic | No, this is unencrypted |
-| seed |  Yes, it is encrypted |
-| extendedkey |  Yes, it is encrypted |
-| privatekey+chaincode+fingerprint | Yes, it is encrypted |
-| encryptedsecret+chaincode+fingerprint  | Yes, **(this is the Wasabi Backup)** |
-


### PR DESCRIPTION
Fixes #145
As discussed with @lontivero this table should be removed because its content is wrong, and it is not worth replacing by Lucas's original table because it was good in the context of a specific question.