### PR TITLE
[USING] Add chapter on Send

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -154,6 +154,7 @@ module.exports = {
           children: [
             "/using-wasabi/WalletGeneration.md",
             "/using-wasabi/Receive.md",
+            "/using-wasabi/Send.md",
             "/using-wasabi/CoinJoin.md",
             "/using-wasabi/PasswordFinder.md",
             "/using-wasabi/ColdWasabi.md",

--- a/docs/using-wasabi/README.md
+++ b/docs/using-wasabi/README.md
@@ -22,6 +22,7 @@ Further tutorials about the different parts of the wallet, for newbies and power
 #### Using Wasabi
 - [Wallet Generation](/using-wasabi/WalletGeneration.md)
 - [Receive](/using-wasabi/Receive.md)
+- [Send](/using-wasabi/Send.md)
 - [CoinJoin](/using-wasabi/CoinJoin.md)
 - [Password Finder](/using-wasabi/PasswordFinder.md)
 - [Cold-Wasabi Protocol](/using-wasabi/ColdWasabi.md)

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -13,6 +13,8 @@
 
 A coin is an unspent transaction output, a chunk of bitcoin which can be send in a future transaction.
 In the Wasabi wallet `Send` tab, you see a list of all the coins you can spend because you have the private keys.
+You can get a coin by first [receiving](/using-wasabi/Receive.md) them from someone else, for example by earning them or buying them for fiat currency.
+You can spend one or more whole coins by selecting it in the `Send` tab, if your payment amount is below the value of the selected coins, then you will receive a [change coin](/using-wasabi/Change.md) back.
 
 ![](/Send.png)
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -65,7 +65,7 @@ This metadata will be used to build an accurate cluster of observers who knows a
 ## Amount
 
 In the `Amount` text box you can specify how many bitcoins the receiving address will gain.
-If it is blow the value of the selected inputs, then the leftover will be send to an automatically generated change address of yours.
+If it is below the value of the selected inputs, then the leftover value will be sent to an automatically generated change address of yours.
 You can send a whole coin by selecting the `Max` button, which will build a transaction with only one output, the receiving address, and no change.
 You can also see the current US Dollar value of the sending amount.
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -13,7 +13,7 @@
 
 1. Select the coins you want to spend.
 2. Specify a destination address.
-3. Label the observers of this transaction.
+3. If necessary label the observers of this transaction.
 4. Specify the amount to send to the destination address, press the `Max` button to send the whole coins.
 5. Select a mining fee.
 6. Enter the password.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -90,7 +90,7 @@ In some cases, there is very little demand for block space, and then Wasabi will
 ## Password
 
 In order to spend a coin, the transaction must be signed by the private key corresponding to that coin.
-Wasabi stores your master private key on the computer, encrypted with the password that you specified during [wallet generation](/using-wasabi/WalletGeneration.md#what-password-to-choose).
+Wasabi stores your master private key on the computer, encrypted with the password that you specified during the [wallet generation](/using-wasabi/WalletGeneration.md#what-password-to-choose).
 To spend a coin you need to type in or copy and paste the password, which decrypts the master private key, which is used to sign the transaction.
 Afterwards the password is wiped from memory.
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -14,7 +14,7 @@
 1. Select the coins you want to spend.
 2. Specify a destination address.
 3. Label the observers of this transaction.
-4. Specify the amount send to the destination address, press the `Max` button to send a whole coin.
+4. Specify the amount to send to the destination address, press the `Max` button to send the whole coins.
 5. Select a mining fee.
 6. Enter the password.
 7. Click `Send Transaction`.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -26,7 +26,7 @@
 A coin is an unspent transaction output (UTXO), a chunk of bitcoin which can be send in a future transaction.
 In the Wasabi wallet `Send` tab, you see a list of all the coins you can spend because you have their private keys.
 You can get a coin by first [receiving](/using-wasabi/Receive.md) them from someone else, for example by earning them or buying them for fiat currency.
-You can spend one or more coins by selecting it in the `Send` tab, if your payment amount is below the value of the selected coins, then you will receive a [change coin](/using-wasabi/Change.md) back.
+You can spend one or more coins by selecting them in the `Send` tab, if your payment amount is below the value of the selected coins, then you will receive a [change coin](/using-wasabi/Change.md) back.
 
 ## Clusters
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -77,7 +77,7 @@ So in order to increase your privacy, you can set a non-rounded amount, like `0.
 
 Every transaction must specify a fee which incentives the miner to include it in a block, it is calculated by `value of inputs - value of outputs`.
 The higher the fee per virtual byte (vbyte) transaction size, the more likely miners are to confirm this transaction.
-Wasabi uses Bitcoin Core's `smart fee` algorithm to estimate the hours it will take to confirm at the given fee level.
+Wasabi uses Bitcoin Core's `smart fee` algorithm to estimate the time it will take to confirm at the given fee level.
 You can change the fee by moving the slider, or even specify it manually by activating this functionality in the settings.
 By clicking on the fee in the brackets below the slider, you can cycle through `total bitcoin amount`, `sats per vbyte`, `percentage fee of sending amount` or `US Dollar equivalent`.
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -63,7 +63,7 @@ This metadata will be used to build an accurate cluster of observers who knows a
 
 ## Amount
 
-In the amount text box you can specify how many bitcoins the receiving address will gain.
+In the `Amount` text box you can specify how many bitcoins the receiving address will gain.
 If it is blow the value of the selected inputs, then the leftover will be send to an automatically generated change address of yours.
 You can send a whole coin by selecting the `Max` button, which will build a transaction with only one output, the receiving address, and no change.
 You can also see the current US Dollar value of the sending amount.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -60,7 +60,7 @@ Similar to the `Receive` tab, you must label every new address with the observer
 In the `Send` tab an address is automatically generated to receive the change amount.
 A label is not required when you send an entire coin, as there will be no change left.
 The observer of a sending transaction is of course the receiver of it, as well as any other third party that will find out about it, for example a payment processor or an exchange.
-This metadata will be used to build an accurate cluster of observers who knows about your coins.
+This metadata will be used to build an accurate cluster of observers who know about your coins.
 
 ## Amount
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -78,4 +78,27 @@ In some cases, there is very little demand for blockspace, and then Wasabi will 
 
 ## Password
 
+In order to spend a coin, the transaction must be signed by the private key corresponding to that coin.
+Wasabi stores your master private key on the computer, encrypted with the password that you specified during [wallet generation](/using-wasabi/WalletGeneration.md#what-password-to-choose).
+To spend a coin you need to type in or copy and paste the password, which decrypts the master private key, which is used to sign the transaction.
+Afterwards the password is wiped from memory.
+
 ## How to send bitcoin step by step
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -51,7 +51,7 @@ By default they have an anonymity set of `2`, `21` and `50`, however, this can b
 When sending bitcoin, you need to know the destination address of the receiver.
 This commits to the spending condition that the receiver agrees to have for this coin.
 The address can be a public key hash [starting with 1...], a script hash [starting with 3...], or a native segwit bech32 public key hash [starting with bc1q...].
-Make sure that you ask the receiver for a [new address](/using-wasabi/AddressReuse.md) for every payment to protect your privacy.
+Make sure that you ask the receiver for a [new address](/using-wasabi/AddressReuse.md) for every payment to protect your privacy and theirs.
 Wasabi will calculate the checksum and notify you if the provided address is wrong.
 
 ## Label

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -23,22 +23,22 @@
 
 ## Coins
 
-A coin is an unspent transaction output (UTXO), a chunk of bitcoin which can be sent in a future transaction.
-In the Wasabi wallet `Send` tab, you see a list of all the coins you can spend because you have their private keys.
+A coin is an unspent transaction output (UTXO), a chunk of bitcoin which can be send in a future transaction.
+In the Wasabi wallet `Send` tab, you see a list of all the coins you can spend because you have their private key.
 You can get a coin by first [receiving](/using-wasabi/Receive.md) them from someone else, for example by earning them or buying them for fiat currency.
-You can spend one or more whole coins by selecting it in the `Send` tab, if your payment amount is below the value of the selected coins, then you will receive a [change coin](/using-wasabi/Change.md) back.
+You can spend one or more coins by selecting it in the `Send` tab, if your payment amount is below the value of the selected coins, then you will receive a [change coin](/using-wasabi/Change.md) back.
 
 ## Clusters
 
 Every time you receive a payment, you first must [label the observers](/using-wasabi/Receive.md#the-importance-of-labeling) who know this address is yours.
 This transaction metadata is used to build a cluster of which parties know about your coins.
 For example, if you receive a coin from Alice, then the cluster is `Alice`. 
-If you now send half of this coin to Bob, then the cluster of the change coin is `Alice, Bob`.
+If you now send half of this coin to Bob, then the cluster of your change coin is `Alice, Bob`.
 The goal is to reduce the number of observers who know about your coins.
 
 ## Anonymity Set
 
-When you do a Wasabi [CoinJoin](/using-wasabi/CoinJoin.md), many peers register coins in the input of the transaction, and in the output there are several equal value coins, for example 100 coins worth exactly 0.1 bitcoin.
+In a Wasabi [CoinJoin](/using-wasabi/CoinJoin.md), many peers register coins in the input of the transaction, and in the output there are several equal value coins, for example 100 coins worth exactly 0.1 bitcoin.
 This means that when looking at one of these CoinJoin outputs, there is a 1 in 100 chance to find the corresponding input.
 Thus the higher the anonymity set, the more your post-mix coin is delinked from the pre-mix history.
 Wasabi shows you three levels of anonymity set, the yellow shield, the green shield and the check mark shield.
@@ -57,9 +57,9 @@ Wasabi will calculate the checksum and notify you if the provided address is wro
 ## Label
 
 Similar to the `Receive` tab, you must label every new address with the observers who know that this is your address.
-In the `Send` tab an address is generated to receive the change amount, thus a label is not required when you send the max amount.
+In the `Send` tab an address is automatically generated to receive the change amount, thus a label is not required when you send the max amount.
 The observer of a sending transaction is of course the receiver of it, as well as any other third party that will find out about it, for example a payment processor or exchange.
-This metadata will be used to build an curate cluster of who knows about your coins.
+This metadata will be used to build an accurate cluster of observers who knows about your coins.
 
 ## Amount
 
@@ -78,11 +78,11 @@ Every transaction must specify a fee which incentives the miner to include it in
 The higher the fee per virtual byte transaction size, the more likely miners are to confirm this transaction.
 Wasabi uses Bitcoin Core's `smart fee` algorithm to estimate the hours it will take to confirm at the given fee level.
 You can change the fee by moving the slider, or even specify it manually by activating this functionality in the settings.
-By clicking on the fee in the brackets below the slider, you can cycle through total bitcoin amount, sats per vbyte, percentage fee of sending amount or US Dollar equivalent.
+By clicking on the fee in the brackets below the slider, you can cycle through `total bitcoin amount`, `sats per vbyte`, `percentage fee of sending amount` or `US Dollar equivalent`.
 
 ![](/SendFeeSlider.png)
 
-In some cases, there is very little demand for blockspace, and then Wasabi will set the minimum fee of `1 sat/vbyte`.
+In some cases, there is very little demand for block space, and then Wasabi will set the minimum fee of `1 sat/vbyte`.
 
 ![](/SendNoFee.png)
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -9,14 +9,14 @@
 
 [[toc]]
 
+![](/Send.png)
+
 ## Coins
 
 A coin is an unspent transaction output (UTXO), a chunk of bitcoin which can be sent in a future transaction.
 In the Wasabi wallet `Send` tab, you see a list of all the coins you can spend because you have their private keys.
 You can get a coin by first [receiving](/using-wasabi/Receive.md) them from someone else, for example by earning them or buying them for fiat currency.
 You can spend one or more whole coins by selecting it in the `Send` tab, if your payment amount is below the value of the selected coins, then you will receive a [change coin](/using-wasabi/Change.md) back.
-
-![](/Send.png)
 
 ## Clusters
 
@@ -49,7 +49,16 @@ In the `Send` tab an address is generated to receive the change amount, thus a l
 The observer of a sending transaction is of course the receiver of it, as well as any other third party that will find out about it, for example a payment processor or exchange.
 This metadata will be used to build an curate cluster of who knows about your coins.
 
-## Payment Amount
+## Amount
+
+In the amount text box you can specify how many bitcoins the receiving address will gain.
+If it is blow the value of the selected inputs, then the leftover will be send to an automatically generated change address of yours.
+You can send a whole coin by selecting the `Max` button, which will build a transaction with only one output, the receiving address, and no change.
+You can also see the current US Dollar value of the sending amount.
+
+If you specify a rounded amount, like `0.01000000 bitcoin`, then the change output will not be rounded, like `0.08968413 bitcoin`.
+This makes it easy to find out that the spending amount was the `0.01 bitcoin`, and that the other output is the change back to the sender.
+So in order to increase your privacy, you can set a non-rounded amount, like `0.01016843`.
 
 ## Mining Fee
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -31,7 +31,7 @@ You can spend one or more coins by selecting it in the `Send` tab, if your payme
 ## Clusters
 
 Every time you receive a payment, you first must [label the observers](/using-wasabi/Receive.md#the-importance-of-labeling) who know this address is yours.
-This transaction metadata is used to build a cluster of which parties know about your coins.
+This transaction metadata is used to build a cluster of which people know about your coins.
 For example, if you receive a coin from Alice, then the cluster is `Alice`. 
 If you now send half of this coin to Bob, then the cluster of your change coin is `Alice, Bob`.
 The goal is to reduce the number of observers who know about your coins.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -24,7 +24,7 @@
 ## Coins
 
 A coin is an unspent transaction output (UTXO), a chunk of bitcoin which can be send in a future transaction.
-In the Wasabi wallet `Send` tab, you see a list of all the coins you can spend because you have their private key.
+In the Wasabi wallet `Send` tab, you see a list of all the coins you can spend because you have their private keys.
 You can get a coin by first [receiving](/using-wasabi/Receive.md) them from someone else, for example by earning them or buying them for fiat currency.
 You can spend one or more coins by selecting it in the `Send` tab, if your payment amount is below the value of the selected coins, then you will receive a [change coin](/using-wasabi/Change.md) back.
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -23,7 +23,7 @@
 
 ## Coins
 
-A coin is an unspent transaction output (UTXO), a chunk of bitcoin which can be send in a future transaction.
+A coin is an unspent transaction output (UTXO), a chunk of bitcoin which can be sent in a future transaction.
 In the Wasabi wallet `Send` tab, you see a list of all the coins you can spend because you have their private keys.
 You can get a coin by first [receiving](/using-wasabi/Receive.md) them from someone else, for example by earning them or buying them for fiat currency.
 You can spend one or more coins by selecting them in the `Send` tab, if your payment amount is below the value of the selected coins, then you will receive a [change coin](/using-wasabi/Change.md) back.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -1,0 +1,26 @@
+---
+{
+  "title": "Send",
+  "description": "A step by step guide on how to send bitcoin in Wasabi. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+}
+---
+
+# Send
+
+[[toc]]
+
+## Coins
+
+## Clusters
+
+## Anonymity Set
+
+## Receiving Address
+
+## Payment Amount
+
+## Mining Fee
+
+## Password
+
+## How to send bitcoin step by step

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -96,5 +96,5 @@ Afterwards the password is wiped from memory.
 
 ## Broadcast
 
-Once the transaction is singed, Wasabi will connect to a random Bitcoin P2P node over Tor and provide this transaction, then it will immediately disconnect.
+Once the transaction is signed, Wasabi will connect to a random Bitcoin P2P node over Tor and provide this transaction, then it will immediately disconnect.
 This first node will gossip the transaction throughout the network, also to miners who include it in a block.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -92,3 +92,8 @@ In order to spend a coin, the transaction must be signed by the private key corr
 Wasabi stores your master private key on the computer, encrypted with the password that you specified during [wallet generation](/using-wasabi/WalletGeneration.md#what-password-to-choose).
 To spend a coin you need to type in or copy and paste the password, which decrypts the master private key, which is used to sign the transaction.
 Afterwards the password is wiped from memory.
+
+## Broadcast
+
+Once the transaction is singed, Wasabi will connect to a random Bitcoin P2P node over Tor and provide this transaction, then it will immediately disconnect.
+This first node will gossip the transaction throughout the network, also to miners who include it in a block.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -32,7 +32,7 @@ You can spend one or more coins by selecting it in the `Send` tab, if your payme
 
 Every time you receive a payment, you first must [label the observers](/using-wasabi/Receive.md#the-importance-of-labeling) who know this address is yours.
 This transaction metadata is used to build a cluster of which people know about your coins.
-For example, if you receive a coin from Alice, then the cluster is `Alice`. 
+For example, if you receive a coin from Alice, then the cluster is `Alice`.
 If you now send half of this coin to Bob, then the cluster of your change coin is `Alice, Bob`.
 The goal is to reduce the number of observers who know about your coins.
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -34,7 +34,7 @@ Every time you receive a payment, you first must [label the observers](/using-wa
 This transaction metadata is used to build a cluster of which people know about your coins.
 For example, if you receive a coin from Alice, then the cluster is `Alice`.
 If you now send half of this coin to Bob, then the cluster of your change coin is `Alice, Bob`.
-The goal is to know the observers who know about your coins.
+The goal is to know the observers who know about your coins and try to reduce their number for each coin.
 
 ## Anonymity Set
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -34,6 +34,8 @@ Thus the higher the anonymity set, the more your post-mix coin is delinked from 
 Wasabi shows you three levels of anonymity set, the yellow shield, the green shield and the check mark shield.
 By default they have an anonymity set of `2`, `21` and `50`, however, this can be [changed in the settings](/FAQ/FAQ-UseWasabi.md#how-can-i-change-the-anonset-target).
 
+![](/SendAnonset.png)
+
 ## Receiving Address
 
 When sending bitcoin, you need to know the destination address of the receiver.
@@ -61,6 +63,18 @@ This makes it easy to find out that the spending amount was the `0.01 bitcoin`, 
 So in order to increase your privacy, you can set a non-rounded amount, like `0.01016843`.
 
 ## Mining Fee
+
+Every transaction must specify a fee which incentives the miner to include it in a block, it is calculated by `value of inputs - value of outputs`.
+The higher the fee per virtual byte transaction size, the more likely miners are to confirm this transaction.
+Wasabi uses Bitcoin Core's `smart fee` algorithm to estimate the hours it will take to confirm at the given fee level.
+You can change the fee by moving the slider, or even specify it manually by activating this functionality in the settings.
+By clicking on the fee in the brackets below the slider, you can cycle through total bitcoin amount, sats per vbyte, percentage fee of sending amount or US Dollar equivalent.
+
+![](/SendFeeSlider.png)
+
+In some cases, there is very little demand for blockspace, and then Wasabi will set the minimum fee of `1 sat/vbyte`.
+
+![](/SendNoFee.png)
 
 ## Password
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -36,6 +36,12 @@ By default they have an anonymity set of `2`, `21` and `50`, however, this can b
 
 ## Receiving Address
 
+When sending bitcoin, you need to know the destination address of the receiver.
+This commits to the spending condition that the receiver agrees to have for this coin.
+The address can be a public key hash [starting with 1...], a script hash [starting with 3...], or a native segwit bech32 public key hash [starting with bc1q...].
+Make sure that you ask the receiver for a [new address](/using-wasabi/AddressReuse.md) for every payment to protect your privacy.
+Wasabi will calculate the checksum and notify you if the provided address is wrong.
+
 ## Payment Amount
 
 ## Mining Fee

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -57,7 +57,8 @@ Wasabi will calculate the checksum and notify you if the provided address is wro
 ## Label
 
 Similar to the `Receive` tab, you must label every new address with the observers who know that this is your address.
-In the `Send` tab an address is automatically generated to receive the change amount, thus a label is not required when you send the max amount.
+In the `Send` tab an address is automatically generated to receive the change amount.
+A label is not required when you send an entire coin, as there will be no change left.
 The observer of a sending transaction is of course the receiver of it, as well as any other third party that will find out about it, for example a payment processor or exchange.
 This metadata will be used to build an accurate cluster of observers who knows about your coins.
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -75,7 +75,7 @@ So in order to increase your privacy, you can set a non-rounded amount, like `0.
 ## Mining Fee
 
 Every transaction must specify a fee which incentives the miner to include it in a block, it is calculated by `value of inputs - value of outputs`.
-The higher the fee per virtual byte transaction size, the more likely miners are to confirm this transaction.
+The higher the fee per virtual byte (vbyte) transaction size, the more likely miners are to confirm this transaction.
 Wasabi uses Bitcoin Core's `smart fee` algorithm to estimate the hours it will take to confirm at the given fee level.
 You can change the fee by moving the slider, or even specify it manually by activating this functionality in the settings.
 By clicking on the fee in the brackets below the slider, you can cycle through `total bitcoin amount`, `sats per vbyte`, `percentage fee of sending amount` or `US Dollar equivalent`.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -34,7 +34,7 @@ Every time you receive a payment, you first must [label the observers](/using-wa
 This transaction metadata is used to build a cluster of which people know about your coins.
 For example, if you receive a coin from Alice, then the cluster is `Alice`.
 If you now send half of this coin to Bob, then the cluster of your change coin is `Alice, Bob`.
-The goal is to reduce the number of observers who know about your coins.
+The goal is to know the observers who know about your coins.
 
 ## Anonymity Set
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -11,6 +11,11 @@
 
 ## Coins
 
+A coin is an unspent transaction output, a chunk of bitcoin which can be send in a future transaction.
+In the Wasabi wallet `Send` tab, you see a list of all the coins you can spend because you have the private keys.
+
+![](/Send.png)
+
 ## Clusters
 
 ## Anonymity Set

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -70,7 +70,7 @@ You can send a whole coin by selecting the `Max` button, which will build a tran
 You can also see the current US Dollar value of the sending amount.
 
 If you specify a rounded amount, like `0.01000000 bitcoin`, then the change output will not be rounded, like `0.08968413 bitcoin`.
-This makes it easy to find out that the spending amount was the `0.01 bitcoin`, and that the other output is the change back to the sender.
+This makes it easy for an observer to conclude that the spending amount was the `0.01 bitcoin`, and that the other output is the change back to the sender.
 So in order to increase your privacy, you can set a non-rounded amount, like `0.01016843`.
 
 ## Mining Fee

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -9,6 +9,16 @@
 
 [[toc]]
 
+## How to send bitcoin step by step
+
+1. Select the coins you want to spend.
+2. Specify a destination address.
+3. Label the observers of this transaction.
+4. Specify the amount send to the destination address, press the `Max` button to send a whole coin.
+5. Select a mining fee.
+6. Enter the password.
+7. Click `Send Transaction`.
+
 ![](/Send.png)
 
 ## Coins
@@ -82,23 +92,3 @@ In order to spend a coin, the transaction must be signed by the private key corr
 Wasabi stores your master private key on the computer, encrypted with the password that you specified during [wallet generation](/using-wasabi/WalletGeneration.md#what-password-to-choose).
 To spend a coin you need to type in or copy and paste the password, which decrypts the master private key, which is used to sign the transaction.
 Afterwards the password is wiped from memory.
-
-## How to send bitcoin step by step
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -59,7 +59,7 @@ Wasabi will calculate the checksum and notify you if the provided address is wro
 Similar to the `Receive` tab, you must label every new address with the observers who know that this is your address.
 In the `Send` tab an address is automatically generated to receive the change amount.
 A label is not required when you send an entire coin, as there will be no change left.
-The observer of a sending transaction is of course the receiver of it, as well as any other third party that will find out about it, for example a payment processor or exchange.
+The observer of a sending transaction is of course the receiver of it, as well as any other third party that will find out about it, for example a payment processor or an exchange.
 This metadata will be used to build an accurate cluster of observers who knows about your coins.
 
 ## Amount

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -28,6 +28,12 @@ The goal is to reduce the number of observers who know about your coins.
 
 ## Anonymity Set
 
+When you do a Wasabi [CoinJoin](/using-wasabi/CoinJoin.md), many peers register coins in the input of the transaction, and in the output there are several equal value coins, for example 100 coins worth exactly 0.1 bitcoin.
+This means that when looking at one of these CoinJoin outputs, there is a 1 in 100 chance to find the corresponding input.
+Thus the higher the anonymity set, the more your post-mix coin is delinked from the pre-mix history.
+Wasabi shows you three levels of anonymity set, the yellow shield, the green shield and the check mark shield.
+By default they have an anonymity set of `2`, `21` and `50`, however, this can be [changed in the settings](/FAQ/FAQ-UseWasabi.md#how-can-i-change-the-anonset-target).
+
 ## Receiving Address
 
 ## Payment Amount

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -91,7 +91,7 @@ In some cases, there is very little demand for block space, and then Wasabi will
 
 In order to spend a coin, the transaction must be signed by the private key corresponding to that coin.
 Wasabi stores your master private key on the computer, encrypted with the password that you specified during the [wallet generation](/using-wasabi/WalletGeneration.md#what-password-to-choose).
-To spend a coin you need to type in or copy and paste the password, which decrypts the master private key, which is used to sign the transaction.
+To spend a coin you need to type in or copy and paste the password, which decrypts the master private key, which is used to derive the child private key that signs the transaction.
 Afterwards the password is wiped from memory.
 
 ## Broadcast

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -78,7 +78,7 @@ So in order to increase your privacy, you can set a non-rounded amount, like `0.
 Every transaction must specify a fee which incentives the miner to include it in a block, it is calculated by `value of inputs - value of outputs`.
 The higher the fee per virtual byte (vbyte) transaction size, the more likely miners are to confirm this transaction.
 Wasabi uses Bitcoin Core's `smart fee` algorithm to estimate the time it will take to confirm at the given fee level.
-You can change the fee by moving the slider, or even specify it manually by activating this functionality in the settings.
+You can change the fee by moving the slider, or even specify it manually by activating this functionality in the [settings](/FAQ/FAQ-UseWasabi.html#how-do-i-set-custom-fee-rate).
 By clicking on the fee in the brackets below the slider, you can cycle through `total bitcoin amount`, `sats per vbyte`, `percentage fee of sending amount` or `US Dollar equivalent`.
 
 ![](/SendFeeSlider.png)

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -20,6 +20,12 @@ You can spend one or more whole coins by selecting it in the `Send` tab, if your
 
 ## Clusters
 
+Every time you receive a payment, you first must [label the observers](/using-wasabi/Receive.md#the-importance-of-labeling) who know this address is yours.
+This transaction metadata is used to build a cluster of which parties know about your coins.
+For example, if you receive a coin from Alice, then the cluster is `Alice`. 
+If you now send half of this coin to Bob, then the cluster of the change coin is `Alice, Bob`.
+The goal is to reduce the number of observers who know about your coins.
+
 ## Anonymity Set
 
 ## Receiving Address

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -42,6 +42,13 @@ The address can be a public key hash [starting with 1...], a script hash [starti
 Make sure that you ask the receiver for a [new address](/using-wasabi/AddressReuse.md) for every payment to protect your privacy.
 Wasabi will calculate the checksum and notify you if the provided address is wrong.
 
+## Label
+
+Similar to the `Receive` tab, you must label every new address with the observers who know that this is your address.
+In the `Send` tab an address is generated to receive the change amount, thus a label is not required when you send the max amount.
+The observer of a sending transaction is of course the receiver of it, as well as any other third party that will find out about it, for example a payment processor or exchange.
+This metadata will be used to build an curate cluster of who knows about your coins.
+
 ## Payment Amount
 
 ## Mining Fee

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -41,7 +41,7 @@ The goal is to know the observers who know about your coins.
 In a Wasabi [CoinJoin](/using-wasabi/CoinJoin.md), many peers register coins in the input of the transaction, and in the output there are several equal value coins, for example 100 coins worth exactly 0.1 bitcoin.
 This means that when looking at one of these CoinJoin outputs, there is a 1 in 100 chance to find the corresponding input.
 Thus the higher the anonymity set, the more your post-mix coin is delinked from the pre-mix history.
-Wasabi shows you three levels of anonymity set, the yellow shield, the green shield and the check mark shield.
+Wasabi shows you three levels of anonymity sets: the yellow shield, the green shield and the check-mark shield.
 By default they have an anonymity set of `2`, `21` and `50`, however, this can be [changed in the settings](/FAQ/FAQ-UseWasabi.md#how-can-i-change-the-anonset-target).
 
 ![](/SendAnonset.png)

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -97,4 +97,4 @@ Afterwards the password is wiped from memory.
 ## Broadcast
 
 Once the transaction is signed, Wasabi will connect to a random Bitcoin P2P node over Tor and provide this transaction, then it will immediately disconnect.
-This first node will gossip the transaction throughout the network, also to miners who include it in a block.
+This first node will gossip the transaction throughout the network, then miners can include it in a block.


### PR DESCRIPTION
This adds a chapter in `/using-wasabi/Send.md` about all the nuances on `Sending` bitcoin with Wasabi. Similar to the `Receive.md` chapter, it is about all the aspects that are relevant to Sending. 

This ready for review branch contains: a brief step by step guide, as well as thorough explanations of coins, clusters, anonset, receiving address, labels, payment amount, mining fee, password, and broadcasting.

I barely cover coin selection strategies here, as I think this deserves it's own chapter in `/using-wasabi/CoinSelection.md` under `Privacy Best Practices`.