### PR TITLE
Increase number of search results

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -92,7 +92,11 @@ module.exports = {
     lastUpdated: 'Last Updated',
     algolia: {
       indexName: 'wasabiwallet',
-      apiKey: 'c9d9b7688e0f9e6d0ed534655321a424'
+      apiKey: 'c9d9b7688e0f9e6d0ed534655321a424',
+      // See https://www.algolia.com/doc/api-reference/api-parameters/
+      algoliaOptions: {
+        hitsPerPage: 25
+      }
     },
     nav: [
       {


### PR DESCRIPTION
As the search results box is not scrollable it does not make sense to increase `hitsPerPage` parameter to more than 25. Closes #446.