### PR TITLE
[GLOSSARY] transaction surveilance company

### DIFF
--- a/docs/glossary/Glossary.md
+++ b/docs/glossary/Glossary.md
@@ -278,6 +278,14 @@ Similarly, Tumbler is the synonym of 'Mixer'.
 :::
 
 :::details
+### Transaction Surveillance Company
+
+A transaction surveillance company is one which attempts to spy on all bitcoin users.
+Their business model is usually to sell the data to any governments, corporations and individuals willing to pay for their services.
+Read more: [Transaction Surveillance Companies](/why-wasabi/TransactionSurveillanceCompanies.md#spying-technology)
+:::
+
+:::details
 ### #twoweeks
 
 The #twoweeks is a fun inside joke often used in the Wasabi documentation and, more generally, in the Internet community.

--- a/docs/glossary/Glossary.md
+++ b/docs/glossary/Glossary.md
@@ -282,7 +282,7 @@ Similarly, Tumbler is the synonym of 'Mixer'.
 
 A transaction surveillance company is one which attempts to spy on all bitcoin users.
 Their business model is usually to sell the data to any governments, corporations and individuals willing to pay for their services.
-Read more: [Transaction Surveillance Companies](/why-wasabi/TransactionSurveillanceCompanies.md#spying-technology)
+Read more: [Transaction Surveillance Companies](/why-wasabi/TransactionSurveillanceCompanies.md)
 :::
 
 :::details

--- a/docs/glossary/Glossary.md
+++ b/docs/glossary/Glossary.md
@@ -280,7 +280,7 @@ Similarly, Tumbler is the synonym of 'Mixer'.
 :::details
 ### Transaction Surveillance Company
 
-A transaction surveillance company is one which attempts to spy on all bitcoin users.
+A transaction surveillance company is one which attempts to spy on all Bitcoin users.
 Their business model is usually to sell the data to any governments, corporations and individuals willing to pay for their services.
 Read more: [Transaction Surveillance Companies](/why-wasabi/TransactionSurveillanceCompanies.md)
 :::

--- a/docs/glossary/Glossary.md
+++ b/docs/glossary/Glossary.md
@@ -281,7 +281,7 @@ Similarly, Tumbler is the synonym of 'Mixer'.
 ### Transaction Surveillance Company
 
 A transaction surveillance company is one which attempts to spy on all Bitcoin users.
-Their business model is usually to sell the data to any governments, corporations and individuals willing to pay for their services.
+Their business model is usually to sell the data to any government, corporation or individual willing to pay for their services.
 Read more: [Transaction Surveillance Companies](/why-wasabi/TransactionSurveillanceCompanies.md)
 :::
 


### PR DESCRIPTION
adds transaction surveillance company to the glossary, the text is forked from the [separate chapter](/why-wasabi/TransactionSurveillanceCompanies.md).