### PR TITLE
Minor fixing Tails guide

### DIFF
--- a/docs/using-wasabi/WasabiSetupTails.md
+++ b/docs/using-wasabi/WasabiSetupTails.md
@@ -51,7 +51,7 @@ You can now save your `Wasabi-${currentVersion}.deb` into the persistent storage
 
 ## Wasabi data folder
 
-As of version 1.1.9 Wasabi doesn’t offer easy ways, especially without command line, to change install directory. There is though a quick workaround.
+As of version ${currentVersion} Wasabi doesn’t offer easy ways, especially without command line, to change install directory. There is though a quick workaround.
 
 Wasabi [saves session files](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) in `/Home/.walletwasabi/client`, you need to mark the “show hidden files” setting to see it.
 

--- a/docs/using-wasabi/WasabiSetupTails.md
+++ b/docs/using-wasabi/WasabiSetupTails.md
@@ -32,7 +32,7 @@ This way, you can launch Wasabi from the terminal via `./wassabee` command, and 
 
 ## Download
 
-Download Wasabi for Debian/Ubuntu from the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion] or [clearnet](https://www.wasabiwallet.io/#download)
+Download Wasabi for Debian/Ubuntu from the [Tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion) or [clearnet](https://www.wasabiwallet.io/#download).
 
 Verify the PGP signature of the downloaded package, the zkSNACKs' PGP public key fingerprint is:
 
@@ -76,7 +76,7 @@ Could be also nice to save the `BitcoinStore` folder, which contains the [BIP 15
 
 ## Install Wasabi
 
-Drop the `Wasabi-${currentVersion}.deb` file from `/home/amnesia/Persistent` into desktop.
+Copy and paste the `Wasabi-${currentVersion}.deb` file from `/home/amnesia/Persistent` into desktop.
 
 Open the terminal and run:
 
@@ -111,7 +111,7 @@ After the first time you save a Wasabi session, your persistent storage will loo
         |__ /BitcoinStore
 ```
 
-To load your saved session, drop the `.walletwasabi` folder into `/Home` before starting Wasabi.
+To load your saved session, copy and paste the `.walletwasabi` folder into `/Home` before starting Wasabi.
 
 You can save multiple copies of `.walletwasabi` in your persistent, each with different data:
 


### PR DESCRIPTION
Minor fixing and it also changes `drop` to `copy and paste`; since recent Tails versions drag and drop is forbidden by default. 