### PR TITLE
Algolia updates

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -50,7 +50,7 @@ module.exports = {
             title = ''
           }
           const slug = slugify(title)
-          return `<details id="${slug}"><summary><a href="#${slug}" aria-hidden="true" class="header-anchor">#</a> ${title}</summary>`
+          return `<details id="${slug}"><summary><a href="#${slug}" aria-hidden="true" class="header-anchor">#</a> <h4>${title}</h4></summary>`
         } else if (token.type === 'container_details_close') {
           return '</details>'
         }

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -129,6 +129,22 @@ body
       color $navbarTextColor
       font-size 1em
 
+    .search-box
+      order 10
+      margin 0 0 0 2rem
+
+    .ds-dropdown-menu
+      position fixed !important
+      top 3.25rem !important
+      bottom 0 !important
+      right 0 !important
+      overflow-y auto
+      border-radius 0
+      border-color lighten($navbarBgColor, 10%)
+
+      [class^="ds-dataset-"]
+        border-radius 0
+
     .suggestions
       background $navbarBgColor
       @media (prefers-color-scheme: light)

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -80,6 +80,9 @@ body
       opacity 1
     &::marker
       color $accentColor
+    h4
+      margin 0
+      display inline
 
   hr
     margin 2.5rem 0


### PR DESCRIPTION
These commits address the issues #449 and #450/#451:

The first one is fixed when merged: It makes the search the rightmost item in the navbar so that the results can be displayed as a sidebar on the right. This gives it more space. In addition to that the CSS changes introduced here make the list scrollable.

The latter issues might be solved by merging, which leads to Algolia reindexing the site. I could not fully verify this locally, but Algolia seems to link to the closest previous headline. The commit makes the FAQ summary a headline, which might fix #450. If so, this way we could restore the old behaviour of directly opening the FAQ item, fixing #451.

Needs to be deployed so that Algolia reindexes and we can test based on that.