### PR TITLE
Drop Windows 7

### DIFF
--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -275,7 +275,7 @@ For the complete explanation please read [ZeroLink: The Bitcoin Fungibility Fram
 ### What are the minimal requirements to run Wasabi?
 
 - 64-bit architecture
-- Windows 7 SP1+
+- Windows 10+
 - macOS 10.13+
 - Debian 9+
 - Ubuntu 16.04+


### PR DESCRIPTION
The sister PR to https://github.com/zkSNACKs/WalletWasabi/pull/2960, to drop Windows 7 support, and only advertise Windows 10 support.