### PR TITLE
Add smooth scroll to documentation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -84,6 +84,7 @@ module.exports = {
   themeConfig: {
     logo: "/Logo_without_text.png",
     searchPlaceholder: 'Search the docs...',
+    smoothScroll: true,
     displayAllHeaders: false,
     sidebarDepth: 0,
     repo: "zkSNACKs/WasabiDoc",


### PR DESCRIPTION
It gives a much better look to the website in general. The best is when an internal link (#) is clicked, e.g. in the FAQs