### PR TITLE
Bump .NET Core SDK version to the required version 3.1

### DIFF
--- a/docs/.vuepress/variables.js
+++ b/docs/.vuepress/variables.js
@@ -1,6 +1,7 @@
 // Add custom variables here:
 const variables = {
   currentVersion: '1.1.10.2',
+  dotnetVersion: '3.1',
   zksnacksPublicKeyFingerprint: '6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E'
 }
 

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -170,7 +170,7 @@ A new version of Wasabi is released when ready, roughly once every #twoweeks.
 Yet in the meantime there are many commits to the latest master branch, not just bug fixes, but also new features and stability improvements.
 If you cannot wait until the next release, and you want to experience the most cutting-edge version of Wasabi, then you can [build the source code](/using-wasabi/BuildSource.md).
 
-The only two required tools are [Git](https://git-scm.com/downloads) and [.NET Core 2.2 SDK](https://www.microsoft.com/net/download) for "Building Apps".
+The only two required tools are [Git](https://git-scm.com/downloads) and [.NET Core ${dotnetVersion} SDK](https://www.microsoft.com/net/download) for "Building Apps".
 You can download every line in the code by `git clone https://github.com/zkSNACKs/WalletWasabi.git`, this will create a new directory called `WalletWasabi`.
 In order to build the Wallet software, change directory to `cd WalletWasabi/WalletWasabi.Gui`.
 Wasabi is written in C# with the .NET framework, and it is very easy to compile it from source, with only one command `dotnet build`, this will only take a minute or two.

--- a/docs/building-wasabi/HowToDebug.md
+++ b/docs/building-wasabi/HowToDebug.md
@@ -15,7 +15,7 @@ This guide is for giving detailed instructions about how to debug Wasabi Wallet 
 We will focus on how to achieve this with `vscode` first because that is the cross-platform IDE used by some of the developer team members.
 
 ## Before to start
-We assume the reader has already read the project [README](https://github.com/zkSNACKs/WalletWasabi/blob/master/README.md) file  and has installed the .NET Core SDK, knows how to clone the repository and build the Wasabi solution.
+We assume the reader has already read the project [README](https://github.com/zkSNACKs/WalletWasabi/blob/master/README.md) file  and has installed the [.NET Core ${dotnetVersion} SDK](https://www.microsoft.com/net/download), knows how to clone the repository and build the Wasabi solution.
 
 
 ## Install VS Code and extensions
@@ -56,7 +56,7 @@ This file contains the list of projects that can be launched, how to do it, what
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build-client",
-      "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp3.1/WalletWasabi.Gui.dll",
+      "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp${dotnetVersion}/WalletWasabi.Gui.dll",
       "args": [],
       "cwd": "${workspaceFolder}/WalletWasabi.Gui",
       "stopAtEntry": false,
@@ -99,7 +99,7 @@ Add the following launcher to the array of `configurations` in the `.vscode/laun
    "type": "coreclr",
    "request": "launch",
    "preLaunchTask": "build-backend",
-   "program": "${workspaceFolder}/WalletWasabi.Backend/bin/Debug/netcoreapp3.1/WalletWasabi.Backend.dll",
+   "program": "${workspaceFolder}/WalletWasabi.Backend/bin/Debug/netcoreapp${dotnetVersion}/WalletWasabi.Backend.dll",
    "args": [],
    "cwd": "${workspaceFolder}/WalletWasabi.Backend",
    "stopAtEntry": false,
@@ -164,7 +164,7 @@ Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugg
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build-client",
-            "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp3.1/WalletWasabi.Gui.dll",
+            "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp${dotnetVersion}/WalletWasabi.Gui.dll",
             "args": [],
             "cwd": "${workspaceFolder}/WalletWasabi.Gui",
             "stopAtEntry": false,
@@ -175,7 +175,7 @@ Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugg
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build-backend",
-            "program": "${workspaceFolder}/WalletWasabi.Backend/bin/Debug/netcoreapp3.1/WalletWasabi.Backend.dll",
+            "program": "${workspaceFolder}/WalletWasabi.Backend/bin/Debug/netcoreapp${dotnetVersion}/WalletWasabi.Backend.dll",
             "args": [],
             "cwd": "${workspaceFolder}/WalletWasabi.Backend",
             "stopAtEntry": false,
@@ -206,7 +206,7 @@ Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugg
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build-client",
-            "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp3.1/WalletWasabi.Gui.dll",
+            "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp${dotnetVersion}/WalletWasabi.Gui.dll",
             "args": [
                 "mix", "--wallet:TestNet"
             ],

--- a/docs/building-wasabi/HowToDebug.md
+++ b/docs/building-wasabi/HowToDebug.md
@@ -56,7 +56,7 @@ This file contains the list of projects that can be launched, how to do it, what
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build-client",
-      "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp3.0/WalletWasabi.Gui.dll",
+      "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp3.1/WalletWasabi.Gui.dll",
       "args": [],
       "cwd": "${workspaceFolder}/WalletWasabi.Gui",
       "stopAtEntry": false,
@@ -99,7 +99,7 @@ Add the following launcher to the array of `configurations` in the `.vscode/laun
    "type": "coreclr",
    "request": "launch",
    "preLaunchTask": "build-backend",
-   "program": "${workspaceFolder}/WalletWasabi.Backend/bin/Debug/netcoreapp3.0/WalletWasabi.Backend.dll",
+   "program": "${workspaceFolder}/WalletWasabi.Backend/bin/Debug/netcoreapp3.1/WalletWasabi.Backend.dll",
    "args": [],
    "cwd": "${workspaceFolder}/WalletWasabi.Backend",
    "stopAtEntry": false,
@@ -164,7 +164,7 @@ Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugg
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build-client",
-            "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp3.0/WalletWasabi.Gui.dll",
+            "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp3.1/WalletWasabi.Gui.dll",
             "args": [],
             "cwd": "${workspaceFolder}/WalletWasabi.Gui",
             "stopAtEntry": false,
@@ -175,7 +175,7 @@ Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugg
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build-backend",
-            "program": "${workspaceFolder}/WalletWasabi.Backend/bin/Debug/netcoreapp3.0/WalletWasabi.Backend.dll",
+            "program": "${workspaceFolder}/WalletWasabi.Backend/bin/Debug/netcoreapp3.1/WalletWasabi.Backend.dll",
             "args": [],
             "cwd": "${workspaceFolder}/WalletWasabi.Backend",
             "stopAtEntry": false,
@@ -206,7 +206,7 @@ Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugg
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build-client",
-            "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp3.0/WalletWasabi.Gui.dll",
+            "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp3.1/WalletWasabi.Gui.dll",
             "args": [
                 "mix", "--wallet:TestNet"
             ],
@@ -278,7 +278,7 @@ Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugg
                 "/consoleloggerparameters:NoSummary"
                 ],
             "problemMatcher": "$msCompile"
-        },        
+        },
         {
             "label": "watch",
             "command": "dotnet",
@@ -296,7 +296,7 @@ Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugg
 }
 ```
 
-## How to setup and run the whole system 
+## How to setup and run the whole system
 
 Sometimes, as developers, we need to test an advanced interaction between the Bitcoin Core node, the Coordinator and one or more Wasabi clients, just imagine the case we want to verify the system behavior after a blockchain reorg. In this cases we have to setup and run all the components and use the regtest.
 
@@ -310,7 +310,7 @@ Download and install Bitcoin Core from https://bitcoincore.org/bin/.
 There are more than one way to do this:
 
 * From **VSCode** go to the Debug panel (CTRL+SHIFT+D), select `Wasabi Backend .NET Core` and press play.
-* From **Terminal** just type `dotnet run <WasabiProjectFolder>/WalletWasabi.Backend/WalletWasabi.Backend.csproj` 
+* From **Terminal** just type `dotnet run <WasabiProjectFolder>/WalletWasabi.Backend/WalletWasabi.Backend.csproj`
 
 ### Get some coins to test
 

--- a/docs/using-wasabi/BuildSource.md
+++ b/docs/using-wasabi/BuildSource.md
@@ -10,7 +10,7 @@
 ## Get The Requirements
 
 1. Install [Git](https://git-scm.com/downloads)
-2. Install [.NET Core 3.1 SDK](https://www.microsoft.com/net/download) for "Building Apps"
+2. Install [.NET Core ${dotnetVersion} SDK](https://www.microsoft.com/net/download) for "Building Apps"
 
 :::tip Optional for privacy
 You can disable .NET's telemetry, which is sending some usage information to Microsoft, by typing:

--- a/docs/using-wasabi/DeterministicBuild.md
+++ b/docs/using-wasabi/DeterministicBuild.md
@@ -19,7 +19,7 @@ This guide describes how to reproduce Wasabi's builds.
 
 ## 1. Assert Correct Environment
 
-In order to reproduce Wasabi's builds you need [Git](https://git-scm.com/downloads), [Windows 10](https://www.microsoft.com/en-us/software-download/windows10ISO) and [.NET Core 3.1 SDK](https://www.microsoft.com/net/download).
+In order to reproduce Wasabi's builds you need [Git](https://git-scm.com/downloads), [Windows 10](https://www.microsoft.com/en-us/software-download/windows10ISO) and [.NET Core ${dotnetVersion} SDK](https://www.microsoft.com/net/download).
 
 ## 2. Reproduce Builds
 


### PR DESCRIPTION
As per this commit in the Wasabi Wallet repo https://github.com/zkSNACKs/WalletWasabi/commit/e6107829f8768b57aaf4d3cc80bbff9ecde427ee.