### PR TITLE
Markdownlint

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "no-trailing-punctuation": false,
+  "no-inline-html": {
+    "allowed_elements": ["iframe"]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ bar
 ### Frequently asked questions
 
 Use this markdown box with the headers to write the FAQ:
+
 ```
 :::details
 ### question

--- a/docs/FAQ/FAQ-Contribution.md
+++ b/docs/FAQ/FAQ-Contribution.md
@@ -8,6 +8,7 @@
 # Contributions to Wasabi
 
 :::details
+
 ### How to donate to Wasabi Wallet?
 
 Adam Ficsor had a donation address for a few years while he was working alone on Wasabi.
@@ -21,6 +22,7 @@ If you want to read more about fees here is a nice explanation: [What are the fe
 ## The Wasabikas of the dojo
 
 :::details
+
 ### Who is contributing to Wasabi already?
 
 There are many Wasabikas working with great effort and care to manifest this powerful tool of self defense.
@@ -36,6 +38,7 @@ For an inclusive list of all the Wasabikas, not just the code developers, please
 :::
 
 :::details
+
 ### Who reviews and merges the pull requests?
 
 As the Wasabi code is libre and open source, anyone has access to review the latest contributions and browse the [open pull requests](https://github.com/zkSNACKs/WalletWasabi/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc).
@@ -46,12 +49,14 @@ Especially review by experienced C# developers are vitally important, yet even t
 There are three developers who have the ability to merge code into master branch.
 Per default, they [require at least one approving review](https://help.github.com/en/github/administering-a-repository/about-required-reviews-for-pull-requests) by one of the other maintainers before a pull request can be merged.
 However, since all three are administrators, they can still force the merge without the approval of others, but this will be noticed by many contributors.
+
 - [Ádám Ficsor](https://github.com/nopara73) [co-founder and former CTO of [zkSNACKs Ltd](https://zksnacks.com/), co-author of the [zero link Bitcoin fungibility framework](https://github.com/nopara73/ZeroLink)] is the [admin](https://help.github.com/en/articles/repository-permission-levels-for-an-organization) of the [Wasabi Wallet repository](https://github.com/zksnacks/walletwasabi).
 - [Lucas Ontivero](https://github.com/lontivero) [lead engineer of [zkSNACKs Ltd](https://zksnacks.com/)] is also [admin](https://help.github.com/en/articles/repository-permission-levels-for-an-organization) of the [Wasabi Wallet repository](https://github.com/zksnacks/walletwasabi).
 - [Dávid Molnár](https://github.com/molnard) [CTO of [zkSNACKs Ltd](https://zksnacks.com/)] is also [admin](https://help.github.com/en/articles/repository-permission-levels-for-an-organization) of the [Wasabi Wallet repository](https://github.com/zksnacks/walletwasabi).
 :::
 
 :::details
+
 ### What is on the future roadmap of Wasabi development?
 
 Wasabi is far from complete, there are many Wasabikas contributing every day to make this tool of self defense even more powerful.
@@ -63,6 +68,7 @@ You can check the [ToDo list](/building-wasabi/ToDo.md) for a somewhat up-to-dat
 ## You can become a Wasabika
 
 :::details
+
 ### How should I start contributing to Wasabi?
 
 Thank you for considering to support this beautiful libre and open source project!
@@ -74,6 +80,7 @@ Join our [Slack](https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2Nz
 :::
 
 :::details
+
 ### Is there a bounty program?
 
 Yes!
@@ -85,6 +92,7 @@ Specifically for the documentation, there is a monthly budget of 1.000 USD to co
 :::
 
 ::::details
+
 ### How can I report a bug?
 
 Code is speech, and can never be perfect.
@@ -105,6 +113,7 @@ Send an email to [adam.ficsor73@gmail.com](mailto:adam.ficsor73@gmail.com), pref
 ::::
 
 :::details
+
 ### How can I request a feature?
 
 Wasabi is a quite beautiful piece of software already.
@@ -121,6 +130,7 @@ To flesh our your argument, please consider alternatives and different approache
 :::
 
 :::details
+
 ### How can I get help and support?
 
 You are already on the right track by first checking [this documentation](https://docs.wasabiwallet.io) for the knowledge you are seeking.
@@ -132,6 +142,7 @@ If your trouble is specific to the code, then it might also be suitable to check
 :::
 
 :::details
+
 ### What does the Wasabi project need help with?
 
 Wasabi is libre and open source software, thus it relies on the support of several contributors on all fronts.

--- a/docs/FAQ/FAQ-GeneralBitcoinPrivacy.md
+++ b/docs/FAQ/FAQ-GeneralBitcoinPrivacy.md
@@ -10,6 +10,7 @@
 ## Why Privacy matters
 
 ::::details
+
 ### I have nothing to hide, do I still need financial privacy?
 
 What did you say to your spouse in bed last night?
@@ -26,6 +27,7 @@ How much money you earn, and where you spend it, is only your business, and of n
 ::::
 
 :::details
+
 ### How is financial privacy an essential element to fungibility in Bitcoin?
 
 If you can meaningfully distinguish one coin from another, then their fungibility is weak.
@@ -35,6 +37,7 @@ This adds friction and transactional costs and makes Bitcoin less valuable as a 
 :::
 
 :::details
+
 ### How is financial privacy essential for entrepreneurs?
 
 If you run a business, you cannot effectively set prices if your suppliers and customers can see all your transactions against your will.
@@ -43,6 +46,7 @@ Individually your informational leverage is lost in your private dealings if you
 :::
 
 :::details
+
 ### How is financial privacy essential for personal safety?
 
 If thieves can see your spending, income, and holdings, they can use that information to target and exploit you.
@@ -50,6 +54,7 @@ Without privacy, malicious parties have more ability to steal your identity, sna
 :::
 
 :::details
+
 ### How is financial privacy essential for human dignity?
 
 No one wants the snotty barista at the coffee shop or their nosy neighbors commenting on their income or spending habits.
@@ -65,6 +70,7 @@ None of this requires globally visible public records.
 ## The Privacy of Bitcoin
 
 :::details
+
 ### How is Bitcoin good in terms of privacy?
 
 Privacy in traditional banking is guaranteed by the institutions that make up the system, such as banks, credit card companies, and governments.
@@ -78,6 +84,7 @@ The addresses do not have names or IP addresses attached to them, so it is not a
 :::
 
 :::details
+
 ### How is Bitcoin bad in terms of privacy?
 
 Bitcoin is by default a transparent system, in which every piece of information is available to the public.
@@ -109,6 +116,7 @@ Having publicly visible Bitcoin addresses could make it easier to find out your 
 :::
 
 :::details
+
 ### What financial privacy does Bitcoin promise?
 
 Globally visible public records in finance are completely unheard-of.
@@ -122,6 +130,7 @@ Sufficient privacy is an essential prerequisite for a viable digital currency.
 :::
 
 ::::details
+
 ### Why is it important to run a full node?
 
 :::tip
@@ -135,6 +144,7 @@ Your full node defines, verifies and enforces the sound money you use to store y
 ::::
 
 :::details
+
 ### How does a full node protect my privacy?
 
 When you run your own full node, then on your local computer you can verify exactly if the bitcoin you receive are actually valid.
@@ -145,6 +155,7 @@ But regardless, running your own full node means that you don't need to communic
 :::
 
 :::details
+
 ### How can I setup a full node?
 
 Starting with v1.1.10 release, Wasabi comes pre-installed with bitcoind from [Bitcoin Core](https://bitcoincore.org/) and it can be started on the same desktop or laptop computer with just one click.
@@ -153,6 +164,7 @@ This is likely the most convenient solution for Wasabikas.
 There are also other node implementations different from Bitcoin Core, such as [Bitcoin Knots](https://github.com/bitcoinknots/bitcoin/) or [Libbitcoin](https://github.com/libbitcoin/libbitcoin-node), that could be used as well.
 
 Instead, if you prefer to use some dedicated hardware solutions, these are some of the most reliable projects:
+
 - [Raspiblitz](https://github.com/rootzoll/raspiblitz), a DIY project based on the Raspberry platform
 - [RaspiBolt](https://stadicus.github.io/RaspiBolt/), another Raspberry DIY node
 - [Nodl](https://www.nodl.it/), works out of the box and runs on a powerful Rockchip CPU
@@ -161,6 +173,7 @@ Instead, if you prefer to use some dedicated hardware solutions, these are some 
 :::
 
 :::details
+
 ### Why is it important to use a new address for every payment?
 
 Addresses being used more than once is very damaging to privacy because that links together more blockchain transactions with proof that they were created by the same entity.
@@ -177,16 +190,17 @@ Avoiding address reuse is like throwing away a pseudonym after it has been used.
 :::
 
 :::details
+
 ### What is a CoinJoin Sudoku?
 
 CoinJoin Sudoku is a type of intra-transaction analysis attack on CoinJoin transactions that aims to link inputs and outputs together based on their combinatorial sums.
 You can read more about CoinJoin Sudoku [here](https://www.coinjoinsudoku.com/advisory/).
 :::
 
-
 ## The Privacy of Tor
 
 :::details
+
 ### How does Tor protect my network-level privacy?
 
 When you make a Bitcoin transaction, you are essentially creating a message on your phone or computer and sending it to the Bitcoin network.
@@ -203,6 +217,7 @@ You can also configure many cloud storage providers in this way.
 :::
 
 ::::details
+
 ### My country/ISP is blocking/censoring Tor, how can I use Wasabi with Tor bridges?
 
 Tor bridges, also called Tor bridge relays, are alternative entry points to the Tor network that are not all listed publicly.
@@ -238,12 +253,15 @@ Feel free to edit these commands according to your distribution.
 1. Get [Tor Bridges](https://bridges.torproject.org/bridges)
 2. Install Tor daemon with `sudo apt-get install tor`
 3. Install OBFS4 support (needed to connect to bridges), by editing your `/etc/apt/sources.list` and adding this line:
+
 ```
 # Tor Bridges
 deb http://deb.torproject.org/torproject.org obfs4proxy main
 ```
+
 4. Update package list with `sudo apt-get update` and install OBFS4 with `sudo apt-get install obfs4proxy`
 5. Configure Tor by editing your `/etc/tor/torrc` file and adding these lines:
+
 ```
 UseBridges 1
 
@@ -254,6 +272,7 @@ Bridge 194.132.209.92:26848 14FF5F91FE1CD6C1EDAB2D41A897B70FCC5DFAFA
 
 ServerTransportPlugin obfs4 exec /usr/bin/obfs4proxy
 ```
+
 6. Restart Tor with `sudo service tor restart` and check logs with `sudo tail -f /var/log/tor/log` to verify that everything is working properly
 
 ::::

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -10,6 +10,7 @@
 ## Installing the Package
 
 :::details
+
 ### Where can I download Wasabi?
 
 It's always best to download software directly from the official source acknowledged by the developers.
@@ -20,6 +21,7 @@ Please take special care to verify the PGP signatures of zkSNACKs' PGP public ke
 :::
 
 ::::details
+
 ### Why is it important to verify PGP signatures?
 
 :::danger
@@ -40,6 +42,7 @@ This protects you against malicious man in the middle attacks where bad guys giv
 ::::
 
 :::details
+
 ### How can I verify PGP signatures?
 
 On the [WasabiWallet.io](https://wasabiwallet.io) website you can download the packages of the latest release.
@@ -53,6 +56,7 @@ For an in depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.md#de
 :::
 
 :::details
+
 ### How do I install Wasabi on Debian and Ubuntu?
 
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.deb` package and the `.deb.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
@@ -68,6 +72,7 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 :::
 
 :::details
+
 ### How do I install Wasabi on other Linux?
 
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.tar.gz` package and the `.tar.gz.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
@@ -80,6 +85,7 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 :::
 
 :::details
+
 ### How do I install Wasabi on Windows?
 
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.msi` package and the `.msi.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
@@ -92,6 +98,7 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 :::
 
 :::details
+
 ### How do I install Wasabi on macOS?
 
 [Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.dmg` package and the `.dmg.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
@@ -106,6 +113,7 @@ Checkout the main documentation for a [step-by-step guide](/using-wasabi/Install
 :::
 
 :::details
+
 ### How do I check the current version of Wasabi?
 
 In the GUI go to the top left menu `Help > About`, here you see the current version of your Wasabi.
@@ -114,6 +122,7 @@ Wasabi is cutting edge software, so it is well advised to stay up-to-date.
 :::
 
 :::details
+
 ### How do I know about a new version of Wasabi?
 
 When a new version has been released, you'll see a notification in the bottom left status bar `New Version Available`.
@@ -122,6 +131,7 @@ It will also be announced on [Twitter](https://twitter.com/wasabiwallet), [Reddi
 :::
 
 :::details
+
 ### How do I securely upgrade Wasabi?
 
 You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
@@ -130,6 +140,7 @@ For step-by-step instructions, follow [this guide](/using-wasabi/InstallPackage.
 :::
 
 :::details
+
 ### Do I need to install Tor separately?
 
 All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself.
@@ -142,12 +153,14 @@ In the second case, if you happen to broadcast a transaction of yours to a full 
 :::
 
 :::details
+
 ### Can I install Wasabi on TAILS?
 
 Yes, just follow the [Wasabi Setup on Tails](/using-wasabi/WasabiSetupTails.md) guide and remember to save/backup the wallet on the Persistence.
 :::
 
 :::details
+
 ### What are the differences between the Debian/Ubuntu version and the "Other Linux" version?
 
 `Debian/Ubuntu` version contains `.deb` package.
@@ -164,6 +177,7 @@ There's no difference in the code, the same binaries are being delivered in diff
 ## Advanced Installation
 
 :::details
+
 ### How do I compile Wasabi from source?
 
 A new version of Wasabi is released when ready, roughly once every #twoweeks.
@@ -179,6 +193,7 @@ You can update the master branch with `git pull`.
 :::
 
 :::details
+
 ### How can I verify the deterministic build?
 
 Wasabi has [reproducible and deterministic builds](/using-wasabi/DeterministicBuild.md), which means that you can verify that the compiled packages are from the [source code](https://github.com/zksnacks/walletwasabi).
@@ -203,6 +218,7 @@ and verify with
 :::
 
 :::details
+
 ### How can I install Wasabi headless daemon without GUI?
 
 To use Wasabi's command line tools on Windows you have to use `wassabeed.exe` that is inside your `Program Files\WasabiWallet`.
@@ -217,6 +233,7 @@ You may want to start with `--help`.
 :::
 
 ::::details
+
 ### My antivirus marks Wasabi Wallet as a virus. Am I downloading the right software? How can I stay safe?
 
 First, make sure you have downloaded Wasabi from the [official website](https://wasabiwallet.io/) or from the [official GitHub repository](https://github.com/zkSNACKs/WalletWasabi/releases).
@@ -233,6 +250,7 @@ In doing so you will help users who use the same antivirus.
 ::::
 
 :::details
+
 ### Why is the executable called wassabee?
 
 The most obvious thing would be to call the executable `Wasabi Wallet.exe` on Windows and `Wasabi Wallet` on Linux and Mac.

--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -10,6 +10,7 @@
 ## The Basics
 
 :::details
+
 ### Explain Wasabi like I'm 5
 
 Wasabi is a software wallet to manage your Bitcoin private keys.
@@ -22,6 +23,7 @@ Of course, Wasabi is libre and open source, which means you have full control ov
 :::
 
 ::::details
+
 ### Who can use Wasabi?
 
 Every single line of code in Wasabi, the [wallet](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Gui), the [backend server](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Backend), the [tests](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Tests), the [packager](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Packager), the [library](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi), the [daemon](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Gui/CommandLine), the [api](https://wasabiwallet.io/swagger/), the [documentation](https://github.com/zkSNACKs/WasabiDoc) - has always been and will always be libre and open source under the [MIT license](https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md).
@@ -37,6 +39,7 @@ Wasabi is a tool for everyone.
 ::::
 
 :::details
+
 ### What is a CoinJoin?
 
 A mechanism by which multiple participants combine their coins (or UTXOs, to be more precise) into one large transaction with multiple inputs and multiple outputs.
@@ -60,6 +63,7 @@ See also the [Bitcoin Wiki on CoinJoins](https://en.bitcoin.it/wiki/CoinJoin)
 :::
 
 :::details
+
 ### Do I need to trust Wasabi with my coins?
 
 No, Wasabi's CoinJoin implementation is trustless by design.
@@ -68,7 +72,9 @@ Wasabi merely coordinates the process of combining the inputs of the participant
 :::
 
 :::details
+
 ### What is the privacy I get after mixing with Wasabi?
+
 This depends on how you handle your outputs after the CoinJoin.
 There are some ways how you can unintentionally undo the mixing by being careless.
 For example, if you make a 1.8 BTC transaction into Wasabi, do the CoinJoin, and then make one single outgoing transaction of 1.8 BTC, a third party observer can reasonably assume that both transactions belong to one single entity, due to both amounts being virtually the same even though they have been through a CoinJoin.
@@ -81,6 +87,7 @@ Find out more about coin control it [here](https://medium.com/@nopara73/coin-con
 :::
 
 :::details
+
 ### Can I hurt my privacy using Wasabi?
 
 No.
@@ -89,6 +96,7 @@ It is crucial to understand that Wasabi is not a fool-proof solution if you negl
 :::
 
 :::details
+
 ### Do I need to run Tor?
 
 All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself.
@@ -101,6 +109,7 @@ In the second case, if you happen to broadcast a transaction of yours to a full 
 :::
 
 :::details
+
 ### Why is Wasabi Bitcoin-only?
 
 There are countless reasons why it is the only logical choice to be [bitcoin-only](https://bitcoin-only.com).
@@ -112,6 +121,7 @@ Any line of code written to support a random shitcoin takes away scarce develope
 :::
 
 :::details
+
 ### Why is the anonymity set 100?
 
 Sufficient anonymity set is a hard question, that not yet enough research done to answer it definitively.
@@ -120,12 +130,14 @@ Furthermore our calculations have shown that with the liquidity of today’s mix
 :::
 
 :::details
+
 ### Is there a way to check Wasabi uptime status?
 
 Yes, you can check the status of Wasabi-related services and websites (like APIs, Backend, etc.) via [UptimeRobot Wasabi Status Page](https://stats.uptimerobot.com/YQqGyUL8A7).
 :::
 
 :::details
+
 ### What software supplies the block filters that Wasabi uses?
 
 The zkSNACKs coordinator supplies the same set of filters to every client.
@@ -135,18 +147,21 @@ Furthermore, the random node will only know which block is needed but it won't h
 :::
 
 :::details
+
 ### Is the Backend's (Coordinator) code open source?
 
 Yes, you can verify the code on [GitHub](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Backend).
 :::
 
 :::details
+
 ### Is there an Android/iOs version?
 
 No, Wasabi and CoinJoin features require considerable computational power, not currently replicable on a smartphone.
 :::
 
 :::details
+
 ### Where can I find Wasabi Wallet on social media?
 
 You can find us on [Twitter](https://twitter.com/wasabiwallet) and [Reddit](https://www.reddit.com/r/WasabiWallet/).
@@ -157,12 +172,14 @@ For chat groups you can find us on [Slack](https://join.slack.com/t/tumblebit/sh
 ## For advanced Wasabikas
 
 :::details
+
 ### Can the coordinator attack me?
 
 The nature of Wasabi is that you should not need to trust the developers or the Wasabi coordinating server, as you can verify that the code does not leak information to anyone.
 The developers have gone to great lengths in an attempt to ensure that the coordinator cannot steal funds nor harvest information (for example, the outputs sent from your Wasabi Wallet are blinded, meaning that even the Wasabi server cannot link the outputs to the inputs).
 
 The only known possible 'malicious' actions that the server *could* perform are two sides of the same coin;
+
 - **Blacklisted UTXO's**:
 Though this would not affect the users who are able to successfully mix with other 'honest/real' peers.
 - **Targeted Sybil Attack**:
@@ -180,12 +197,14 @@ See [here](https://github.com/nopara73/ZeroLink/#e-sybil-attack) for more info.
 :::
 
 :::details
+
 ### What is the history of Wasabi?
 
 Ádám Ficsor worked with several others on a privacy-focused Bitcoin wallet called Hidden Wallet all the way [back in December 2015](https://docs.google.com/drawings/d/1wLL7aSgYBWNoyzllg6_haisFt-gQCf-QUzVzQPkARts/edit).
 Wasabi was unveiled in 2018 at the Building on Bitcoin conference by Ádám.
 At the time, Wasabi was essentially HiddenWallet rebranded and rewritten from scratch with some new features.
 Key dates:
+
 - The Beta release was on August 1 (on the first anniversary of UASF.)
 - The 1.0 release was on October 31 (on the tenth anniversary of the Bitcoin Whitepaper.)
 
@@ -194,6 +213,7 @@ Key dates:
 :::
 
 :::details
+
 ### Who is contributing to Wasabi?
 
 There are many Wasabikas working with great effort and care to manifest this powerful tool of self defense.
@@ -210,6 +230,7 @@ For an inclusive list of all the Wasabikas, not just the code developers, please
 :::
 
 ::::details
+
 ### Why is Wasabi libre and open source software?
 
 Wasabi follows the philosophy behind Bitcoin by making the software open source and by publishing it under MIT License.
@@ -246,6 +267,7 @@ Additionally, open source software tends to both incorporate and operate accordi
 ::::
 
 :::details
+
 ### What is the general idea of ZeroLink CoinJoin?
 
 While fungibility is an essential property of good money, Bitcoin has its limitations in this area.
@@ -272,6 +294,7 @@ For the complete explanation please read [ZeroLink: The Bitcoin Fungibility Fram
 :::
 
 :::details
+
 ### What are the minimal requirements to run Wasabi?
 
 - 64-bit architecture
@@ -281,6 +304,6 @@ For the complete explanation please read [ZeroLink: The Bitcoin Fungibility Fram
 - Ubuntu 16.04+
 - For other Linux distributions, it depends on the specific OS.
 
-Click [here](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) to check if .NET Core 3.1 supports your OS. 
+Click [here](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) to check if .NET Core 3.1 supports your OS.
 
 :::

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -12,6 +12,7 @@
 @[youtube](XykixYdbFpA)
 
 :::details
+
 ### How do I generate a new wallet?
 
 You can generate as many new wallets as you'd like, for no extra cost and without asking for permission.
@@ -37,6 +38,7 @@ You have successfully setup your wallet when you click `I wrote down my Recovery
 :::
 
 ::::details
+
 ### Can I rename my Wallet?
 
 Yes you can.
@@ -53,7 +55,9 @@ To avoid problems, make sure you close Wasabi Wallet before proceeding to rename
 ::::
 
 ::::details
+
 ### What password should I use?
+
 The password you set is used as a 13th word (passphrase) as described in [BIP 39](../using-wasabi/BIPs.md#bip-39-mnemonic-code-for-generating-deterministic-keys), and is used to encrypt the private key of the extended private key as described in [BIP 38](../using-wasabi/BIPs.md#bip-38-password-protected-private-key) to get an encrypted private key which is stored on the computer.
 This is the password that will unlock your bitcoin to anyone who has access to the backup or computer.
 You will need to type in the password before you can spend from a Wasabi wallet.
@@ -70,6 +74,7 @@ A secure password manager software might also be used, but be careful here.
 ::::
 
 ::::details
+
 ### How do I back up my mnemonic words?
 
 :::tip
@@ -94,6 +99,7 @@ Please see [this great guide](https://github.com/6102bitcoin/FAQ/blob/master/see
 ::::
 
 ::::details
+
 ### Where can I find the Wasabi data folder?
 
 * Windows: `/Users/{your username}/AppData/Roaming/WalletWasabi/Client`
@@ -108,6 +114,7 @@ You can also easily reach it from inside Wasabi: `File > Open > Data Folder`.
 ::::
 
 ::::details
+
 ### How do I backup my wallet file?
 
 Although you can backup your private keys with the mnemonic words and password, this is only a last resort recovery.
@@ -127,6 +134,7 @@ So it is good advice to encrypt this wallet file.
 ::::
 
 ::::details
+
 ### Can I spend my bitcoin without the password?
 
 :::danger
@@ -144,6 +152,7 @@ Always backup your mnemonic recovery words, and your password in two separate se
 ::::
 
 :::details
+
 ### Why BIP 38?
 
 [BIP 38](/using-wasabi/BIPs.md#bip-38-password-protected-private-key) is a good standard, a well-tested and very secure way to encrypt a private key.
@@ -153,6 +162,7 @@ Take into account that it is not only encryption what [BIP 38](/using-wasabi/BIP
 :::
 
 :::details
+
 ### Does Wasabi support the hidden wallets of hardware wallets?
 
 Partially.
@@ -164,6 +174,7 @@ It’s part of [BIP 39](/using-wasabi/BIPs.md#bip-39-mnemonic-code-for-generatin
 :::
 
 :::details
+
 ### I forgot my lockscreen PIN, what should I do?
 
 As described in the settings, you can just delete it.
@@ -173,6 +184,7 @@ Open the `UiConfig.json` file inside your [Wasabi data folder](/FAQ/FAQ-UseWasab
 "LockScreenActive": false,
 "LockScreenPinHash": ""
 ```
+
 :::
 
 ## Synchronization
@@ -180,6 +192,7 @@ Open the `UiConfig.json` file inside your [Wasabi data folder](/FAQ/FAQ-UseWasab
 @[youtube](qguwAvA5Fx4)
 
 ::::details
+
 ### What are BIP-158 block filters?
 
 When you do not run a full node, you need to communicate with some third party node to find out how much money you have.
@@ -210,6 +223,7 @@ You also do not have proof that the block you download from a P2P node is actual
 ::::
 
 :::details
+
 ### How does Wasabi download a relevant block?
 
 Wasabi uses [BIP 158](/using-wasabi/BIPs.md#bip-158-compact-block-filters-for-light-clients) block filter to find out if a specific block contains a transaction of a specific wallet.
@@ -222,6 +236,7 @@ You can also specify the local IP or tor hidden service of your remote full node
 :::
 
 :::details
+
 ### How do I know if the synchronization is finished?
 
 You know that tor is properly connected, that all the block filters and all the relevant blocks are downloaded when you see that the status bar is `Ready`.
@@ -230,6 +245,7 @@ You know that tor is properly connected, that all the block filters and all the 
 :::
 
 :::details
+
 ### What does it mean "Missing Filters"?
 
 The `Missing Filters` label indicates that Wasabi is still downloading the [BIP 158 block filters](/using-wasabi/BIPs.md#bip-158-compact-block-filters-for-light-clients) and it's synchronizing your wallet.
@@ -237,6 +253,7 @@ You have just to wait until the status bar is `Ready`.
 ::::
 
 :::details
+
 ### How long does the initial, and a subsequent synchronization take?
 
 It usually only takes a couple seconds to scan the block filters, download and parse the blocks.
@@ -246,6 +263,7 @@ For especially old wallets, it might be worth considering to start a new wallet 
 :::
 
 :::details
+
 ### Can Wasabi work with a pruned bitcoin node?
 
 Yes.
@@ -257,6 +275,7 @@ Wasabi is a hybrid, if your node doesn't have a block, then it acquires it from 
 @[youtube](9i7CceIdFg4)
 
 ::::details
+
 ### Why is it bad to re-use addresses?
 
 Bitcoin is designed so that for every payment you can use a new address that is not tied to any of your previous addresses.
@@ -279,6 +298,7 @@ Every time a coin is received, the address is removed from the GUI so that you a
 ::::
 
 :::details
+
 ### How do I generate a new receiving address?
 
 You can generate a new bech32 address in the `Receive` tab of Wasabi Wallet.
@@ -295,6 +315,7 @@ When you import the wallet file into a new Wasabi client, then it will use this 
 :::
 
 :::details
+
 ### Why do I have to label my address?
 
 Bitcoin addresses look like cyphertext, they are not easily remembered and it's not clear how they were used previously.
@@ -319,6 +340,7 @@ or:
 :::
 
 :::details
+
 ### How can I change the label of my receive address?
 
 You can change the label of your receive address in the right click menu by clicking `Change Label`, then type in the new label.
@@ -330,12 +352,14 @@ This is very bad for your privacy because of [address reuse](/using-wasabi/Addre
 :::
 
 :::details
+
 ### How can I edit the label of my address after a transaction has gone through?
 
 To date there is no possibility to change the label of an address after it has sent or received bitcoins.
 :::
 
 ::::details
+
 ### Are there privacy concerns regarding whom I send my address?
 
 Yes.
@@ -351,6 +375,7 @@ This is a complete de-anonymization of your entire wallet!!
 ::::
 
 :::details
+
 ### Why does Wasabi only use SegWit bech32 addresses?
 
 Wasabi generates Bech32 addresses only, also known as bc1 addresses or native SegWit addresses.
@@ -362,6 +387,7 @@ Be careful, if you send all your coins from an old wallet to a new wallet (from 
 :::
 
 :::details
+
 ### Where can I find my address QR code and public key?
 
 You can see the address QR code, public key and the key path in the drop down menu of the `Receive` tab.
@@ -372,6 +398,7 @@ You can save the png file of the QR code in the right click menu.
 :::
 
 :::details
+
 ### What derivation paths does Wasabi use?
 
 Wasabi follows [BIP 84: Derivation scheme for P2WPKH Based Accounts](/using-wasabi/BIPs.md#bip-84-derivation-scheme-for-p2wpkh-based-accounts), so the main path is `m/84'/0'/0'`.
@@ -380,6 +407,7 @@ Due to the CoinJoin implementation, the key depth can be rather large, thus when
 :::
 
 :::details
+
 ### Can I generate a multi signature script?
 
 No.
@@ -401,6 +429,7 @@ So when Schnorr is activated in the Bitcoin consensus layer, in #twoweeks, there
 :::
 
 :::details
+
 ### How does Wasabi know of incoming transactions to the mempool?
 
 When Wasabi is running, it connects to random Bitcoin peer to peer nodes and listens for their gossip of all transactions on the network.
@@ -417,6 +446,7 @@ In this case you have to wait until your transaction is confirmed in a block, an
 @[youtube](AdmlM-Qvco0)
 
 :::details
+
 ### What are coins?
 
 Bitcoin uses a system of inputs and outputs to keep track who owns how many sats.
@@ -428,6 +458,7 @@ This chain of links between inputs being spent and outputs being generated is ve
 :::
 
 :::details
+
 ### Why is coin control so important?
 
 Coin control is a feature in Wasabi that allows the user to choose which coins are to be spent as inputs in an outgoing transaction.
@@ -449,6 +480,7 @@ Alice can protect herself against this by using a CoinJoin UTXO, because now Bob
 :::
 
 :::details
+
 ### How do I set a destination address?
 
 In the `Send` tab, there is a text box for the `Address` right under the coin list.
@@ -459,6 +491,7 @@ So make sure that the coins get into the right hands.
 :::
 
 :::details
+
 ### Can I pay to many addresses?
 
 Unfortunately pay to many is not not yet implemented in the GUI.
@@ -466,6 +499,7 @@ However, you can use the [RPC server `send` call](/using-wasabi/RPC.md#send) and
 :::
 
 :::details
+
 ### How do I set the payment amount?
 
 After you select one or more coins as inputs in `Send` tab, say two anonset coins worth 0.1 bitcoin each.
@@ -476,6 +510,7 @@ Then Wasabi will help you with automatically calculating the precise change outp
 :::
 
 ::::details
+
 ### How can I use the MAX button?
 
 When you select one or more coins as inputs in `Send` tab, say two anonset coins worth each 0.1 bitcoin.
@@ -501,6 +536,7 @@ But you can also use it to your advantage when paying others.
 ::::
 
 :::details
+
 ### Why does Wasabi choose a new random node every time I send a transaction?
 
 When you broadcast a transaction from a full node, that transaction is flooded onto the network.
@@ -514,6 +550,7 @@ This reduces the risk of a passive bystander being able to link two transactions
 :::
 
 ::::details
+
 ### What fee should I select?
 
 Wasabi uses the [smartfee](https://bitcointechtalk.com/an-introduction-to-bitcoin-core-fee-estimation-27920880ad0) estimation algorithm provided by bitcoind.
@@ -539,6 +576,7 @@ These sats are precious, so don't overpay on fees!
 ::::
 
 :::details
+
 ### How do I set custom fee rate?
 
 Go to `Settings` and under the UI category turn on `Manual fee entry`.
@@ -546,6 +584,7 @@ In the `Send` tab, simply click on the `Fee` box and manually type the fee rate 
 :::
 
 :::details
+
 ### How can I display the fee in satoshis per byte?
 
 The fee you pay to get confirmation on the Bitcoin timechain is denominated in satoshis per virtual byte.
@@ -556,6 +595,7 @@ You can toggle the display of the fee between `sat/vByte` & `percentage of trans
 :::
 
 :::details
+
 ### How do I select coins for spending?
 
 Unlike other Bitcoin wallets, the user cannot spend from Wasabi without selecting coins, since ["Coin Control Is Must Learn If You Care About Your Privacy In Bitcoin"](https://medium.com/@nopara73/coin-control-is-must-learn-if-you-care-about-your-privacy-in-bitcoin-33b9a5f224a2), at least for today.
@@ -567,6 +607,7 @@ Spending whole coins is beneficial to privacy.
 :::
 
 :::details
+
 ### How is the transaction broadcasted?
 
 Wasabi previously did not maintain its P2P connections over Tor.
@@ -588,6 +629,7 @@ Wasabi will implement the [Dandelion](/using-wasabi/BIPs.md#bip-156-dandelion-pr
 :::
 
 :::details
+
 ### What is the cluster history?
 
 Clusters are a property of a Bitcoin wallet with strong coin-control and good labeling.
@@ -630,6 +672,7 @@ For example, if you buy coins anonymously in a P2P way, you should try to avoid 
 :::
 
 :::details
+
 ### What's the difference between Send and Build Transaction?
 
 The only difference is that `Build Transaction` does not propagate the transaction, it simply builds it.
@@ -646,6 +689,7 @@ Broadcast tx|Send tab||Send tab
 :::
 
 :::details
+
 ### Why Wasabi did not send some of my selected coins?
 
 Because they were not necessary for the transaction.
@@ -659,6 +703,7 @@ Example: If you select 10 coins with total value of 2 btc and you want to send 1
 @[youtube](ypfZT9GlqTw)
 
 :::details
+
 ### What's the legal status of Wasabi/CoinJoin?
 
 USA: On May 9, 2019, the Financial Crimes Enforcement Network (FinCEN) issued an interpretive guidance that stated the following in section 4.5.1(b):
@@ -673,6 +718,7 @@ Here's a great explanation about it:
 :::
 
 ::::details
+
 ### Why aren't there smaller equal denomination outputs like 0.05 BTC?
 
 There are many reasons for that.
@@ -687,11 +733,11 @@ So that means constructing a CoinJoin with 0.1 BTC outputs, with 100 participant
 So let's dig into the numbers a bit further.
 What does it cost (from the miner perspective) to participate in a CoinJoin? Well most users will provide 1 input, and 2 outputs (change + mixed UTXO) and we can calculate the vbytes like so:
 :::tip
-1 * (68 vbytes) + 2 * (33 vbytes) = 134 vbytes
+1 *(68 vbytes) + 2* (33 vbytes) = 134 vbytes
 :::
 But it is important to note that many users provide 2 inputs (UTXOs) or even sometimes 3 or 4, so we should really put a multiplier of 1.5x on the inputs:
 :::tip
-1.5 * (68 vbytes) + 2 * (33 vbytes) = 168 vbytes
+1.5 *(68 vbytes) + 2* (33 vbytes) = 168 vbytes
 :::
 Excellent, this is the Cost-per-participant of an equal-output CoinJoin.
 Now let's consider the variable miner fees in sat/vbyte that we might pay to get the CoinJoin mined within a reasonable time (<24 hours):
@@ -738,6 +784,7 @@ So there you have it! Here is the trade-off with CJ output denominations and why
 ::::
 
 :::details
+
 ### What are the fees for the CoinJoin?
 
 You pay a coordinator fee of 0.003% * anonymity set.
@@ -755,6 +802,7 @@ In this case, the difference is split between the active outputs of the mix.
 :::
 
 :::details
+
 ### What is the anonymity set?
 
 The anonymity set is effectively the size of the group you are hiding in.
@@ -777,8 +825,8 @@ Your Wasabi software has limited information on what the anonymity set should be
 With Wasabi we are trying to do lower estimations, rather than higher ones.
 :::
 
-
 :::details
+
 ### What are the equal denominations created in one mixing round?
 
 In every CoinJoin round the minimum to register is roughly 0.1 BTC, you need to have at least this much to participate.
@@ -794,6 +842,7 @@ For example, with a 0.7 BTC input you would expect the following outputs: ~0.1, 
 :::
 
 :::details
+
 ### What is the best time to CoinJoin?
 
 You can CoinJoin whenever you want.
@@ -812,6 +861,7 @@ To avoid traffic detection and behavioral analysis, you should CoinJoin at diffe
 :::
 
 :::details
+
 ### Why are the denominations such an odd number?
 
 The output value changes each round to ensure that you can enqueue a coin and have it remix (mix over and over again - increasing the anonymity set, improving privacy).
@@ -819,6 +869,7 @@ As a result the round mixing amount will often be a specific number which genera
 :::
 
 :::details
+
 ### What is happening in the input registration phase?
 
 During this phase you have the opportunity to register coins that you want to mix in this round.
@@ -829,6 +880,7 @@ But regardless of how many participants, two hours after the last CoinJoin this 
 :::
 
 :::details
+
 ### What is happening in the connection confirmation phase?
 
 Because the input registration phase can take up to two hours, the coordinator needs to ensure that everyone is still online and ready to continue.
@@ -836,6 +888,7 @@ So in the [connection confirmation phase](/using-wasabi/CoinJoin.md#connection-c
 :::
 
 :::details
+
 ### What is happening in the output registration phase?
 
 You use some secret parameters to unblind the blinded CoinJoin output to reveal the clear text address that still contains the signature of the coordinator.
@@ -845,6 +898,7 @@ Immediately after that, Bob disconnects and the [output registration phase](/usi
 :::
 
 :::details
+
 ### What is happening in the signing phase?
 
 After all Alices have registered their inputs and change outputs, and all Bobs their anonset outputs, the coordinator has all the information to build the CoinJoin transaction and include his fee output.
@@ -854,12 +908,14 @@ The [singing phase](/using-wasabi/CoinJoin.md#signing) is concluded when the coo
 :::
 
 :::details
+
 ### What is happening in the broadcasting phase?
 
 In the [broadcasting phase](/using-wasabi/CoinJoin.md#broadcasting) the coordinator sends the signed final CoinJoin transaction to several random Bitcoin peer to peer nodes, and it is gossiped throughout the network to the miners.
 :::
 
 :::details
+
 ### Is there any additional anonymity using multiple wallets for CoinJoins?
 
 You'd gain 1 less anonymity set than if you'd only mix with one wallet (and Wasabi doesn't display that).
@@ -867,6 +923,7 @@ On the other hand, the systemic anonymity is slightly improved if a few people a
 :::
 
 :::details
+
 ### How is the anonymity set target determined for CoinJoins?
 
 `2*2 = 4` and `3*3 = 9`. `2->3: 50% increase`, `4->9:125%` increase.
@@ -878,6 +935,7 @@ Now if even that'd fail, then we can start thinking about lowering the required 
 :::
 
 :::details
+
 ### I'd like to experience CoinJoin but I'm not comfortable using real Bitcoin. What can I do?
 
 You can try to make a CoinJoin via Wasabi on the Bitcoin [TestNet](/FAQ/FAQ-UseWasabi.md#what-is-testnet) (an alternative Bitcoin blockchain, to be used for testing).
@@ -889,6 +947,7 @@ or
 :::
 
 :::details
+
 ### Does Wasabi have to stay on during CoinJoin?
 
 Yes, Wasabi needs to stay on during CoinJoins, you cannot be offline and still participate in CoinJoins.
@@ -905,6 +964,7 @@ Here is how Wasabi handles different scenarios:
 :::
 
 :::details
+
 ### What if there's a power outage during CoinJoin? Do I lose my coins?
 
 No you don't.
@@ -913,6 +973,7 @@ If your wallet crashes or your computer goes offline during CoinJoin you can sim
 :::
 
 :::details
+
 ### How much anonymity set do I need?
 
 It is commonly said that an anonymity set of 50 is sufficient to evade blockchain forensics analysis.
@@ -921,6 +982,7 @@ With Wasabi this can be achieved in a matter of hours (or minutes if there are a
 :::
 
 :::details
+
 ### How many rounds should I CoinJoin?
 
 There is no simple answer for this.
@@ -928,6 +990,7 @@ If you want more anonymity you should CoinJoin multiple times.
 :::
 
 :::details
+
 ### Are coins automatically requeued after the round is complete?
 
 Yes they are, based on the anonymity set target.
@@ -937,6 +1000,7 @@ However, you can manually enqueue them for a new round at any time.
 :::
 
 :::details
+
 ### How can I select UTXOs for CoinJoin?
 
 You need to go to `CoinJoin` tab and select your desired UTXO by clicking the checkbox.
@@ -944,12 +1008,14 @@ It will be queued and registered for the next CoinJoin round.
 :::
 
 :::details
+
 ### How does my wallet communicate with the Wasabi coordinator server?
 
 Wasabi communicates in many ways to the coordinator server, and it is always over the tor network.
 
 First of all, Wasabi uses [BIP 158 block filters](/using-wasabi/BIPs.md#bip-158-compact-block-filters-for-light-clients) to ensure network level privacy.
 You can follow these FAQs to have a full explanation on the theme:
+
 - [What are BIP-158 Block Filters?](/FAQ/FAQ-UseWasabi.md#what-are-bip-158-block-filters)
 - [What software supplies the block filters that Wasabi uses?](/FAQ/FAQ-Introduction.md#what-software-supplies-the-block-filters-that-wasabi-uses)
 - [Can the coordinator attack me?](/FAQ/FAQ-Introduction.md#can-the-coordinator-attack-me)
@@ -957,6 +1023,7 @@ You can follow these FAQs to have a full explanation on the theme:
 
 Then, there are five different phases in a CoinJoin.
 You can follow these links to have a full explanation on that:
+
 1. [INPUT REGISTRATION PHASE](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-input-registration-phase)
 2. [CONNECTION CONFIRMATION PHASE](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-connection-confirmation-phase)
 3. [OUTPUT REGISTRATION PHASE](/FAQ/FAQ-UseWasabi.md#what-is-happening-in-the-output-registration-phase)
@@ -967,6 +1034,7 @@ You also get information about the current mempool for fee estimation as well as
 :::
 
 :::details
+
 ### How long does it take to mix my coins?
 
 It depends on many things, the longest period is the wait for all peers to register their coins.
@@ -979,6 +1047,7 @@ Summing up: the faster peers register in the CoinJoins, the faster the mixes are
 :::
 
 :::details
+
 ### What is the coordinator address?
 
 The coordinator gets paid in every CoinJoin.
@@ -987,16 +1056,19 @@ And for transparency reasons, the same coordinator address is used.
 The current address used by the Wasabi coordinator is `bc1qa24tsgchvuxsaccp8vrnkfd85hrcpafg20kmjw`.
 
 Old addresses:
+
 - `bc1qs604c7jv6amk4cxqlnvuxv26hv3e48cds4m0ew`
 :::
 
 :::details
+
 ### What is the maximum number of coins that can be registered in a CoinJoin?
 
 Wasabi Wallet will register only up to 7 coins in a CoinJoin.
 :::
 
 :::details
+
 ### Why Wasabi did not register some of my enqueued coins?
 
 Because they were not necessary for the CoinJoin.
@@ -1014,6 +1086,7 @@ Example: If you select 10 coins with total value of 0.2 btc but the sum of 4 coi
 @[youtube](sM2uhyROpAQ)
 
 ::::details
+
 ### What hardware wallets does Wasabi support?
 
 The answer is simple:
@@ -1029,7 +1102,9 @@ Everything seems to work fine with the ColdCard, BitBox, Trezor, Ledger and Keep
 ::::
 
 :::details
+
 ### Why does Wasabi use the Hardware Wallet Interface?
+
 Wasabi uses the [Bitcoin Core Hardware Wallet Interface [HWI]](https://github.com/bitcoin-core/HWI), a python library tool for proper integration of off-line signing devices.
 It provides a standard way for any software wallet to communicate with any hardware wallet without needing any device specific drivers.
 HWI was developed and carefully reviewed over several years, with outstanding contributions by especially [Andrew Chow](https://github.com/achow101).
@@ -1038,12 +1113,14 @@ Wasabi uses this powerful tool because there are no other dependencies necessary
 :::
 
 :::details
+
 ### How can I generate a Wasabi skeleton wallet file in ColdCard?
 
 On the ColdCard (Mk2, firmware 2.1.1 and up) you go to `>Advanced>MicrcoSD Card>Wasabi Wallet` and it will save a skeleton json-file to the MicroSD card in the hardware wallet.
 :::
 
 :::details
+
 ### How can I import the Wasabi skeleton wallet file?
 
 Take the MicroSD card from the ColdCard and plug it in the computer with the Wasabi Wallet software.
@@ -1052,6 +1129,7 @@ Now select the Wasabi skeleton json-file from the MicroSD card, if this fails yo
 :::
 
 :::details
+
 ### How can I generate a receiving address of my hardware wallet?
 
 In Wasabi Wallet you load your previously imported wallet (from Wasabi skeleton, or USB detection) and go to the `Receive` tab, here you enter a label for the observers of the incoming transaction and click `Generate Receive Address`.
@@ -1059,6 +1137,7 @@ In the tab below the newly generated receive address can be viewed / copied.
 :::
 
 :::details
+
 ### How can I sign a transaction with a USB connected hardware wallet?
 
 To send a transaction you will need to connect your Hardware wallet and unlock the device (using PIN or password), in Wasabi Wallet you go to the `Send` tab where you can specify the address to send to, amount of bitcoin to send and which coins to use as input (only use green/private coins here!).
@@ -1066,6 +1145,7 @@ After filling in all transaction details you click `Send Transaction` to sign it
 :::
 
 :::details
+
 ### How can I build and export a transaction to ColdCard?
 
 In the Wallet Explorer on the right side of the GUI, select `YourWallet>Advanced>Build Transaction`.
@@ -1075,6 +1155,7 @@ This file should be moved to the MicroSD card that you can then insert in the Co
 :::
 
 :::details
+
 ### How can I sign a transaction on the ColdCard?
 
 On the ColdCard (Mk2, firmware 2.1.1 and up) you enter the PIN code to unlock the hardware wallet and press `>Ready To Sign` with the MicroSD card containing the previously generated transaction or PSBT-file.
@@ -1083,6 +1164,7 @@ The finalized transaction (xxx-final.txn) can now be broadcast by Wasabi Wallet 
 :::
 
 :::details
+
 ### How can I import and broadcast a final transaction from ColdCard?
 
 In the Wallet Explorer you go to `YourWallet>Advanced>Broadcast Transaction` and click `Import Transaction`, now you can select the previously finalized (and signed) transaction file from the MicroSD card.
@@ -1091,12 +1173,14 @@ Now click `Broadcast Transaction` to send it off over Tor to a random Bitcoin no
 :::
 
 :::details
+
 ### Can I CoinJoin bitcoins on my hardware wallet?
 
 You can't do that directly, you have to send the bitcoins (in small portions > 0.1 BTC if needed) to a `hot` Wasabi Wallet, do the CoinJoin and then send them back to a new address on the Hardware wallet for cold-storage.
 :::
 
 ::::details
+
 ### Does Ledger Live server spy on my xpub?
 
 Yes, when using the Ledger Live software wallet to manage your coins, you send your extended public key to the Ledger company server.
@@ -1116,6 +1200,7 @@ Please consider this carefully before making a decision.
 ::::
 
 :::details
+
 ### After I CoinJoined my coins and reached green anonset, I sent them to my hardware wallet address. When I check my HW via Wasabi, the coins are now red. Why?
 
 Everything is working as expected.
@@ -1126,6 +1211,7 @@ You should put a meaningful label when you generate a receive address in your ha
 :::
 
 :::details
+
 ### How can I enter the PIN of my Trezor One?
 
 You can enter the PIN to unlock your Trezor One the same way you use the Trezor browser wallet.
@@ -1134,6 +1220,7 @@ Inside Wasabi, click on the boxes that correspond to your PIN in the order shown
 :::
 
 :::details
+
 ### How can I type in the passphrase of my Trezor One?
 
 The Trezor One was a pioneer in offline signing devices, however it has one critical design flaw.
@@ -1144,6 +1231,7 @@ However, Wasabi does not support to use the hot computer keyboard to type in the
 :::
 
 :::details
+
 ### How can I type in the passphrase of my Trezor T?
 
 After connecting the Trezor T to your computer and upon trying to load your wallet, you get a message on the Trezor T to choose where to type your passphrase, on the device or the host (computer), choose the first option (device) then enter the passprase using the touchscreen of your Trezor T.
@@ -1153,6 +1241,7 @@ Wasabi wallet will now load this passphrase protected wallet.
 ## History
 
 :::details
+
 ### How can I check the transactions history?
 
 In the `History` tab you see a list of all the transactions made with this Wasabi wallet.
@@ -1166,6 +1255,7 @@ The check mark indicates that the transaction is confirmed in the longest proof-
 :::
 
 :::details
+
 ### Can I export a list of transactions?
 
 There is currently no convenient way to export a list with transaction details.
@@ -1175,6 +1265,7 @@ However, you can see the `wallet.json` files inside the `WalletBackups` folder (
 ## Settings
 
 :::details
+
 ### What is Testnet?
 
 The testnet is an alternative Bitcoin blockchain, to be used for testing.
@@ -1194,6 +1285,7 @@ It was introduced with the 0.7 release, introduced a third genesis block, a new 
 :::
 
 :::details
+
 ### How do I connect my own full node to Wasabi?
 
 There is currently a basic implementation of connecting [your full node to Wasabi](/using-wasabi/BitcoinFullNode.md).
@@ -1208,6 +1300,7 @@ If your node is on a remote device [raspberry pi, nodl, server], then you can sp
 :::
 
 :::details
+
 ### How can I turn off Tor?
 
 You can turn off Tor in the Settings.
@@ -1217,6 +1310,7 @@ In the second case, if you happen to broadcast a transaction of yours to a full 
 :::
 
 :::details
+
 ### How can I change the anonset target?
 
 In the `Settings` tab at the bottom you can change the three `PrivacyLevelX` values of the desired anon set of the
@@ -1241,6 +1335,7 @@ Remember that you pay a fee proportional to the Anonymity Set.
 :::
 
 :::details
+
 ### What is the dust threshold?
 
 Dust can mean [a lot of things](https://bitcoin.stackexchange.com/questions/10986/what-is-meant-by-bitcoin-dust), depending how you look at it.
@@ -1254,9 +1349,11 @@ When you set it to `0.0000 5000 bitcoin`, and when you receive a coin worth `0.0
 :::
 
 :::details
+
 ### Where can I find the logs?
 
 In the top left menu `File > Open` you can see there are several logs available.
+
 * The `Log File` shows you the general information about Wasabi Wallet.
 * The `Tor Log File` shows the Tor specific logs.
 
@@ -1266,6 +1363,7 @@ Alternatively, you can find the logs inside your [Wasabi data folder](/FAQ/FAQ-U
 :::
 
 :::details
+
 ### How to activate Lurking Wife Mode?
 
 You can activate Lurking Wife Mode from `Settings` or by clicking on your wallet balance.
@@ -1273,6 +1371,7 @@ You can read more about Lurking Wife Mode [here](/using-wasabi/LurkingWifeMode.m
 :::
 
 :::details
+
 ### How can I change to the white theme?
 
 You can change from the default dark to the white theme in the `.walletwasabi/client/Gui/Settings/` [data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder).
@@ -1290,6 +1389,7 @@ Please note that Wasabi is designed for the dark theme, and some color schemes m
 @[youtube](k4VzJ6dUT9I)
 
 :::details
+
 ### Can I consolidate anonset coins?
 
 It is advisable to limit the recombining of mixed coins because it can only decrease the privacy of said coins.
@@ -1305,6 +1405,7 @@ If you would like to dive into the details of this topic, you can [read more her
 :::
 
 :::details
+
 ### How can I send my anonset coins to my hardware wallet?
 
 Most hardware wallets communicate with servers to provide you with your balance.
@@ -1316,6 +1417,7 @@ Alternatively, you can use your hardware wallet with Electrum, which connects to
 :::
 
 ::::details
+
 ### What can I do with small change?
 
 There are no hard and fast rules for what to do with the change.
@@ -1334,6 +1436,7 @@ For more information, see this [dedicated chapter](/using-wasabi/ChangeCoins.md)
 ::::
 
 :::details
+
 ### How can I mix large amounts?
 
 Use Unequal Input Mixing and gain fungibility for UTXOs of 0.1, 0.2, 0.4, 0.8, 1.6, 3.2, ... bitcoin!
@@ -1343,11 +1446,14 @@ Read more: [What are the equal denominations created in one mixing round?](/FAQ/
 :::
 
 :::details
+
 ### Which coins can I select for CoinJoins?
+
 You can select any coin, as long as the total sum reaches the minimum to register (usually ~0.1 BTC).
 :::
 
 :::details
+
 ### Why do my coins occasionally get banned from participating in CoinJoin?
 
 A CoinJoin consists of multiple users registering inputs (coins) and blinded outputs.
@@ -1374,6 +1480,7 @@ This is a temporary ban on your coins in participation of the CoinJoin.
 :::
 
 :::details
+
 ### What does spent coin status mean?
 
 The `spent` coin status is a symptom of corrupted wallet state.

--- a/docs/building-wasabi/CodeCoverage.md
+++ b/docs/building-wasabi/CodeCoverage.md
@@ -16,7 +16,6 @@ So, first of all we need to install the package in the [WalletWasabi.Tests](http
 dotnet add WalletWasabi.Tests/WalletWasabi.Tests.csproj package AltCover
 ```
 
-
 Next, run:
 
 ```sh

--- a/docs/building-wasabi/ContributionChecklist.md
+++ b/docs/building-wasabi/ContributionChecklist.md
@@ -17,6 +17,7 @@ So you're interested in contributing to Wasabi - welcome!
 This checklist will get you plugged in and productive as quickly as possible.
 
 ## Who is a contributor?
+
 :::tip
 Wasabi is free and open source software, but contributing is **not** just about writing code.
 **A contributor is any individual who works to improve and add value to Wasabi and its users.**
@@ -26,6 +27,7 @@ All such contributions are very welcomed and greatly appreciated.
 :::
 
 ## Say hello and get started
+
 - Join our [Slack](https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2NzQ1ODI0LWIzOTg5YTM3YmNkOTg1NjZmZTQ3NmM1OTAzYmQyYzk1M2M0MTdlZDk2OTQwNzFiNTg1ZmExNzM0NjgzY2M0Yzg), [Telegram](https://t.me/WasabiWallet), [Riot](https://riot.im/app/#/room/#wasabiwallet:matrix.org) or [Sub-Reddit](https://www.reddit.com/r/WasabiWallet/), and check out the [GitHub](https://github.com/zkSnacks/WalletWasabi)
 - Introduce yourself, say a bit about your skills and interests.
 This will help others point you in the right direction.
@@ -33,6 +35,7 @@ This will help others point you in the right direction.
 This will help you to find the interesting challenges you can work on.
 
 ## Learn how we work
+
 - To understand how Wasabi coin joins work, read [Zero Link: The Bitcoin Fungibility Framework](https://github.com/nopara73/zerolink) and explore the [Documentation](/FAQ/FAQ-UseWasabi.md#coinjoin).
 - Familiarize yourself with [C4: The Collective Code Construction Contract](https://rfc.unprotocols.org/spec:1/C4/).
 It’s a simple set of collaboration rules based on GitHub’s fork+pull request model, and a foundational part of how we work together.
@@ -41,12 +44,15 @@ It’s a simple set of collaboration rules based on GitHub’s fork+pull request
 Open for many additions!`
 
 ## Get connected
+
 - Subscribe to the [Wasabi YouTube channel](https://www.youtube.com/channel/UCobsrSexTuVkL39mbrQ35VQ) and watch the last clips of the developer calls.
 - Watch the [GitHub Repository](https://github.com/zkSnacks/WalletWasabi) to get email notifications about the latest contributions.
 - Follow [@WasabiWallet](https://twitter.com/wasabiwallet) on Twitter
 
 ## Do valuable work
+
 Ok. You’re all set up and ready to work. Here’s what to do next.
+
 1. **Find a problem somewhere in Wasabi-land** that (a) needs fixing and (b) is a match for your skills and interests.
 Browse [open issues](https://github.com/zksnacks/walletwasabi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) and [ToDo's](ToDo.md), ask around about what other contributors think needs fixing.
 Because while you don’t need anybody’s permission and you can work on whatever you want, you’ll want to know up front whether anybody else is going to care about the work you do.
@@ -56,8 +62,8 @@ Make it as easy as possible for others to review your work. Make it a *pleasure*
 4. **Incorporate review feedback** you get until your fix gets merged or is otherwise accepted.
 5. Repeat steps 1–4.
 
-
 ## What to work on
+
 It is not required to work on an existing issue to contribute to Wasabi, and no one is here to tell you what to do.
 Contributors who have their own ideas are free to work in their own forks on whatever they wish, however they wish, and without any permission from anyone.
 
@@ -72,6 +78,7 @@ Do this in order to ensure your contribution is:
 Remember: _every contributor_ is free to work on what they want, including maintainers who may or may not want to review and merge your pull request if they don't have any prior context for it, or reason to believe it's worth spending their time on.
 
 ### Reviews are for everybody
+
 :::tip
 If you want to be really popular around here, don’t just submit your own work, but also spend time reviewing the work of others.
 :::

--- a/docs/building-wasabi/Credits.md
+++ b/docs/building-wasabi/Credits.md
@@ -9,6 +9,7 @@
 
 Part of the content in this documentation comes from other open source projects.
 Here are some credits, thanks and sources (in casual order):
+
 - [Bitcoin Wiki](https://en.bitcoin.it/wiki/Main_Page)
 - [BTC Pay Server Documentation](https://docs.btcpayserver.org/)
 - [Bisq Documentation](https://docs.bisq.network/)

--- a/docs/building-wasabi/Dojo.md
+++ b/docs/building-wasabi/Dojo.md
@@ -67,7 +67,6 @@ Osu!
 | ThunderBiscuit   | [Twitter][46]               | [Wasabi Documentation][49]   | 2019-08: white belt by Max Hillebrand|
 | Riccardo Masutti   | [Twitter][50]               | [Wasabi Documentation][51]   | 2019-11: white belt by Max Hillebrand|
 
-
 [1]: https://twitter.com/NicolasDorier/
 [2]: https://github.com/NicolasDorier/
 [3]: https://github.com/MetacoSA/NBitcoin/

--- a/docs/building-wasabi/FalsePositive.md
+++ b/docs/building-wasabi/FalsePositive.md
@@ -20,6 +20,7 @@ This page contains online form submissions, email template, addresses and GUI tu
 [[toc]]
 
 ## Email Template
+
 :::tip
 Ensure that the email subject line starts with the word FALSE.
 :::
@@ -83,7 +84,6 @@ Name and Surname
 |Microsoft  | [Yes](https://www.microsoft.com/en-us/wdsi/filesubmission) | N/A
 |Qihoo-360 | [Yes](https://www.360totalsecurity.com/en/suspicion/false-positive/) | N/A
 |TrendMicro  | [Yes](https://www.trendmicro.com/en_us/about/legal/detection-reevaluation.html) | N/A
-
 
 ## GUI Tutorials
 

--- a/docs/building-wasabi/HardwareWalletTestingGuide.md
+++ b/docs/building-wasabi/HardwareWalletTestingGuide.md
@@ -44,7 +44,9 @@ Follow this step-by-step [guide](../using-wasabi/BuildSource.md).
 ## Step 2: Test
 
 ### 1. Does Wasabi recognize your hardware wallet?
+
 ### 2. Does Wasabi load your hardware wallet?
+
 ### 3. Can you send transaction using Wasabi and your hardware wallet?
 
 ## Step 3: Report Results

--- a/docs/building-wasabi/HowToDebug.md
+++ b/docs/building-wasabi/HowToDebug.md
@@ -15,22 +15,24 @@ This guide is for giving detailed instructions about how to debug Wasabi Wallet 
 We will focus on how to achieve this with `vscode` first because that is the cross-platform IDE used by some of the developer team members.
 
 ## Before Starting
+
 We assume the reader has already read the project [README](https://github.com/zkSNACKs/WalletWasabi/blob/master/README.md) file and has installed the [.NET Core ${dotnetVersion} SDK](https://www.microsoft.com/net/download), and knows how to clone the repository and build the Wasabi solution.
 
-
 ## Install VS Code and extensions
+
 ### 1: Get Visual Studio Code
+
 Install Visual Studio Code (VSC).
 Pick the latest VSC version from here: [https://code.visualstudio.com/download](https://code.visualstudio.com/download)
 
-
 ### 2: Install C# Extension
+
 Open the command palette in VS Code (press <kbd>F1</kbd>) and type `ext install C#` to trigger the installation of the extension.
 VS Code will show a message that the extension has been installed and it will restart.
 Installing this extension can take a while.
 
-
 ### 3: Open the WalletWasabi directory in VS Code
+
 Go to `File->Open Folder` and open the WalletWasabi directory in Visual Studio Code.
 The Wasabi vscode settings forces a download of the latest omnisharp versions every time the folder is opened and this can take a while.
 
@@ -126,6 +128,7 @@ Add the following launcher to the array of `configurations` in the `.vscode/laun
    }
 }
 ```
+
 As before, we need to create a task for compiling the backend project before executing the code, and this is done again in the `.vscode/tasks.jon` file.
 Add the following task to the array of tasks:
 
@@ -144,8 +147,6 @@ Add the following task to the array of tasks:
 
 And that is all.
 Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugger, set a couple of breakpoints, select the `Wasabi Backend .NET Core` launcher and press the play button to start debugging.
-
-
 
 ### Files
 
@@ -237,7 +238,6 @@ Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugg
 }
 ```
 
-
 #### .vscode/tasks.json
 
 ```json
@@ -298,14 +298,13 @@ Once this has been done a developer can press (CTRL+SHIFT+D) to go to the debugg
 
 ## How to setup and run the whole system
 
-Sometimes, as developers, we need to test an advanced interaction between the Bitcoin Core node, the Coordinator, and one or more Wasabi clients. 
+Sometimes, as developers, we need to test an advanced interaction between the Bitcoin Core node, the Coordinator, and one or more Wasabi clients.
 Just imagine a case in which we want to verify the system behavior after a blockchain reorg.
 In these cases we have to setup and run all the components, and use regtest.
 
 ### Install Bitcoin Core
 
 Download and install Bitcoin Core from [https://bitcoincore.org/bin/](https://bitcoincore.org/bin/).
-
 
 ### Running the backend (coordinator)
 

--- a/docs/building-wasabi/LICENSE.md
+++ b/docs/building-wasabi/LICENSE.md
@@ -21,7 +21,6 @@ Licensed works, modifications, and larger works may be distributed under differe
 | Distribution   |              |                              |
 | Private use    |              |                              |
 
-
 Copyright (c) 2019 zkSNACKs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/docs/building-wasabi/ToDo.md
+++ b/docs/building-wasabi/ToDo.md
@@ -33,7 +33,7 @@ When you are ever bored and want to be productive, why not pick up one of these 
 - Join Market integration
 - [SNICKER integration: Simple Non-Interactive CoinJoin with Keys for Encryption Reused](https://github.com/zkSNACKs/Meta/issues/67)
 - [Encryption manager BIP 322](https://github.com/zkSNACKs/WalletWasabi/issues/1121)
-- Lightning network integration 
+- Lightning network integration
 - CoinJoin statistics database and website
 - SegWit v1 Schnorr / Taproot
 - [SigNet integration](https://github.com/zkSNACKs/Meta/issues/66)

--- a/docs/glossary/Glossary-GeneralBitcoin.md
+++ b/docs/glossary/Glossary-GeneralBitcoin.md
@@ -8,6 +8,7 @@
 ## Bitcoin in general
 
 :::details
+
 ### Address
 
 A Bitcoin invoice address commits to a public key or script which defines who can spend the coin.
@@ -17,6 +18,7 @@ Read more: [Bitcoin addresses](/using-wasabi/Receive.md#bitcoin-public-keys-and-
 :::
 
 :::details
+
 ### Bitcoin Improvement Proposal (BIP)
 
 Bitcoin Improvement Proposal.
@@ -25,6 +27,7 @@ Read more: [Wasabi Supported BIPs](/using-wasabi/BIPs.md)
 :::
 
 :::details
+
 ### Block
 
 A block is a batch of valid Bitcoin transactions and its hash must be a value below a certain difficulty target to prove the work of the miner.
@@ -33,6 +36,7 @@ On average a new block is mined every 10 minutes.
 :::
 
 :::details
+
 ### Blockchain
 
 The blockchain is the one chain of valid Bitcoin blocks with the most accumulated proof of work.
@@ -41,6 +45,7 @@ Because of its uniquely verifiable and global consensus, it is a revolutionary s
 :::
 
 :::details
+
 ### Change
 
 In a spending transaction where the provided input coins are larger than the value sent to the destination address, then the leftover change is sent to a new address of the same wallet.
@@ -48,6 +53,7 @@ Read more: [Change coins](/using-wasabi/ChangeCoins.md)
 :::
 
 :::details
+
 ### Coinbase
 
 A special field used as the sole input for coinbase transactions.
@@ -55,6 +61,7 @@ The coinbase allows claiming the block reward and provides up to 100 bytes for a
 :::
 
 :::details
+
 ### Coinbase Transaction
 
 The first transaction in a block.
@@ -62,6 +69,7 @@ Always created by a miner, it includes a single coinbase.
 :::
 
 :::details
+
 ### Cold Storage
 
 Refers to keeping a reserve of important Bitcoin secrets offline.
@@ -72,6 +80,7 @@ Read more: [Cold Wasabi Protocol](/using-wasabi/ColdWasabi.md)
 :::
 
 :::details
+
 ### Confirmations
 
 Once a transaction is included in a block, it has one confirmation.
@@ -80,18 +89,21 @@ Six or more confirmations is considered sufficient proof that a transaction cann
 :::
 
 :::details
+
 ### Consensus
 
 When several nodes, usually most nodes on the network, all have the same blocks in their locally-validated best blockchain.
 :::
 
 :::details
+
 ### Consensus Rules
 
 The block validation rules that full nodes follow to stay in consensus with other nodes.
 :::
 
 :::details
+
 ### Custodial (Wallet or Mixer)
 
 A custodial wallet is any wallet where the private keys of your coins are in the hands of a third party.
@@ -102,18 +114,21 @@ This means that you are at risk of being stolen from.
 :::
 
 :::details
+
 ### Difficulty
 
 A network-wide setting that controls how much computation is required to produce a proof of work.
 :::
 
 :::details
+
 ### Difficulty Retargeting (Difficulty Adjustment)
 
 A network-wide recalculation of the difficulty that occurs once every 2,016 blocks and considers the hashing power of the previous 2,016 blocks.
 :::
 
 :::details
+
 ### Difficulty Target
 
 A difficulty at which all the computation in the network will find blocks approximately every 10 minutes.
@@ -121,6 +136,7 @@ It specifies the numeric value the hash of a block must not be above to be consi
 :::
 
 :::details
+
 ### Fork
 
 Fork, also known as accidental fork, occurs when two or more blocks have the same block height, forking the blockchain.
@@ -129,6 +145,7 @@ Can also happen as part of an attack.
 :::
 
 :::details
+
 ### Fungibility
 
 Fungibility is a desirable property of Bitcoin UTXOs that are indistinguishable from each other.
@@ -136,12 +153,14 @@ Read more: [Transaction surveillance companies attempting to destroy fungibility
 :::
 
 :::details
+
 ### Genesis Block
 
 The first block in the blockchain, used to initialize the cryptocurrency.
 :::
 
 :::details
+
 ### Hard Fork
 
 Hard fork, also known as hard-forking change, is a permanent divergence in the blockchain, it occurs when non-upgraded nodes can not validate blocks created by upgraded nodes that follow newer consensus rules.
@@ -150,12 +169,15 @@ Not to be confused with fork, soft fork, software fork or Git fork.
 :::
 
 :::details
+
 ### Hardware Wallet (HWW)
+
 A hardware wallet is a special type of Bitcoin wallet which generates and stores the user's private keys on a dedicated hardware device.
 Read more: [Hardware Wallet FAQs](/FAQ/FAQ-UseWasabi.md#hardware-wallet)
 :::
 
 :::details
+
 ### Hash
 
 A cryptographic hash function takes any input of arbitrary size [the message] and computes a value of fixed size that is unique to the input, which is called a hash or a digest.
@@ -166,18 +188,21 @@ Bitcoin uses the SHA256 in many parts of the protocol.
 :::
 
 :::details
+
 ### HD Protocol
 
 The Hierarchical Deterministic (HD) key creation and transfer protocol (BIP32), which allows creating child keys from parent keys in a hierarchy.
 :::
 
 :::details
+
 ### HD Wallet
 
 Wallets using the Hierarchical Deterministic (HD Protocol) key creation and transfer protocol (BIP32).
 :::
 
 :::details
+
 ### Hot Wallet
 
 A hot wallet is a software wallet that runs on a computer which is connected to the Internet.
@@ -185,12 +210,14 @@ Wasabi is a hot wallet by default.
 :::
 
 :::details
+
 ### Input
 
 Input, transaction input, or TxIn is an input in a Bitcoin transaction which contains two fields: a unique transaction hash and an index number, which references one utxo of a previous transaction which is spent in this transaction.
 :::
 
 :::details
+
 ### Lightning Network (LN)
 
 Lightning Network is a proposed implementation of Hashed Timelock Contracts (HTLCs) with bi-directional payment channels which allows payments to be securely routed across multiple peer-to-peer payment channels.
@@ -199,12 +226,14 @@ Read more: [Use Lightning](/why-wasabi/10Commandments.md#_10-use-lightning)
 :::
 
 :::details
+
 ### Mainnet
 
 The original and main network for Bitcoin transactions, where satoshis have real economic value.
 :::
 
 :::details
+
 ### Mempool
 
 The Bitcoin Mempool (memory pool) is a collection of all transaction data in a block that have been verified by Bitcoin nodes, but are not yet confirmed.
@@ -212,6 +241,7 @@ Read more: [How does Wasabi know of incoming transactions to the mempool?](/FAQ/
 :::
 
 :::details
+
 ### Merkle Root
 
 The root node of a merkle tree, a descendant of all the hashed pairs in the tree.
@@ -219,6 +249,7 @@ Block headers must include a valid merkle root descended from all transactions i
 :::
 
 :::details
+
 ### Merkle Tree
 
 A tree constructed by hashing paired data (the leaves), then pairing and hashing the results until a single hash remains, the merkle root.
@@ -226,12 +257,14 @@ In Bitcoin, the leaves are almost always transactions from a single block.
 :::
 
 :::details
+
 ### Miner
 
 A network node that finds valid proof of work for new blocks, by repeated hashing.
 :::
 
 :::details
+
 ### Multisignature (multisig)
 
 Multisignature (m-of-n multisig) refers to requiring more than one key to authorize a Bitcoin transaction.
@@ -240,6 +273,7 @@ Read more: [Can I generate a multi signature script?](/FAQ/FAQ-UseWasabi.md#can-
 :::
 
 :::details
+
 ### Nonce
 
 The `nonce` in a Bitcoin block is a 32-bit (4-byte) field whose value is set so that the hash of the block will contain a run of leading zeros.
@@ -247,6 +281,7 @@ The rest of the fields may not be changed, as they have a defined meaning.
 :::
 
 :::details
+
 ### Non-Custodial (Wallet or Mixer)
 
 A non-custodial wallet is any wallet where the private keys of your coins are in your hands.
@@ -259,12 +294,14 @@ The funds will always be in a Bitcoin address that you control.
 :::
 
 :::details
+
 ### Output
 
 Output, transaction output, or TxOut is an output in a Bitcoin transaction which contains two fields: a value field for transferring zero or more satoshis and a pubkey script for indicating what conditions must be fulfilled for those satoshis to be further spent.
 :::
 
 :::details
+
 ### Off-chain Transaction
 
 An off-chain transaction is the movement of value outside of the blockchain.
@@ -273,6 +310,7 @@ An off-chain transaction relies on other methods to record and validate the tran
 :::
 
 :::details
+
 ### P2PKH
 
 Many transactions processed on the Bitcoin network spend outputs locked with a Pay-to-Public-Key-Hash or `P2PKH` script.
@@ -281,6 +319,7 @@ An output locked by a P2PKH script can be unlocked (spent) by presenting a publi
 :::
 
 :::details
+
 ### P2SH
 
 P2SH or Pay-to-Script-Hash is a type of transaction that simplifies the use of complex transaction scripts.
@@ -288,12 +327,14 @@ With P2SH the complex script that details the spending conditions (redeem script
 :::
 
 :::details
+
 ### P2WPKH
 
 The signature of a P2WPKH (Pay-to-Witness-Public-Key-Hash) contains the same information as a P2PKH spending, but is located in the witness field instead of the scriptSig field.
 :::
 
 :::details
+
 ### Paper Wallet
 
 In the most specific sense, a paper wallet is a document containing all the secrets to spend a Bitcoin UTXO.
@@ -301,6 +342,7 @@ It is a way of storing bitcoin offline as a physical document.
 :::
 
 :::details
+
 ### Partially Signed Bitcoin Transaction (PSBT)
 
 PSBT is a binary transaction format which contains the information necessary for a signer to produce signatures for the transaction and holds the signatures for an input while the input does not have a complete set of signatures.
@@ -309,6 +351,7 @@ Read more: [BIP 174 Partially Signed Bitcoin Transaction Format](https://github.
 :::
 
 :::details
+
 ### Payment Channels
 
 A payment channel is class of techniques designed to allow users to make multiple Bitcoin transactions without committing all of the transactions to the Bitcoin blockchain.
@@ -316,6 +359,7 @@ In a typical payment channel, only two transactions are added to the blockchain 
 :::
 
 :::details
+
 ### Pay-to-Witness-Public-Key-Hash (P2WPKH)
 
 The signature of a P2WPKH contains the same information as a Pay-to-Public-Key-Hash (P2PKH) spending, but is located in the witness field instead of the scriptSig field.
@@ -324,6 +368,7 @@ Read more: [BIP 84 derivation scheme for P2WPKH based accounts](/using-wasabi/BI
 :::
 
 :::details
+
 ### Public Key
 
 A public key is calculated by multiplying the private key to the generator point of an elliptic curve.
@@ -336,6 +381,7 @@ Read more: [Bitcoin private keys](/using-wasabi/Receive.html#bitcoin-public-keys
 :::
 
 :::details
+
 ### Private Key
 
 A private key is a large number that must be chosen at random, it is thus a very secure password and should be kept secret.
@@ -346,6 +392,7 @@ Read more: [Bitcoin private keys](/using-wasabi/Receive.html#bitcoin-public-keys
 :::
 
 :::details
+
 ### Proof of Work (POW)
 
 One of the requirements for a Bitcoin block to be valid is its hash should be below a certain difficulty target.
@@ -354,18 +401,21 @@ By providing this pre-image block, anyone can verify the amount of computational
 :::
 
 :::details
+
 ### Regtest
 
 A local testing environment in which developers can instantly generate blocks on demand for testing events, and can create private satoshis with no real-world value.
 :::
 
 :::details
+
 ### Replace by Fee (RBF)
 
 Replacing one version of an unconfirmed transaction with a different version of the transaction that pays a higher transaction fee.
 :::
 
 :::details
+
 ### Mining Reward
 
 An amount of satoshis included in each new block as a reward by the network to the miner who found the proof of work solution.
@@ -374,6 +424,7 @@ This leads to a total money supply of just below 21 million bitcoin.
 :::
 
 :::details
+
 ### satoshi (sat)
 
 A satoshi is the smallest denomination of bitcoin that can be recorded on the blockchain.
@@ -382,6 +433,7 @@ Read more: [How can I display the fee in satoshi per byte?](/FAQ/FAQ-UseWasabi.m
 :::
 
 :::details
+
 ### Satoshi Nakamoto
 
 Satoshi Nakamoto is the name used by the person or people who designed Bitcoin and created its original reference implementation, Bitcoin Core.
@@ -391,6 +443,7 @@ Their real identity remains unknown.
 :::
 
 :::details
+
 ### Script
 
 Bitcoin uses a scripting system for transactions.
@@ -399,6 +452,7 @@ It is purposefully not Turing-complete, with no loops.
 :::
 
 :::details
+
 ### ScriptPubKey
 
 ScriptPubKey or pubkey script, is a script included in outputs which sets the conditions that must be fulfilled for those satoshis to be spent.
@@ -406,12 +460,14 @@ Data for fulfilling the conditions can be provided in a signature script.
 :::
 
 :::details
+
 ### ScriptSig
 
 ScriptSig or signature script, is the data generated by a spender which is almost always used as variables to satisfy a pubkey script.
 :::
 
 :::details
+
 ### Segregated Witness (SegWit)
 
 Segregated Witness is a structure where the witness [signature or redeem script] is stored separately from the transaction Merkle tree.
@@ -420,6 +476,7 @@ Read more: [Why Wasabi uses only SegWit](/FAQ/FAQ-UseWasabi.md#why-does-wasabi-o
 :::
 
 :::details
+
 ### Simplified Payment Verification (SPV)
 
 SPV is a method for verifying particular transactions were included in a block without downloading the entire block.
@@ -428,18 +485,21 @@ Read more: [Wasabi Wallet under the hood](/building-wasabi/TechnicalOverview.md#
 :::
 
 :::details
+
 ### Soft Fork
 
 Soft fork or soft-forking change is a fork in the blockchain which commonly occurs when miners using non-upgraded nodes don’t follow a new consensus rule their nodes don’t know about.
 :::
 
 :::details
+
 ### Testnet
 
 A testing environment in which users can obtain and spend satoshis that have no real-world value on a global network that is very similar to the Bitcoin mainnet.
 :::
 
 :::details
+
 ### Transaction
 
 In simple terms, a transfer of bitcoin.
@@ -448,6 +508,7 @@ Transactions are transmitted over the Bitcoin network, collected by miners, and 
 :::
 
 :::details
+
 ### Transaction Fees
 
 A transaction includes a fee to the network for processing the requested transaction.
@@ -456,6 +517,7 @@ Read more: [What fee should I select?](/FAQ/FAQ-UseWasabi.md#what-fee-should-i-s
 :::
 
 :::details
+
 ### Unspent Transaction Output (UTXO)
 
 UTXO is an unspent transaction output that can be spent as an input in a new transaction.
@@ -463,6 +525,7 @@ Read more: [How can I select UTXOs for CoinJoin?](/FAQ/FAQ-UseWasabi.md#how-can-
 :::
 
 :::details
+
 ### Wallet
 
 Software that holds all your Bitcoin addresses and secret keys.

--- a/docs/glossary/Glossary-PrivacyWasabi.md
+++ b/docs/glossary/Glossary-PrivacyWasabi.md
@@ -8,6 +8,7 @@
 ## Privacy and Wasabi
 
 :::details
+
 ### Address Reuse
 
 Address reuse refers to the use of the same address for multiple transactions, this is very bad for privacy.
@@ -15,6 +16,7 @@ Read more: [Address reuse](/using-wasabi/AddressReuse.md)
 :::
 
 :::details
+
 ### Anonymity Set (anonset)
 
 The anonymity set is effectively the size of the group you are hiding in during a CoinJoin.
@@ -23,6 +25,7 @@ Read more: [What is the anonymity set?](/FAQ/FAQ-UseWasabi.md#what-is-the-anonym
 :::
 
 :::details
+
 ### Block filters
 
 A filter representing a compact list of addresses in one block.
@@ -32,6 +35,7 @@ Read more: [BIP 158: Compact Block Filters for Light Clients](/using-wasabi/BIPs
 :::
 
 :::details
+
 ### Blockchain Analysis
 
 Blockchain analysis is used by transaction surveillance companies to follow the transaction history of coins.
@@ -40,6 +44,7 @@ Read more: [Blockchain Analysis](/why-wasabi/TransactionSurveillanceCompanies.md
 :::
 
 :::details
+
 ### Bloom Filter
 
 A filter used primarily by SPV clients to request only block headers and merkle proofs of a given transaction from full nodes.
@@ -48,6 +53,7 @@ Read more: [BIP 37: Connection Bloom Filtering](/using-wasabi/BIPs.md#bip-37-con
 :::
 
 :::details
+
 ### Change Address Detection
 
 Many Bitcoin transactions have change outputs.
@@ -56,6 +62,7 @@ Read more: [Change coins](/using-wasabi/ChangeCoins.md)
 :::
 
 :::details
+
 ### Chaumian CoinJoin
 
 A Chaumian CoinJoin is a special type of CoinJoin that utilizes Chaumian [or Schnorr] blind signatures to prevent the central coordinator from spying on the linkage between inputs and outputs.
@@ -63,6 +70,7 @@ Read more: [Use of blind signatures in CoinJoin](/using-wasabi/CoinJoin.md#zerol
 :::
 
 :::details
+
 ### Cluster
 
 Which entities know about which coins.
@@ -71,6 +79,7 @@ Read more: [What is the cluster history?](/FAQ/FAQ-UseWasabi.md#what-is-the-clus
 :::
 
 :::details
+
 ### CoinJoin (CJ)
 
 CoinJoin is a trustless method for combining multiple Bitcoin payments from multiple spenders into a single transaction to make it more difficult for outside parties to determine which spender paid which recipient.
@@ -78,6 +87,7 @@ Read more: [What is a CoinJoin?](/FAQ/FAQ-Introduction.md#what-is-a-coinjoin)
 :::
 
 :::details
+
 ### CoinJoined coins
 
 Coins that have successfully participated in a CoinJoin (with the exception of the change) and thus lose their association to a previous cluster.
@@ -85,6 +95,7 @@ Read more: [What is the privacy I get after mixing with Wasabi?](/FAQ/FAQ-Introd
 :::
 
 :::details
+
 ### Coin Control
 
 Coin control is a must learn if you care about your privacy in Bitcoin.
@@ -93,6 +104,7 @@ Read more: [Coin Control Best Practices](/FAQ/FAQ-UseWasabi.md#coin-control-best
 :::
 
 :::details
+
 ### Common-Input-Ownership heuristic
 
 This is a heuristic or assumption which says that if a transaction has more than one input then all those inputs are owned by the same entity.
@@ -100,6 +112,7 @@ Read more: [Wasabi Wallet under the hood](/building-wasabi/TechnicalOverview.md#
 :::
 
 :::details
+
 ### Coordinator
 
 The coordinator is a server which creates CoinJoins and accepts UTXOs in the mix.
@@ -107,6 +120,7 @@ Read more: [Wasabi Wallet under the hood](/FAQ/FAQ-UseWasabi.md#how-does-my-wall
 :::
 
 :::details
+
 ### Daemon
 
 A daemon is a command line interface to run Wasabi without the GUI (Graphical User Interface).
@@ -114,6 +128,7 @@ Read more: [Headless Wasabi Daemon](/using-wasabi/Daemon.md)
 :::
 
 :::details
+
 ### Dust
 
 Dust is an UTXO that is uneconomical to spend.
@@ -122,6 +137,7 @@ Read more: [What is the dust threshold](/FAQ/FAQ-UseWasabi.html#what-is-the-dust
 :::
 
 :::details
+
 ### Know Your Customer (KYC)
 
 KYC (Know Your Customer) is the process of a business being forced to identify and verify the identity of its clients, and to share this information with a government.
@@ -130,6 +146,7 @@ Read more: [AML/KYC Information](/why-wasabi/TransactionSurveillanceCompanies.md
 :::
 
 :::details
+
 ### Label
 
 A way to track who knows about the ownership of your coins.
@@ -138,6 +155,7 @@ Read more: [The importance of labeling](/using-wasabi/Receive.md#the-importance-
 :::
 
 :::details
+
 ### Lurking Wife Mode (LWM)
 
 Lurking Wife Mode is a Wasabi feature that hides sensitive and critical information on the wallet itself, which is useful for screenshots.
@@ -145,6 +163,7 @@ Read more: [Lurking Wife Mode](/using-wasabi/LurkingWifeMode.md)
 :::
 
 :::details
+
 ### Pay to EndPoint (P2EP)
 
 Pay to EndPoint is sending of bitcoins where the receiver adds one of his own coins as input for a two party CoinJoin.
@@ -152,6 +171,7 @@ Read more: [Pay to EndPoint](/using-wasabi/PayToEndPoint.md)
 :::
 
 :::details
+
 ### Peers
 
 Peers in our documentation refers mainly to Bitcoin and Wasabi Wallet users, but it also means people.
@@ -159,6 +179,7 @@ They are literally peers in the network, or in the CoinJoin.
 :::
 
 :::details
+
 ### RPC
 
 RPC, or Remote Procedure Call, is an interface to interact with Wasabi Wallet programmatically.
@@ -166,6 +187,7 @@ Read more: [RPC Interface](/using-wasabi/RPC.md)
 :::
 
 :::details
+
 ### Shield (or anonset shield)
 
 We often talk about
@@ -183,6 +205,7 @@ Essentially, when we talk about shields, we mean a specific privacy level set by
 :::
 
 :::details
+
 ### XPUB (Extended Public Key)
 
 An xpub, also know as Extended Public Key, is a part of BIP-32 that will allow you to observe your wallet without the private key (xpriv).
@@ -190,6 +213,7 @@ Read more: [Wasabi's Solution](/why-wasabi/BitcoinPrivacy.md#wasabi-s-solution-4
 :::
 
 :::details
+
 ### Taint
 
 Taint is equivalent to the 'trail' that a Bitcoin transaction leaves during the course of its journey.
@@ -198,6 +222,7 @@ Read more: [Blockchain Analysis](/why-wasabi/TransactionSurveillanceCompanies.md
 :::
 
 :::details
+
 ### The Onion Router (Tor)
 
 Tor (The Onion Router) is free and open-source software for enabling anonymous communication.
@@ -206,6 +231,7 @@ Read more: [How does Tor protect my network level privacy?](/FAQ/FAQ-GeneralBitc
 :::
 
 :::details
+
 ### Tumbling / Tumbler
 
 Tumbling is a synonym of 'Mixing'.
@@ -213,6 +239,7 @@ Similarly, Tumbler is the synonym of 'Mixer'.
 :::
 
 :::details
+
 ### Transaction Surveillance Company
 
 A transaction surveillance company is one which attempts to spy on all Bitcoin users.
@@ -221,6 +248,7 @@ Read more: [Transaction Surveillance Companies](/why-wasabi/TransactionSurveilla
 :::
 
 :::details
+
 ### #twoweeks
 
 The #twoweeks is a fun inside joke often used in the Wasabi documentation and, more generally, in the Internet community.
@@ -230,6 +258,7 @@ Eg. "Lightning Network is coming to Wasabi in #twoweeks"
 :::
 
 :::details
+
 ### Wallet fingerprinting
 
 A careful analyst sometimes deduces which software created a certain transaction, because many different wallet softwares don't always create transactions in exactly the same way.
@@ -237,12 +266,14 @@ Read more: [Technical Overview of Wasabi Wallet](/building-wasabi/TechnicalOverv
 :::
 
 :::details
+
 ### Wasabika
 
 Wasabikas are builders, users and supporters of Wasabi in general.
 :::
 
 :::details
+
 ### ZeroLink
 
 ZeroLink is a framework to holistically design a privacy and fungibility setup for Bitcoin.

--- a/docs/using-wasabi/AddressReuse.md
+++ b/docs/using-wasabi/AddressReuse.md
@@ -25,27 +25,27 @@ But not all types of address reuse are equal - there are 6 different ways how th
 
 ## 1. Donations
 
-Many peers post one of their Bitcoin addresses on the internet, and then the same address can be viewed by countless others, not just at the time of publishing, but even years afterwards. 
+Many peers post one of their Bitcoin addresses on the internet, and then the same address can be viewed by countless others, not just at the time of publishing, but even years afterwards.
 It is very easy and convenient to have such a donation address, and thus many peers do this.
 
-To register such a donation UTXO for coin join is not only legitimate, but desired. 
-If you accept donations to an address, you should be registering these UTXOs together to one CoinJoin round. 
-Of course block explorers will note it as address reuse in the CoinJoin, which is technically correct, but it misleads the observer, because he will think something is wrong. 
+To register such a donation UTXO for coin join is not only legitimate, but desired.
+If you accept donations to an address, you should be registering these UTXOs together to one CoinJoin round.
+Of course block explorers will note it as address reuse in the CoinJoin, which is technically correct, but it misleads the observer, because he will think something is wrong.
 You better consolidate your donations into one UTXO instead of many, and you might as well do it in a CoinJoin.
 
-**How to improve?** 
+**How to improve?**
 To encourage address reuse here, when we are selecting coins to CoinJoin, we should intentionally select coins together those are on the same address.
 
 ## 2. Coordinator Address
 
 The coordinator address participates in every CoinJoin, thus it’s address reuse.
 The idea is to be transparent about what a Wasabi CoinJoin is and what isn’t, as well as to show the total fee earnings of Wasabi.
-Otherwise only blockchain analysis would be able to figure this information out, and it’d be able to do this without a mistake. 
+Otherwise only blockchain analysis would be able to figure this information out, and it’d be able to do this without a mistake.
 This way anyone can.
 
 **How to improve?**
-The idea of coordinator address reuse is transparency. 
-We could give up transparency here to confuse less sophisticated observers by creating a new coordinator address for every CoinJoin. 
+The idea of coordinator address reuse is transparency.
+We could give up transparency here to confuse less sophisticated observers by creating a new coordinator address for every CoinJoin.
 It’s a different tradeoff, not an improvement.
 The current coordinator address is `bc1qa24tsgchvuxsaccp8vrnkfd85hrcpafg20kmjw`, and the old one is `bc1qs604c7jv6amk4cxqlnvuxv26hv3e48cds4m0ew`.
 
@@ -59,19 +59,19 @@ The hope is that this dust coin is consolidated with another coin, thus linking 
 This is also address reuse, there’s nothing to do about it, Bitcoin is a push-based system.
 
 **How to improve?**
-In response we introduced a default, modifiable dust limit. 
+In response we introduced a default, modifiable dust limit.
 While this mitigates the potential privacy implications, this doesn’t make the address reuse to not appear in block explorers.
 
 ## 4. Intentional
 
-Since Wasabi is libre and open source, anyone can modify a fork of Wasabi to make sure the same two addresses are recycled in every CoinJoin registration. 
-This is someone intentionally deanonymizing himself, such a behavior might have quite dubious motives. 
-However there are numerous claims about this being some kind of Sybil attack, which makes no sense in multiple levels. 
-One bad actor participating in numerous mixes lowers our anonymity set, but only a bit. 
-If there’s 100 participants in a mix and of them one isn’t anonymous it makes no difference. 
+Since Wasabi is libre and open source, anyone can modify a fork of Wasabi to make sure the same two addresses are recycled in every CoinJoin registration.
+This is someone intentionally deanonymizing himself, such a behavior might have quite dubious motives.
+However there are numerous claims about this being some kind of Sybil attack, which makes no sense in multiple levels.
+One bad actor participating in numerous mixes lowers our anonymity set, but only a bit.
+If there’s 100 participants in a mix and of them one isn’t anonymous it makes no difference.
 Furthermore if I would want to Sybil attack Wasabi I would do it in a way to try to hide the fact that I’m Sybil attacking, or at the very least I wouldn’t make changes to the code to announce that I’m Sybil attacking.
 
-**How to improve?** 
+**How to improve?**
 There’s nothing to improve.
 Because the CoinJoin output is blinded in the first steps of the ceremony, it cannot be noticed before the output registration phase.
 We could refuse the registration of these actors, but then they’d change their addresses, then we’d have to pick them out again, then they’d change their addresses again and so on…
@@ -79,7 +79,7 @@ This would also decrease the denial of service protections currently implemented
 
 ## 5. Wallet State Issue
 
-Finally we arrived to the type of address reuse that was actually a known bug in Wasabi. 
+Finally we arrived to the type of address reuse that was actually a known bug in Wasabi.
 This was happening, because Wasabi sometimes lost unconfirmed transactions, so the wallet wasn’t aware of that an address was used, thus it registered it to a CoinJoin.
 The unconfirmed tx loss is thought to be eliminated since version 1.1.6, but of course this still happens for those who are using older software versions.
 Because only very few users report this bugs there’s no need for forcing everyone to update.

--- a/docs/using-wasabi/BIPs.md
+++ b/docs/using-wasabi/BIPs.md
@@ -19,43 +19,49 @@ Here is a list of all the supported and integrated Bitcoin Improvement Proposals
 ## What is supported today
 
 :::details
+
 ### BIP 21: URI Scheme
 
 [BIP 21: URI Scheme](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)
 :::
 
 :::details
+
 ### BIP 32: Hierarchical Deterministic Wallets
 
 [BIP 32: Hierarchical Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
 :::
 
-
 :::details
+
 ### BIP 38: Password-Protected Private Key
 
 [BIP 38: Password-Protected Private Key](https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki)
 :::
 
 :::details
+
 ### BIP 39: Mnemonic Code for Generating Deterministic Keys
 
 [BIP 39: Mnemonic Code for Generating Deterministic Keys](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
 :::
 
 :::details
+
 ### BIP 44: Multi-Account Hierarchy for Deterministic Wallets
 
 [BIP 44: Multi-Account Hierarchy for Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
 :::
 
 :::details
+
 ### BIP 72: bitcoin: uri extensions for Payment Protocol
 
 [BIP 72: bitcoin: uri extensions for Payment Protocol](https://github.com/bitcoin/bips/blob/master/bip-0072.mediawiki)
 :::
 
 :::details
+
 ### BIP 84: Derivation scheme for P2WPKH Based Accounts
 
 [BIP 84](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki) defines a standard derivation scheme for hierarchical deterministic wallets BIP 32, specifically for segregated witness P2WPKH [BIP 173](BIPs.md#bip-173-base32-address-format-for-native-v0-16-witness-outputs).
@@ -66,30 +72,35 @@ On the TestNet and on the RegTest Wasabi deviates from the standard and uses `m/
 :::
 
 :::details
+
 ### BIP 125: Opt-In full Replace-by-Fee Signaling
 
 [BIP 125: Opt-In full Replace-by-Fee Signaling](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) is activated for a subset of transactions chosen randomly, so to decrease wallet fingerprinting.
 :::
 
 :::details
+
 ### BIP 141: Segregated Witness (Consensus Layer)
 
 [BIP 141: Segregated Witness (Consensus Layer)](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)
 :::
 
 :::details
+
 ### BIP 143: Transaction Signature Verification for Version 0 Witness Program
 
 [BIP 143: Transaction Signature Verification for Version 0 Witness Program](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki)
 :::
 
 :::details
+
 ### BIP 144: Segregated Witness (Peer Services)
 
 [BIP 144: Segregated Witness (Peer Services)](https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki)
 :::
 
 :::details
+
 ### BIP 158: Compact Block Filters for Light Clients
 
 [BIP 158 Block filters](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki) are the reverse of [BIP 37 Bloom filters](BIPs.md#bip-37-connection-bloom-filters) - the client will connect to a Bitcoin node and say "Hey, for every block, I would like a condensed list of addresses that were affected."
@@ -101,27 +112,30 @@ This has been proven to be by far the best way to do light clients privately, an
 :::
 
 :::details
+
 ### BIP 173: Base32 address format for native v0-16 witness outputs
 
 [BIP 173: Base32 address format for native v0-16 witness outputs](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
 :::
 
 :::details
+
 ### BIP 174: Partially Signed Bitcoin Transaction Format
 
 [BIP 174: Partially Signed Bitcoin Transaction Format](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki)
 :::
 
 :::details
+
 ### Hardware Wallet Interface
 
 [Hardware Wallet Interface](https://github.com/bitcoin-core/HWI)
 :::
 
-
 ## What will be supported in #twoweeks
 
 :::details
+
 ### BIP 47: Reusable Payment Codes for Hierarchical Deterministic Wallets
 
 [BIP 47](https://github.com/bitcoin/bips/blob/master/bip-0047.mediawiki) defines a technique for creating a payment code which can be publicly advertised and associated with a real-life identity without creating the loss of security or privacy inherent to P2PKH address reuse.
@@ -129,8 +143,8 @@ This has been proven to be by far the best way to do light clients privately, an
 This BIP is a particular application of [BIP 43](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki) and is intended to supplement HD wallets which implement BIP44.
 :::
 
-
 :::details
+
 ### BIP 156: Dandelion - Privacy Enhancing Routing
 
 [BIP 156 Dandelion](https://github.com/bitcoin/bips/blob/master/bip-0156.mediawiki) is a transaction routing mechanism that provides formal anonymity guarantees against attacks on Bitcoin's transaction spreading protocol.
@@ -139,10 +153,11 @@ This approach, known as diffusion in academia, allows network adversaries to lin
 
 Dandelion mitigates this class of attacks by sending transactions over a randomly selected path before diffusion.
 Transactions travel along this path during the "stem phase" and are then diffused during the "fluff phase" (hence Dandelion).
-We have shown that this routing protocol provides near-optimal anonymity guarantees among schemes that do not introduce additional encryption mechanisms. 
+We have shown that this routing protocol provides near-optimal anonymity guarantees among schemes that do not introduce additional encryption mechanisms.
 :::
 
 :::details
+
 ### BIP 157: Client Side Block Filtering
 
 [BIP 157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki) describes a new light client protocol in Bitcoin that improves upon currently available options.
@@ -155,17 +170,20 @@ The resulting protocol guarantees that light clients with at least one honest pe
 :::
 
 :::details
+
 ### BIP 322: Generic Message Signing Format
 
 [BIP 322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki) is a standard for interoperable generic signed messages based on the Bitcoin Script format.
 :::
 
 :::details
+
 ### BIP 325: Signet
 
 [BIP 325](https://github.com/bitcoin/bips/blob/master/bip-0325.mediawiki) is a new model for a testing network of Bitcoin that is based on block signing, not block mining.
 
 :::details
+
 ### BIP 340: Schnorr Signatures for secp256k1
 
 [BIP 340 Schnorr Signatures for secp256k1](https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki) is a digital signature scheme which has many benefits over the status-quo ECDSA.
@@ -173,6 +191,7 @@ One advantage is that any N-of-N and M-of-N multisignature can be easily made to
 :::
 
 :::details
+
 ### BIP 341: Taproot: SegWit version 1 output spending rules
 
 [BIP 341 Taproot: SegWit version 1 output spending rules](https://github.com/sipa/bips/blob/bip-schnorr/bip-taproot.mediawiki) is a way to combine [Schnorr signatures](BIPs.md#bip-schnorr) with [MAST](https://bitcoinmagazine.com/articles/the-next-step-to-improve-bitcoin-s-flexibility-scalability-and-privacy-is-called-mast-1476388597/).
@@ -185,15 +204,16 @@ Other branches would only be used where some participant is failing to cooperate
 :::
 
 :::details
+
 ### BIP 342: Validation of Taproot Scripts
 
 [BIP Validation of Taproot Scripts](https://github.com/sipa/bips/blob/bip-schnorr/bip-tapscript.mediawiki) defines a slight variation on Bitcoin’s existing Script language to be used in [BIP Taproot](BIPs.md#bip-taproot) merkle spends.
 :::
 
-
 ## What is not supported
 
 :::details
+
 ### BIP 37: Connection Bloom Filtering
 
 [BIP 37 Bloom filters](https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki) are filters that a client will send to a Bitcoin full node which says "Hey, if you see any transactions that get caught in these filters, they may or may not be mine!".
@@ -203,15 +223,15 @@ This was quite brilliant of an idea at the time, but has since been proven to no
 :::
 
 :::details
+
 ### BIP 69: Lexicographical Indexing of Transaction Inputs and Outputs
 
 [BIP 69: Lexicographical Indexing of Transaction Inputs and Outputs](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki)
 :::
 
 :::details
+
 ### BIP 70: Payment Protocol
 
 [BIP 70: Payment Protocol](https://github.com/bitcoin/bips/blob/master/bip-0070.mediawiki)
 :::
-
-

--- a/docs/using-wasabi/BitcoinFullNode.md
+++ b/docs/using-wasabi/BitcoinFullNode.md
@@ -33,7 +33,7 @@ Wasabi currently has a work in progress partial Bitcoin Core integration.
 The zkSNACKs coordinating server broadcasts [BIP 158 block filters](/using-wasabi/BIPs.md#bip-158-compact-block-filters-for-light-clients) to all Wasabi clients, who locally check if the filter hits for their public keys.
 Then you know that this block has a transaction of yours included, or maybe it is a false positive.
 
-:::warning 
+:::warning
 The zkSNACKs server has to be trusted to serve correct filters, until [BIP 157 client side block filtering](/using-wasabi/BIPs.md#bip-158-compact-block-filters-for-light-clients) is implemented in Bitcoin Core.
 :::
 

--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -9,7 +9,6 @@
 
 [[toc]]
 
-
 ## Types of change
 
 ### Non-CoinJoin change
@@ -55,7 +54,6 @@ Since your identity was already known in the red-shield/anonset 1 UTXO, it can n
 
 Whenever you combine and send more than one UTXO in a single transaction, the lowest anonymity set among the inputs becomes the overriding anonymity set for all of the UTXOs used in that transaction.
 
-
 ### Second round CoinJoin change
 
 When you take a 100 anonset UTXO, and you CoinJoin it again in a new 100 participant round, then you receive one UTXO with new, combined anonset of 200, and one leftover/change UTXO with same anonset as the input UTXO: 100.
@@ -78,6 +76,7 @@ You want to avoid merging `anonymity set 1` coins with `anonymity set > 1` mixed
 ## Your options to use change privately
 
 ### Avoid change in the first place.
+
 Whenever possible, choose UTXO's for transactions where the destination addresses receive the entire value of your UTXO's, and you don't get any change back.
 This can easily be done by clicking the `Max` button in the `Send` tab, which will automatically deduct the mining fee and send the highest amount possible to the destination.
 This might not be possible in some cases where you have to pay a specific value of a payment request.
@@ -87,6 +86,7 @@ Consider supporting invaluable projects like [The Tor Project](https://donate.to
 You can find a list of organizations that accept Bitcoin donations [here](https://en.bitcoin.it/wiki/Donation-accepting_organizations_and_projects).
 
 ### Spend the change with another entity, where you don't mind if each of the two know that you transact with the other entity.
+
 For example, if you buy something from Alice that costs 0.03 bitcoin, and you choose a UTXO in your wallet containing 0.1 bitcoin to use for payment.
 Alice receives her 0.03 bitcoin, and the remaining change 0.07 bitcoin is assigned to another address in your wallet.
 Since Alice knows the details of the transaction, she knows that the 0.07 bitcoin at that address belongs to you.
@@ -94,12 +94,14 @@ Since Alice knows the details of the transaction, she knows that the 0.07 bitcoi
 When you later spend these 0.07 bitcoin to an address, Alice knows that you are involved in this transaction, and she could potentially use that information against you.
 
 ### Mix with JoinMarket.
+
 In [JoinMarket](https://github.com/JoinMarket-Org/joinmarket-clientserver) as a `market taker` you can specify exactly what denomination of equal value outputs are generated in the CoinJoin.
 So you can send the Wasabi change to your JoinMarket wallet and take an offer to mix for some number of rounds.
 
 The coins you will receive after the JoinMarket tumbling algorithm will have a sufficient anonymity set, and you can use them for spending again.
 
 ### Open a Lightning Network channel.
+
 The Lightning Network can be a very private way of sending bitcoin, and you can choose the channel size to be exactly the size of your change coin.
 However, it is very important that you do not link this non-private coin to your main Lightning node public key.
 
@@ -111,6 +113,7 @@ After the balance of the channel is entirely on the other side, cooperatively cl
 Since Wasabi does not yet support Lightning Network functionality, you must use a different wallet for this task.
 
 ### Atomic swap into Lightning Network
+
 There are some services that provide an atomic swap where you send the whole change coin to a multisignature hashed time locked contract on-chain.
 In exchange, you receive a payment routed through the Lightning Network into one of your payment channels.
 
@@ -121,6 +124,7 @@ For much better privacy, use rendezvous routing so that the sender does not gain
 Also ensure that the communication with the swap server is done over the tor network.
 
 ### Consolidate several change coins, but in a CoinJoin directly.
+
 If you consolidate many change coins in a regular non-CoinJoin transaction in the `Send` tab, then any outside observer can easily see that one user controls all these coins.
 But when consolidating in a CoinJoin directly, because there are hundreds of randomly ordered inputs in a Wasabi CoinJoin transaction, it is no longer easy to find out which coins belong to one single user.
 
@@ -138,6 +142,7 @@ In this CoinJoin you get an equal value mixed coin, which is no longer tied to a
 So consolidating your change in a CoinJoin is strictly more private and efficient than consolidating in a regular sending transaction, but it is always possible to follow the path of (red) non-anonymous change outputs, while the anonymous (yellow, green or check-marked) equal denominated mixed outputs are in no way connected to the previous inputs.
 
 ### Spend the change to the same entity as in the initial transaction, but always use a new address.
+
 So, if in the first transaction you have 0.10 bitcoin and send Alice 0.04 bitcoin, you get 0.06 bitcoin back as change in a new address, which Alice can see belongs to you.
 Now, in a second transaction where you want to send Alice 0.05 bitcoin, you can select that 0.06 bitcoin change coin without losing any privacy, because Alice already knows this is your coin.
 

--- a/docs/using-wasabi/CoinJoin.md
+++ b/docs/using-wasabi/CoinJoin.md
@@ -61,7 +61,6 @@ Just leave Wasabi running in the background of your computer.
 
 6. When the CoinJoin is finished, and the CoinJoin transaction is broadcast, you will receive a fresh coin with a high anonymity set, as well as non-private change.
 
-
 ## ZeroLink protocol step-by-step
 
 ### Input registration
@@ -157,6 +156,7 @@ Wasabi saves on mining fees by setting a confirmation target of roughly 12 hours
 ## Wasabi CoinJoin examples
 
 Here's a list of Wasabi CoinJoin examples and how they appear on an explorer:
+
 - [e4a789d16a24a6643dfee06e018ad27648b896daae6a3577ae0f4eddcc4d9174](https://blockstream.info/tx/e4a789d16a24a6643dfee06e018ad27648b896daae6a3577ae0f4eddcc4d9174) | [.onion version](http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/tx/e4a789d16a24a6643dfee06e018ad27648b896daae6a3577ae0f4eddcc4d9174)
 - [c69aed505ca50473e2883130221915689c1474be3c66bcf7ac7dc0e26246afc8](https://blockstream.info/tx/c69aed505ca50473e2883130221915689c1474be3c66bcf7ac7dc0e26246afc8) | [.onion version](http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/tx/c69aed505ca50473e2883130221915689c1474be3c66bcf7ac7dc0e26246afc8)
 - [ef329b3ed8e790f10f0b522346f1b3d9f1c9d45dfa5b918e92d6f0a25d91c7ce](https://blockstream.info/tx/ef329b3ed8e790f10f0b522346f1b3d9f1c9d45dfa5b918e92d6f0a25d91c7ce) | [.onion version](http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/tx/ef329b3ed8e790f10f0b522346f1b3d9f1c9d45dfa5b918e92d6f0a25d91c7ce)

--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -15,6 +15,7 @@ It offers a high level of protection for digital assets, because keys are secure
 However, cold storage should be considered as an option for everyone who is managing digital assets.
 It can be the secure foundation for a more complex scenario that also involves hot wallets, offering the maximum security for whatever percentage of funds don't need to be actively available at all times.
 A few questions can help you determine if you can move some of your funds from hot wallets to cold storage:
+
 - How much readily available liquidity do you need?
 - How often are you moving your digital assets?
 - How often are you exchanging your digital assets?
@@ -28,6 +29,7 @@ To minimize the possibility that an intruder could steal the entire reserve in a
 The only amount kept on the server is the amount needed to cover anticipated withdrawals.
 
 Methods of cold storage include keeping bitcoins:
+
 - On a USB drive or other data storage medium in a safe place (e.g. safe deposit box, safe)
 - On a paper wallet
 - On a bearer item such as a physical bitcoin
@@ -40,7 +42,9 @@ There are a number of cases where secret/private keys and/or backup seeds can be
 ## A list of the more common mediums of cold storage with some of their weaknesses:
 
 :::details
+
 ### Written on a piece of paper
+
 - Anyone who can see it, can steal it
 - Handwriting can be hard to read or completely illegible
 - Human error in transcription can cause errors on end product
@@ -48,7 +52,9 @@ There are a number of cases where secret/private keys and/or backup seeds can be
 :::
 
 :::details
+
 ### Printed on a piece of paper
+
 - Anyone who can see it, can steal it
 - Type of printer - non-laser printers can run if paper gets wet
 - Have to trust printer - some have internet connections, wifi, and memory
@@ -56,7 +62,9 @@ There are a number of cases where secret/private keys and/or backup seeds can be
 :::
 
 :::details
+
 ### On laminated paper
+
 - Anyone who can see it, can steal it
 - Lamination is prone or degradation over time and puncture or cuts that could allow moisture to get trapped in the paper and cause deterioration or rotting in some circumstances | store in cool dry place
 - Can burn or be smoke damaged
@@ -65,7 +73,9 @@ Remember people can just carry out a small safe
 :::
 
 :::details
+
 ### Engraved / etched/ ablated/ stamped on a piece of metal
+
 - Anyone who can see it, can steal it
 - Some metals can deteriorate or corrode, choose a good metal; also store your metal away from direct contact other metals. - Some metals that are corrosion resistant have low melting points, are extremely expensive, or hard to machine.
 - Metals can still deform or melt from heat, destroying any engraved SK. "Most house fires do not burn hotter than 1,200 degrees Fahrenheit.
@@ -80,7 +90,9 @@ Titanium is above the housefire range and so is tungsten, however tungsten rings
 :::
 
 :::details
+
 ### Stored digitally on a computer
+
 - Computers can crash, making data recovery expensive
 - Data can still technically be recovered after a system is abandoned by the user. In some cases data can be recovered after multiple overwriting attempts and physical destruction (as long as the attacker can get all or most the pieces) so if you copy files to a new computer and ditch the old one, be careful.
 - Can burn or be smoke damaged
@@ -95,7 +107,9 @@ Titanium is above the housefire range and so is tungsten, however tungsten rings
 :::
 
 :::details
+
 ### Stored digitally on CD, floppy disk, laserdisc, or mini-disc
+
 - Plastics break down over time and with exposure to heat, humidity, regular light, all sorts of chemicals, even the oxygen in the air.
 This can lead to the loss of your data when stored on a medium made of plastic or written/printed on plastic.
 - Can burn or be smoke damaged
@@ -105,7 +119,9 @@ This can lead to the loss of your data when stored on a medium made of plastic o
 :::
 
 :::details
+
 ### Stored digitally on a flash drive
+
 - Can break and have to be physically repaired before use
 - Rapidly changing magnetic fields (See MRIs) can damage the data stored on flash drives
 - Can burn or be smoke damaged
@@ -118,7 +134,9 @@ There are large quality differences in drives but I am assuming you aren't using
 :::
 
 :::details
+
 ### A pre-funded physical bitcoin coin (where the manufacturer generates and installs the secret key)
+
 - The medium that the key is on is often paper/plastic which can burn or be smoke damaged
 - Trust in the manufacturer themselves, they could copy the key
 - Trust in their key generation procedure
@@ -151,7 +169,7 @@ This is fine for small amounts of bitcoin, but not for larger bitcoin holdings.
 That is where "Cold" hardware wallet storage comes in!
 So after the CoinJoin you might want to send some of those coins back to the hardware wallet, but not expose those addresses to the central servers of the hardware wallet company or some sneaky peaky Electrum Wallet spies...
 
-5. Connect your hardware wallet device (for the PSBT-protocol use a MicroSD card instead) 
+5. Connect your hardware wallet device (for the PSBT-protocol use a MicroSD card instead)
 
 6. Open another Wasabi Wallet instance, select `Hardware Wallet` to find your connected device.
 
@@ -177,7 +195,9 @@ You should put a meaningful label when you generate a receive address in your ha
 :::
 
 # Cold-Wasabi PSBT protocol
+
 When you want to safely spend some of those Cold-Wasabi funds from the hardware wallet, you could use the Partially Signed Bitcoin Transaction for offline/airgapped signing of transactions for an extra layer of defense.
 
 ## Workflow diagram
+
 ![](/ColdWasabiPSBTWorkflow.png)

--- a/docs/using-wasabi/Daemon.md
+++ b/docs/using-wasabi/Daemon.md
@@ -6,9 +6,10 @@
 ---
 
 # Headless Wasabi Daemon
+
 The default of how to interact with your Wasabi wallet is the graphical user interface.
 There is also a headless daemon where you do not run a resource intensive GUI, but only the command line interface.
-This daemon is especially useful for power users mixing bitcoin in the backend of their servers. 
+This daemon is especially useful for power users mixing bitcoin in the backend of their servers.
 
 To start the daemon, in the command line type:
 

--- a/docs/using-wasabi/Deanonimization.md
+++ b/docs/using-wasabi/Deanonimization.md
@@ -13,7 +13,6 @@ Any serious approach to anonymity in Bitcoin requires a total use of encryption 
 Over the course of just a few months, you could come into contact with hundreds of Bitcoin addresses.
 It is often only necessary to associate just one of these addresses to your real identity to de-anonymize you.
 
-
 [[toc]]
 
 ## Revealing your Bitcoin address before it goes into the blockchain could let others track you
@@ -22,11 +21,11 @@ As soon as a Bitcoin address is entered into the blockchain, it is publicly reco
 Before that happens, it's likely that only two parties (the recipient and the sender) had knowledge of this address.
 If you are making a search for an address that is not in the blockchain, either you are the owner of this address, or someone is requesting a payment from you.
 To avoid being tracked in this way, it is important to make all payment requests and other mentions of addresses via encrypted channels:
+
 - Make sure the website you are visiting has HTTPS enabled when you search for Bitcoin addresses.
 - Use VPNs and Tor when possible.
 You should check addresses with Blockstream Explorer via their [.onion v3 address](http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/).
 - Encrypt your communications with PGP (emails, files and text) and OTR (chats).
-
 
 ## Possessing a wallet file might be enough proof that you control Bitcoin
 

--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -71,8 +71,8 @@ You can ignore this, but if you want to fully verify your download, you need to 
 9. You can install Wasabi by double clicking the `.msi` and following the GUI instructions.
 
 Wasabi will be installed to your `C:\Program Files\WasabiWallet\` folder.
-You will also have an icon in your Start Menu and on your Desktop. 
-After the first run, a [data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created. 
+You will also have an icon in your Start Menu and on your Desktop.
+After the first run, a [data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
 Among others, here is where your wallet files and your logs reside.
 
 ### Manual PGP public key import
@@ -100,7 +100,6 @@ In the context menu navigate to `More GpgEx options/Import keys`.
 Press `OK` and close Kleopatra.
 
 ![](/InstallWindowsImportPGPManualKleopatra.png)
-
 
 ## Debian and Ubuntu
 

--- a/docs/using-wasabi/LurkingWifeMode.md
+++ b/docs/using-wasabi/LurkingWifeMode.md
@@ -14,9 +14,11 @@ Lurking Wife Mode is an exclusive Wasabi Wallet feature that hides sensitive and
 ![](https://i.imgur.com/4OgtaHP.png)
 
 ## How to activate Lurking Wife Mode
-You can activate LWM from Settings or by clicking on your wallet balance in the top right corner. 
+
+You can activate LWM from Settings or by clicking on your wallet balance in the top right corner.
 
 ## More information on LWM
+
 - In LWM the wallet is still usable, which means input field information isn't hidden.  
 - LWM only masks the surface. This means if you request sensitive information to be seen in LWM mode, for example like clicking on an expander, LWM won't hide the content.
 - Some justification of design decisions can be seen here: [https://github.com/zkSNACKs/WalletWasabi/issues/2234](https://github.com/zkSNACKs/WalletWasabi/issues/2234)

--- a/docs/using-wasabi/NetworkLevelPrivacy.md
+++ b/docs/using-wasabi/NetworkLevelPrivacy.md
@@ -175,6 +175,7 @@ You cannot even tie together two connections of the client, since the client con
 The only adversary that could possibly overcome this would have to setup thousands of full nodes over onion and also break Tor itself.
 
 ### Adversaries Identified
+
 - ISP
 - Tor Breaker Sybil Attacker With Thousands Of Full Nodes Over Onion
 

--- a/docs/using-wasabi/PasswordFinder.md
+++ b/docs/using-wasabi/PasswordFinder.md
@@ -12,12 +12,12 @@
 ---
 
 [Wasabi Password Finder](https://github.com/lontivero/WasabiPasswordFinder) is a tool for helping those who made a mistake typing the password during the wallet creation process.
-This tool tries to find the password that decrypts the encrypted secret key stored in a given wallet file. 
+This tool tries to find the password that decrypts the encrypted secret key stored in a given wallet file.
 
 ## Limitations
 
 Wasabi Wallet protects the encrypted secret key with the same technology used to protect paper wallets ([BIP 38](/using-wasabi/BIPs.md#bip-38-password-protected-private-key)) and for that reason it is computationally infeasible to brute force the password using all the possible combinations.
-It is important to know that Wasabi Password Finder is not for breaking wallet passwords but for finding errors (typos) in an already known password. 
+It is important to know that Wasabi Password Finder is not for breaking wallet passwords but for finding errors (typos) in an already known password.
 
 ## Usage
 
@@ -66,11 +66,9 @@ Note that for a 4 characters length password it took more than a minute to find.
 Moreover, the process is heavy in CPU and for that reason it can be a good idea to use the best combination of parameters to reduce the search space.
 
 * __language__ (default: en) specify the charset (characters to search in) to reduce the search space.
-For example, while the *Italian* charset is "abcdefghimnopqrstuvxyzABCDEFGHILMNOPQRSTUVXYZ", the *French* charset is "aâàbcçdæeéèëœfghiîïjkmnoôpqrstuùüvwxyÿzAÂÀBCÇDÆEÉÈËŒFGHIÎÏJKMNOÔPQRSTUÙÜVWXYŸZ". 
+For example, while the *Italian* charset is "abcdefghimnopqrstuvxyzABCDEFGHILMNOPQRSTUVXYZ", the *French* charset is "aâàbcçdæeéèëœfghiîïjkmnoôpqrstuùüvwxyÿzAÂÀBCÇDÆEÉÈËŒFGHIÎÏJKMNOÔPQRSTUÙÜVWXYŸZ".
 
 * __numbers__ (default: true) is for indicating that our password contains, or could contain, at least one digit. This increases the charset by 10 (from 0 to 9).
 
 * __symbols__ (default: true) is for indicating that our password contains, or could contain, at least one symbol.
 This increases the charset by 34 (|!¡@$¿?_-\"#$/%&()´+*=[]{},;:.^`<>). Note that only the most commonly used characters are available.
-
-

--- a/docs/using-wasabi/PayToEndPoint.md
+++ b/docs/using-wasabi/PayToEndPoint.md
@@ -113,7 +113,7 @@ For now, we had a practical problem to solve.
 How do we establish a connection between the sender and the recipient in a P2P way?
 
 Jessie’s idea was to extend the [BIP21 Bitcoin URI Scheme](/using-wasabi/BIPs.md#bip-21-uri-scheme) with an endpoint.
-Somehow like this: 
+Somehow like this:
 `bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?endpoint=http://3g2upl4pq6kufc4m.onion`
 
 In this case, first the sender would try to figure out if the recipient is online.
@@ -171,31 +171,36 @@ However if it the receiver participated in the transaction above, then this tran
 What does not exist, that does not exist.
 Thus if some people start using strange schemes, that affects how Blockchain analysis interprets other transactions, too.
 
-#### Side effect 1: 
+#### Side effect 1:
+
 In exchange for the privacy benefit, the sender has to pay more fees than a normal transaction.
 It is a con for the sender, but a pro for the receiver, since the receiver does not have to consolidate its coin later.
 Also it is a pro from a global point of view, due to its UTXO consolidation effects, I will detail a few lines below.
 
-#### Side effect 2: 
+#### Side effect 2:
+
 Harder to coordinate, since the receiver must be online and the payment will take a few seconds longer.
 But it is arguable, that if everyone would be able to use this scheme all the time, then that would be the new pattern, thus the new reliable Heuristics for Blockchain analysis.
 It is crucial that not everyone use this pattern all the time. Its practical limitations achieves its goal.
 
-#### Side effect 3: 
+#### Side effect 3:
+
 Receiver must have a hot wallet.
 This is problematic in a buyer to merchant payment, since merchants usually receive coins to cold wallets.
 While my above comment still applies here, notice that this notion makes our problem of UTXO spying a corner case?
 That attack only applied if “the receiver is publicly known.”
 In peer to peer, person to person payments, the attacker would have to somehow first acquire an endpoint to a receiver.
 
-#### Side effect 4: 
+#### Side effect 4:
+
 Wallets must be deencrypted.
 Since many wallets only send-time decrypt the private keys, it would need to decrypt receive-time, too.
 There are multiple ways to implement this.
 It could be implemented in address generation time, which in our case it is also an endpoint generation time.
 But if it is strictly implemented at receive time, the UTXO spying defense may not be needed at all.
 
-##### Side effect 5: 
+##### Side effect 5:
+
 It helps with UTXO bloat.
 Let us assume the above transaction is a Sender-Receiver transaction.
 Then, if the receiver would not participate, that would mostly result in a one input, two output transaction.

--- a/docs/using-wasabi/README.md
+++ b/docs/using-wasabi/README.md
@@ -14,6 +14,7 @@ Further tutorials about the different parts of the wallet, for newbies and power
 ### Chapters
 
 #### Installing Wasabi
+
 - [Install package](/using-wasabi/InstallPackage.md)
 - [Build from source code](/using-wasabi/BuildSource.md)
 - [Deterministic Build](/using-wasabi/DeterministicBuild.md)
@@ -21,6 +22,7 @@ Further tutorials about the different parts of the wallet, for newbies and power
 - [Wasabi Setup on Qubes](/using-wasabi/WasabiSetupVM.md)
 
 #### Using Wasabi
+
 - [Wallet Generation](/using-wasabi/WalletGeneration.md)
 - [Receive](/using-wasabi/Receive.md)
 - [Send](/using-wasabi/Send.md)
@@ -34,6 +36,7 @@ Further tutorials about the different parts of the wallet, for newbies and power
 - [Supported BIPs](/using-wasabi/BIPs.md)
 
 #### Privacy Best Practices
+
 - [Address Reuse](/using-wasabi/AddressReuse.md)
 - [Change Coins](/using-wasabi/ChangeCoins.md)
 - [Network Level Privacy](/using-wasabi/NetworkLevelPrivacy.md)
@@ -42,6 +45,7 @@ Further tutorials about the different parts of the wallet, for newbies and power
 - [Joinmarket](/using-wasabi/Joinmarket.md)
 
 #### Restoring Wasabi
+
 - [Wallet Recovery](/using-wasabi/WalletRecovery.md)
 - [Restoring Wasabi Wallet to Electrum](/using-wasabi/RestoreElectrum.md)
 - [Lost Password Strategy](/using-wasabi/LostPassword.md)

--- a/docs/using-wasabi/RPC.md
+++ b/docs/using-wasabi/RPC.md
@@ -172,6 +172,7 @@ curl -s --data-binary '{"jsonrpc":"2.0","id":"1","method":"listunspentcoins"}' h
 ```
 
 In case there is no wallet open it will return:
+
 ```json
 {
   "jsonrpc": "2.0",
@@ -468,6 +469,7 @@ curl -s --data-binary '{"jsonrpc":"2.0","id":"1","method":"howknows"}' http://12
 ```
 
 ### Parse error
+
 ```bash
 curl -s --data-binary '{"jsonrpc":"2.0" []}' http://127.0.0.1:37128/ | jq
 ```

--- a/docs/using-wasabi/RestoreElectrum.md
+++ b/docs/using-wasabi/RestoreElectrum.md
@@ -39,6 +39,7 @@ By typing the seed or pasting the master private key on a hot or compromised dev
 
 :::tip
 Steps to find your master private key inside Wasabi:
+
 - Go to `Advanced` tab -> `Wallet Info`.
 - Copy your `Extended Account zprv`
 :::
@@ -85,6 +86,7 @@ This will be your Electrum wallet file.
 
 :::tip
 Steps to find your master private key inside Wasabi:
+
 - Go to `Advanced` tab -> `Wallet Info`.
 - Copy your `Extended Account zprv`
 - Copy your `Extended Account zpub`

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -70,7 +70,7 @@ It is strongly recommended to use long and random passwords for everything, espe
 
 ### What not to do
 
-Here are a couple of examples that do it completely wrong. 
+Here are a couple of examples that do it completely wrong.
 You should not generate your password like this:
 
 1. Do not use publicly known information like your grandma's maiden name and the birthday of your dog.

--- a/docs/using-wasabi/WasabiSetupTails.md
+++ b/docs/using-wasabi/WasabiSetupTails.md
@@ -117,7 +117,7 @@ You can save multiple copies of `.walletwasabi` in your persistent, each with di
 
 ```sh
 /Persistent
-|__ /bitcoin-0.18.1            	   # Bitcoin Core launcher folder
+|__ /bitcoin-0.18.1                # Bitcoin Core launcher folder
 |__ /Bitcoin                       # Bitcoin Core data folder
 |__ /Wasabi                        # General Wasabi folder
     |__ /Wasabi-${currentVersion}.deb          # Wasabi installer
@@ -149,7 +149,7 @@ Remember to backup either your files or your [persistent storage](https://tails.
 
 Alternatively, you can use this [script](https://github.com/permabull/wasabi_tails_installer/blob/master/wasabi_tails_installer) made by [permabull](https://github.com/permabull), which, after downloading Wasabi by following [step 2](/using-wasabi/WasabiSetupTails.html#download), automatically installs Wasabi from the persistent folder and moves the wallet you want to open (or all of them) by user input:
 
-```
+```bash
 #!/bin/bash
 
 sudo dpkg -i Wasabi-${currentVersion}.deb
@@ -167,23 +167,22 @@ ls -1 -d */
 echo "*********************"
 
 while true
-do	
-    read -p "Enter wallet to open: " wallet_name
-    FOLDER="$wallet_name"
+do
+  read -p "Enter wallet to open: " wallet_name
+  FOLDER="$wallet_name"
 
-    if [ -d "$FOLDER" ]
-    then
-        echo "$FOLDER wallet found."
-	cd "$FOLDER"/.walletwasabi/
-	cp -r client/* ~/.walletwasabi/client
-	echo "Your files have been moved to wasabi folder"
-	break
-    else
-	echo ""$FOLDER" wallet doesn't exist"
-	continue
-fi
+  if [ -d "$FOLDER" ]
+  then
+    echo "$FOLDER wallet found."
+    cd "$FOLDER"/.walletwasabi/
+    cp -r client/* ~/.walletwasabi/client
+    echo "Your files have been moved to wasabi folder"
+    break
+  else
+    echo ""$FOLDER" wallet doesn't exist"
+    continue
+  fi
 done
 
 wassabee </dev/null &>/dev/null &
 ```
-

--- a/docs/using-wasabi/WasabiSetupVM.md
+++ b/docs/using-wasabi/WasabiSetupVM.md
@@ -52,6 +52,7 @@ You can disable .NET's telemetry, which is sending some usage information to Mic
 ```sh
 [user@template-wasabi ~]$ export DOTNET_CLI_TELEMETRY_OPTOUT=1
 ```
+
 :::
 
 If you need to update .NET Core, then do it in this VM.

--- a/docs/why-wasabi/BitcoinPrivacy.md
+++ b/docs/why-wasabi/BitcoinPrivacy.md
@@ -32,7 +32,7 @@ Two aspects in particular—privacy and identity—function very differently wit
 
 _**Pseudonyms protect your identity in Bitcoin**_
 
-A bank account, PayPal account, or credit card is always tied to a real identity, making it difficult for many people to open them. 
+A bank account, PayPal account, or credit card is always tied to a real identity, making it difficult for many people to open them.
 Bitcoin allows you to use any persona or online identity you wish.
 
 Being able to use the internet anonymously or pseudonymously is the only way for many people to truly be themselves.
@@ -40,7 +40,7 @@ Hundreds of millions of people around the globe are not accepted in their societ
 
 Pseudonyms are used by women speaking up for their rights, atheists living in religious societies, and people critical of their governments to spread their thoughts, empower their causes, and encourage those around them to do the same.
 
-These courageous men and women put their own safety and well-being at risk to defend who they are and what they believe in. 
+These courageous men and women put their own safety and well-being at risk to defend who they are and what they believe in.
 Technology empowers them to become leaders of social change in societies by providing this very pseudonymity.
 Technology also connects like-minded individuals so they can form the communities for which they strive.
 
@@ -106,7 +106,7 @@ _**Easy wallet clustering**_
 A Bitcoin address commits to the spending condition of this UTXO.
 For example in Wasabi, each address is a [native SegWit pay to witness public key hash P2WPKH](https://programmingblockchain.gitbook.io/programmingblockchain/other_types_of_ownership/p2wpkh_pay_to_witness_public_key_hash), meaning that this coin can only be spend with a single valid signature of the corresponding private key.
 When the same address is used for several UTXOs, then this means that the same private key can spend all these coins.
-It is very easy to find all the UTXOs with the same address, and thus to find out how many bitcoin this private key holds. 
+It is very easy to find all the UTXOs with the same address, and thus to find out how many bitcoin this private key holds.
 
 Further, when in a transaction one output has a reused address, then it is very likely that this output is the payment destination, and not the change.
 Most wallets automatically generate new change addresses for every transaction, but payment addresses are selected manually by the user.
@@ -119,8 +119,7 @@ _**Remove used address from GUI**_
 
 Wasabi uses the industry best practice [BIP 44 hierarchical deterministic wallet](/using-wasabi/BIPs.md#bip-44-multi-account-hierarchy-for-deterministic-wallets), where out of one master secret a tree structure of child private keys are generated.
 It is deterministic because the same parent secret always calculates the same child private keys. When given a hardened child private key, then the parent private key cannot be calculated.
-In the `Receive` tab, a new address is generated every time, and as soon as a coin is sent to it, this specific address is removed from the GUI. 
-
+In the `Receive` tab, a new address is generated every time, and as soon as a coin is sent to it, this specific address is removed from the GUI.
 
 ## Inputs and outputs
 
@@ -149,7 +148,6 @@ Contrarily to many other wallets, Wasabi does not show only the total value of b
 Because it is required to label every receiving address, the history of this coin is clear at first glance.
 In order to spend a specific coin, it is manually selected, which prevents the wrong coin being included in the transaction.
 
-
 ## Transaction graph
 
 ### Problem
@@ -173,7 +171,6 @@ However, the equal value CoinJoin outputs with an anonymity set can not be tied 
 This means that when sending an anonset coin, the receiver does not know about the transaction history before the CoinJoin.
 And when the receiver does a CoinJoin himself, then the sender cannot spy on the later spending patterns.
 An outside observer can only guess the correct link at a rate of 1 in the anonset, for example 1-in-100, or 1%.
-
 
 ## Network snooping
 

--- a/docs/why-wasabi/TransactionSurveillanceCompanies.md
+++ b/docs/why-wasabi/TransactionSurveillanceCompanies.md
@@ -5,7 +5,7 @@
 }
 ---
 
-#  Transaction Surveillance Companies
+# Transaction Surveillance Companies
 
 [[toc]]
 
@@ -18,20 +18,24 @@ Their business model is usually to sell the data to any governments, corporation
 There are a number of techniques probably used by transaction surveillance companies:
 
 ### AML/KYC information
+
 Many bitcoin exchanges require users to undergo Anti-Money Laundering (AML) Know-Your-Customer (KYC) checks, which requires users to reveal all kinds of invasive personal information such as their real name, residence, occupation, net worth and income.
 All this information is usually passed onto the exchange's partner transaction surveillance company, which keeps a database linking the victim's personal information with their bitcoin addresses and transactions.
 
 ### Blockchain analysis
+
 Bitcoin on-chain transactions are visible to all and so can be analyzed.
 Important techniques are the common-input-ownership heuristic and address reuse.
 
 ### Wallet synchronization analysis
+
 Bitcoin lightweight wallets often download their own history and balance by querying a third-party server.
 Transaction surveillance companies often try to exploit this to learn which addresses and transactions belong to certain wallets.
 The companies have been known to collect [BIP 37](/using-wasabi/BIPs.md#bip-37-connection-bloom-filtering) filters from BIP37-enabled wallets.
 They almost-certainly also run many Electrum servers which can spy on any Electrum wallet that connects to them.
 
 ### Transaction broadcasting
+
 Surveillance companies have been known to sybil attack the bitcoin network in order to try to find the source IP addresses of unconfirmed transactions.
 
 ## Criticisms

--- a/docs/why-wasabi/WhyPrivacyImportant.md
+++ b/docs/why-wasabi/WhyPrivacyImportant.md
@@ -34,7 +34,6 @@ I say, "Here's my email address.
 What I want you to do when you get home is email me the passwords to all of your email accounts, not just the nice, respectable work one in your name, but all of them, because I want to be able to just troll through what it is you're doing online, read what I want to read and publish whatever I find interesting.
 After all, if you're not a bad person, if you're doing nothing wrong, you should have nothing to hide."
 Not a single person has taken me up on that offer. - Glenn Greenwald in [Why privacy matters - TED Talk](https://www.ted.com/talks/glenn_greenwald_why_privacy_matters)
-
 > The primary reason for window curtains in our house, is to stop people from being able to see in.
 The reason we don’t want them to see in is because we consider much of what we do inside our homes to be private.
 Whether that be having dinner at the table, watching a movie with your kids, or even engaging in intimate or sexual acts with your partner.
@@ -42,13 +41,14 @@ None of these things are illegal by any means but even knowing this, we still ke
 We clearly have this strong desire for privacy when it comes to our personal life and the public. - Joshua in [The Crypto Paper](https://github.com/cryptoseb/CryptoPaper#let-me-explain-further)
 
 # Read also:
+
 - [Nothing to hide argument (Wikipedia)](https://en.wikipedia.org/wiki/Nothing_to_hide_argument)
 - [How do you counter the "I have nothing to hide?" argument? (reddit.com)](https://www.reddit.com/r/privacy/comments/3hynvp/how_do_you_counter_the_i_have_nothing_to_hide/)
 - ['I've Got Nothing to Hide' and Other Misunderstandings of Privacy (Daniel J. Solove - San Diego Law Review)](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=998565)
 
 # Quotes
-> Arguing that you don't care about the right to privacy because you have nothing to hide is no different than saying you don't care about free speech because you have nothing to say. - Edward Snowden on [Reddit](https://www.reddit.com/r/IAmA/comments/36ru89/just_days_left_to_kill_mass_surveillance_under/crglgh2)
 
+> Arguing that you don't care about the right to privacy because you have nothing to hide is no different than saying you don't care about free speech because you have nothing to say. - Edward Snowden on [Reddit](https://www.reddit.com/r/IAmA/comments/36ru89/just_days_left_to_kill_mass_surveillance_under/crglgh2)
 > The NSA has built an infrastructure that allows it to intercept almost everything.
 With this capability, the vast majority of human communications are automatically ingested without targeting.
 If I wanted to see your emails or your wife's phone, all I have to do is use intercepts.
@@ -56,7 +56,6 @@ I can get your emails, passwords, phone records, credit cards.
 I don't want to live in a society that does these sort of things...
 I do not want to live in a world where everything I do and say is recorded.
 That is not something I am willing to support or live under. - Edward Snowden in [The Guardian](https://www.theguardian.com/world/2013/jun/09/nsa-whistleblower-edward-snowden-why)
-
 > We all need places where we can go to explore without the judgmental eyes of other people being cast upon us, only in a realm where we're not being watched can we really test the limits of who we want to be.
 It's really in the private realm where dissent, creativity and personal exploration lie. - Glenn Greenwald in [Huffington Post](https://www.huffingtonpost.com/2014/06/20/glenn-greenwald-privacy_n_5509704.html)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3090,6 +3090,12 @@
         "regexp.prototype.flags": "^1.2.0"
       }
     },
+    "deep-extend": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+      "dev": true
+    },
     "deepmerge": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
@@ -4738,6 +4744,12 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+      "dev": true
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -4860,6 +4872,12 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "gray-matter": {
@@ -5320,6 +5338,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
     "internal-ip": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -5739,6 +5763,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonc-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.0.tgz",
+      "integrity": "sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -5866,6 +5896,18 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.differencewith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
+      "integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
     },
     "lodash.kebabcase": {
@@ -6033,6 +6075,80 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz",
       "integrity": "sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw==",
+      "dev": true
+    },
+    "markdownlint": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.18.0.tgz",
+      "integrity": "sha512-nQAfK9Pbq0ZRoMC/abNGterEnV3kL8MZmi0WHhw8WJKoIbsm3cXGufGsxzCRvjW15cxe74KWcxRSKqwplS26Bw==",
+      "dev": true,
+      "requires": {
+        "markdown-it": "10.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+          "dev": true
+        },
+        "markdown-it": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+          "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "entities": "~2.0.0",
+            "linkify-it": "^2.0.0",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        }
+      }
+    },
+    "markdownlint-cli": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.21.0.tgz",
+      "integrity": "sha512-gvnczz3W3Wgex851/cIQ/2y8GNhY+EVK8Ael8kRd8hoSQ0ps9xjhtwPwMyJPoiYbAoPxG6vSBFISiysaAbCEZg==",
+      "dev": true,
+      "requires": {
+        "commander": "~2.9.0",
+        "deep-extend": "~0.5.1",
+        "get-stdin": "~5.0.1",
+        "glob": "~7.1.2",
+        "ignore": "~5.1.4",
+        "js-yaml": "~3.13.1",
+        "jsonc-parser": "~2.2.0",
+        "lodash.differencewith": "~4.5.0",
+        "lodash.flatten": "~4.4.0",
+        "markdownlint": "~0.18.0",
+        "markdownlint-rule-helpers": "~0.6.0",
+        "minimatch": "~3.0.4",
+        "rc": "~1.2.7"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        }
+      }
+    },
+    "markdownlint-rule-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.6.0.tgz",
+      "integrity": "sha512-LiZVAbg9/cqkBHtLNNqHV3xuy4Y2L/KuGU6+ZXqCT9NnCdEkIoxeI5/96t+ExquBY0iHy2CVWxPH16nG1RKQVQ==",
       "dev": true
     },
     "md5.js": {
@@ -7896,6 +8012,26 @@
         }
       }
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "deep-extend": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+          "dev": true
+        }
+      }
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -9014,6 +9150,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "strip-outer": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prestart": "rm -rf $npm_package_config_dist",
     "start": "vuepress dev docs",
     "build": "vuepress build docs",
+    "lint": "markdownlint README.md docs/**/*.md",
     "deploy": "echo 'docs.wasabiwallet.io' > $npm_package_config_dist/CNAME && gh-pages -d $npm_package_config_dist -m 'deploy'"
   },
   "repository": {
@@ -24,6 +25,7 @@
     "@vuepress/plugin-back-to-top": "1.2.0",
     "gh-pages": "2.2.0",
     "markdown-it-custom-block": "0.1.1",
+    "markdownlint-cli": "^0.21.0",
     "vuepress": "1.2.0"
   },
   "engines": {


### PR DESCRIPTION
This is a work in progress state to discuss an approach to close #523.
The basic idea is to do style checking via [markdownlint](https://github.com/DavidAnson/markdownlint), which can be configured to match the conventions we'd like to establish.

To check it out, clone the branch and run the following commands:

```bash
npm install
npm run lint  # shows you what should be improved 
npm run lint -- --fix # automatically fixes some issues
```

The configuration is done in `.markdownlint.json` – [available options](https://github.com/DavidAnson/markdownlint/blob/master/schema/markdownlint-config-schema.json).

Opening it up for feedback on whether or not this might be helpful.