### PR TITLE
Fix typo's

### DIFF
--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -105,7 +105,7 @@ In the second case, if you happen to broadcast a transaction of yours to a full 
 
 There are countless reasons why it is the only logical choice to be [bitcoin-only](https://bitcoin-only.com).
 With Bitcoin we have a once in a lifetime opportunity to manifest libre sound money.
-If we suceed, then this might emerge an utmost beautiful agora of sovereign individuals.
+If we succeed, then this might emerge an utmost beautiful agora of sovereign individuals.
 If we fail, then this will conjure up the most horrific Orwellian nightmare.
 There is no room for wasted time and energy, this Great Work requires our full attention.
 Any line of code written to support a random shitcoin takes away scarce developer time to work on real problems.

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -552,7 +552,7 @@ The fee you pay to get confirmation on the Bitcoin timechain is denominated in s
 This means that the larger your transaction size, meaning the number of inputs and outputs, the more total bitcoin you have to pay for confirmation.
 If you want faster confirmation, then you have to pay proportionally more sats per vByte.
 
-You can toggle the display of the fee between `sat/vByte` & `percentage of transfered value` & `total bitcoin` & `total USD` by clicking on the text of the fee.
+You can toggle the display of the fee between `sat/vByte` & `percentage of transferred value` & `total bitcoin` & `total USD` by clicking on the text of the fee.
 :::
 
 :::details
@@ -723,7 +723,7 @@ High: 100 sat/vbyte: 16,800 satoshis per participant (0.168 %)
 
 Here, we already observe that in some extreme cases, the miner is earning almost 0.2%!
 Recall that Wasabi has a coordinator fee that is capped at 0.3%, so in these extreme cases the total fee paid by the user (you) is closer to 0.5%.
-Now we proceed to go to a smaller denominaton, 0.01 BTC:
+Now we proceed to go to a smaller denomination, 0.01 BTC:
 
 :::tip
 Minimum: 2 sat/vbyte: 336 satoshis per participant (0.0336 %)

--- a/docs/glossary/Glossary-GeneralBitcoin.md
+++ b/docs/glossary/Glossary-GeneralBitcoin.md
@@ -369,7 +369,7 @@ Replacing one version of an unconfirmed transaction with a different version of 
 ### Mining Reward
 
 An amount of satoshis included in each new block as a reward by the network to the miner who found the proof of work solution.
-Initially it was 50 bitcoin per block, which is halvend every 210 000 blocks, or roughly 4 years.
+Initially it was 50 bitcoin per block, which is halved every 210 000 blocks, or roughly 4 years.
 This leads to a total money supply of just below 21 million bitcoin.
 :::
 

--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -161,7 +161,7 @@ For hardware wallet related questions see: [Hardware Wallet FAQs](/FAQ/FAQ-UseWa
 
 7. `Load Wallet` to import the xpub or Public Key (used to generate all receive addresses)
 
-8. Go to `Receive` tab and Generate Receive Address, Copy this to clipboard (memorise the first/last few characters). (Note, don't generate more than 20 unused receive addresses).
+8. Go to `Receive` tab and Generate Receive Address, Copy this to clipboard (memorize the first/last few characters). (Note, don't generate more than 20 unused receive addresses).
 
 9. Send a single mixed coin (don't combine UTXOs/coins as this hurts your anon-set badly) from your "Hot" Wasabi Wallet to this "Cold" Wasabi Wallet receive address by pasting from clipboard (check address hasn't changed).
 

--- a/docs/using-wasabi/Joinmarket.md
+++ b/docs/using-wasabi/Joinmarket.md
@@ -25,7 +25,7 @@ Joinmarket is well [documented](https://github.com/JoinMarket-Org/joinmarket-cli
 
 Joinmarket makers are users running the [yield generator script](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/YIELDGENERATOR.md) and offering their coins as potential inputs in a CoinJoin transaction.
 These users advertise the total volume of bitcoin they would like to mix [for example a range from 0.1 to 5 bitcoins], as well as the fee they charge for their provided service [for example at least 2000 sats, or 0.02% of the CoinJoin denomination] to a public IRC channel.
-A maker chooses to offer coins for liquidity knowing that the taker can deanonymze the maker in this one transaction, thus it is advised to do several rounds of making with different takers to gain privacy even against any one taker. 
+A maker chooses to offer coins for liquidity knowing that the taker can deanonymize the maker in this one transaction, thus it is advised to do several rounds of making with different takers to gain privacy even against any one taker.
 The requirement is an always on, stable and relatively high bandwidth internet connection, so as to successfully coordinate many mixes.
 
 :::tip Reclaim your privacy & stack sats!


### PR DESCRIPTION
I know small commits are encouraged but it seemed a bit much to make one commit per typo ...

In the end I did one commit per section of the documentation ; FAQ, Glossary and using-wasabi.