### PR TITLE
[DECLUTTER WHY] Rework Privacy in Bitcoin

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -125,15 +125,27 @@ module.exports = {
         link: "/glossary/"
       }
     ],
+
     sidebar: {
       "/why-wasabi/": [
         {
-          title: "Why Wasabi",
+          title: "Why Privacy",
           collapsable: false,
           sidebarDepth: 2,
           children: [
             "/why-wasabi/WhyPrivacyImportant.md",
-            "/why-wasabi/BitcoinPrivacy.md",
+            "/why-wasabi/WhyFinancialPrivacy.md"
+          ]
+        },
+
+        {
+          title: "Privacy in Bitcoin",
+          collapsable: false,
+          sidebarDepth: 2,
+          children: [
+            "/why-wasabi/AddressReuse.md",
+            "/why-wasabi/Coins.md",
+            "/why-wasabi/TransactionGraph.md",
             "/why-wasabi/NetworkLevelPrivacy.md",
             "/why-wasabi/TransactionSurveillanceCompanies.md"
           ]

--- a/docs/FAQ/FAQ-GeneralBitcoinPrivacy.md
+++ b/docs/FAQ/FAQ-GeneralBitcoinPrivacy.md
@@ -101,7 +101,7 @@ They can see two transactions on your account: one for 0.4 bitcoin and one for 0
 They cannot see which was the purchase and which is the “change,” but it’s a 50% guess.
 The next time you make a transaction, it’s a 25% guess and so on.
 
-This is why making lots of transactions increases your anonymity in the Bitcoin network (as long as you [don't reuse addresses](/why-wasabi/BitcoinPrivacy.md#address-reuse)!).
+This is why making lots of transactions increases your anonymity in the Bitcoin network (as long as you [don't reuse addresses](/why-wasabi/AddressReuse.md)!).
 
 Similarly, if you receive 0.5 bitcoin but want to spend 1 bitcoin, you need to own additional Bitcoin addresses with a combined value of at least 0.5 bitcoin in them.
 Again it’s a 50% guess, but now you have one extra publicly visible Bitcoin address.

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -352,7 +352,7 @@ or:
 You can change the label of your receive address in the right click menu by clicking `Change Label`, then type in the new label.
 This is useful for when you have generated a receiving address with a specific label, but then the cause for receiving is no longer present.
 Take care with whom you have shared this address, because if you send it to several people, they might all send many coins to the same address.
-This is very bad for your privacy because of [address reuse](/why-wasabi/BitcoinPrivacy.md#address-reuse), and it confuses you with the labeling of each unique coin.
+This is very bad for your privacy because of [address reuse](/why-wasabi/AddressReuse.md), and it confuses you with the labeling of each unique coin.
 
 ![](/ReceiveAddressDropDownMenu.png)
 :::

--- a/docs/glossary/Glossary-PrivacyWasabi.md
+++ b/docs/glossary/Glossary-PrivacyWasabi.md
@@ -11,7 +11,7 @@
 ### Address Reuse
 
 Address reuse refers to the use of the same address for multiple transactions, this is very bad for privacy.
-Read more: [Address reuse](/why-wasabi/BitcoinPrivacy.md#address-reuse)
+Read more: [Address reuse](/why-wasabi/AddressReuse.md)
 :::
 
 :::details

--- a/docs/using-wasabi/Receive.md
+++ b/docs/using-wasabi/Receive.md
@@ -40,7 +40,7 @@ Wasabi Wallet does not "store your money", rather it stores your public keys and
 
 Whenever you use the same address to lock up different UTXOs, then all these coins can be spent by anyone who knows the private key.
 This makes it obvious for anyone that this one entity [you] owns all these coins, which is very bad for privacy.
-The first rule of Bitcoin privacy is [never reuse addresses](/why-wasabi/BitcoinPrivacy.md#address-reuse)!
+The first rule of Bitcoin privacy is [never reuse addresses](/why-wasabi/AddressReuse.md)!
 
 :::tip
 This is why Wasabi removes the address from the `Receive` tab as soon as it has received a coin.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -54,7 +54,7 @@ By default they have an anonymity set of `2`, `21` and `50`, however, this can b
 When sending bitcoin, you need to know the destination address of the receiver.
 This commits to the spending condition that the receiver agrees to have for this coin.
 The address can be a public key hash [starting with 1...], a script hash [starting with 3...], or a native segwit bech32 public key hash [starting with bc1q...].
-Make sure that you ask the receiver for a [new address](/why-wasabi/BitcoinPrivacy.md#address-reuse) for every payment to protect your privacy and theirs.
+Make sure that you ask the receiver for a [new address](/why-wasabi/AddressReuse.md) for every payment to protect your privacy and theirs.
 Wasabi will calculate the checksum and notify you if the provided address is wrong.
 
 ## Label

--- a/docs/why-wasabi/AddressReuse.md
+++ b/docs/why-wasabi/AddressReuse.md
@@ -21,8 +21,6 @@ The second rule of Bitcoin privacy:
 
 #### Easy wallet clustering
 
-A Bitcoin address commits to the spending condition of this UTXO.
-For example, in Wasabi each address is a [native SegWit pay to witness public key hash P2WPKH](https://programmingblockchain.gitbook.io/programmingblockchain/other_types_of_ownership/p2wpkh_pay_to_witness_public_key_hash), meaning that this coin can only be spent with a single valid signature of the corresponding private key.
 If the an address is used more than once, it means that the same private key can spend all its coins.
 It is very easy to find all the UTXOs of an address, and thus to find out how many bitcoin the private key holds.
 
@@ -35,7 +33,7 @@ There are different types of address reuse:
 
 ### Publicly advertised addresses (donations)
 
-Here, one person sends one address to a public forum, like in the bio of a social media network or on a website, and anyone can send bitcoin to this address.
+Here, a person publishes a single address to a public forum, like in the bio of a social media network or on a website, and anyone can send bitcoin to this address.
 
 ### Dusting
 
@@ -45,7 +43,7 @@ The attacker hopes that this dust coin is consolidated with another coin, thus l
 ### Intentionally malicious
 
 Since Wasabi is libre and open source, anyone can modify a fork of Wasabi to make sure the same two addresses are recycled in every CoinJoin registration.
-This is someone intentionally deanonymizing himself, such a behavior might have quite dubious motives.
+This is someone intentionally deanonymizing himself, and he might have quite dubious motives.
 
 ## Wasabi's Solution
 
@@ -53,6 +51,7 @@ This is someone intentionally deanonymizing himself, such a behavior might have 
 
 Wasabi uses the industry best practice [BIP 44 hierarchical deterministic wallet](/using-wasabi/BIPs.md#bip-44-multi-account-hierarchy-for-deterministic-wallets) where, from one master secret, a tree structure of child private keys are generated.
 It is deterministic because the same parent secret always calculates the same child private keys.
+BIP 44 HD wallets use an alternative key derivation function called "hardened derivation", which alters the relationship between parent keys and child keys in a way that increases security significantly.
 When given a hardened child private key, then the parent private key cannot be calculated.
 In the `Receive` tab, a new address is generated every time, and as soon as a coin is sent to it, this specific address is removed from the GUI.
 

--- a/docs/why-wasabi/AddressReuse.md
+++ b/docs/why-wasabi/AddressReuse.md
@@ -22,11 +22,11 @@ The second rule of Bitcoin privacy:
 _**Easy wallet clustering**_
 
 A Bitcoin address commits to the spending condition of this UTXO.
-For example in Wasabi, each address is a [native SegWit pay to witness public key hash P2WPKH](https://programmingblockchain.gitbook.io/programmingblockchain/other_types_of_ownership/p2wpkh_pay_to_witness_public_key_hash), meaning that this coin can only be spent with a single valid signature of the corresponding private key.
-When the same address is used for several UTXOs, then this means that the same private key can spend all these coins.
+For example, in Wasabi each address is a [native SegWit pay to witness public key hash P2WPKH](https://programmingblockchain.gitbook.io/programmingblockchain/other_types_of_ownership/p2wpkh_pay_to_witness_public_key_hash), meaning that this coin can only be spent with a single valid signature of the corresponding private key.
+If the same address is used for several UTXOs, it means that the same private key can spend all these coins.
 It is very easy to find all the UTXOs with the same address, and thus to find out how many bitcoin this private key holds. 
 
-Further, when in a transaction one output has a reused address, then it is very likely that this output is the payment destination, and not the change.
+Further, in a transaction in which one output has a reused address, then it is very likely that this output is the payment destination, and not the change.
 Most wallets automatically generate new change addresses for every transaction, but payment addresses are selected manually by the user.
 
 Read more about the privacy concerns of address reuse in the [separate entry](https://en.bitcoin.it/wiki/Address_reuse) and the [privacy chapter](https://en.bitcoin.it/Privacy#Address_reuse) of the Bitcoin wiki.
@@ -35,12 +35,12 @@ There are different types of address reuse.
 
 ### Publicly advertised addresses (donations)
 
-Here one person sends one address to a public forum, like in the bio of a social media network or on a website, and anyone can send bitcoin to this address.
+Here, one person sends one address to a public forum, like in the bio of a social media network or on a website, and anyone can send bitcoin to this address.
 
 ### Dusting
 
 With a [forced address reuse attack](https://en.bitcoin.it/Privacy#Forced_address_reuse), an attacker sends a small amount of bitcoin to an already existing address of an old coin.
-The hope is that this dust coin is consolidated with another coin, thus linking the two in a cluster.
+The attacker hopes that this dust coin is consolidated with another coin, thus linking the two in a cluster.
 
 ### Intentionally malicious
 
@@ -51,10 +51,9 @@ This is someone intentionally deanonymizing himself, such a behavior might have 
 
 _**Remove used address from GUI**_
 
-Wasabi uses the industry best practice [BIP 44 hierarchical deterministic wallet](/using-wasabi/BIPs.md#bip-44-multi-account-hierarchy-for-deterministic-wallets), where out of one master secret a tree structure of child private keys are generated.
+Wasabi uses the industry best practice [BIP 44 hierarchical deterministic wallet](/using-wasabi/BIPs.md#bip-44-multi-account-hierarchy-for-deterministic-wallets) where, from one master secret, a tree structure of child private keys are generated.
 It is deterministic because the same parent secret always calculates the same child private keys. When given a hardened child private key, then the parent private key cannot be calculated.
 In the `Receive` tab, a new address is generated every time, and as soon as a coin is sent to it, this specific address is removed from the GUI. 
 
 To protect against forced address reuse attack (Dusting), Wasabi has a modifiable dust limit, where the wallet does not show coins below a certain threshold value.
-
 

--- a/docs/why-wasabi/AddressReuse.md
+++ b/docs/why-wasabi/AddressReuse.md
@@ -19,19 +19,19 @@ The second rule of Bitcoin privacy:
 
 ## Problem
 
-_**Easy wallet clustering**_
+#### Easy wallet clustering
 
 A Bitcoin address commits to the spending condition of this UTXO.
 For example, in Wasabi each address is a [native SegWit pay to witness public key hash P2WPKH](https://programmingblockchain.gitbook.io/programmingblockchain/other_types_of_ownership/p2wpkh_pay_to_witness_public_key_hash), meaning that this coin can only be spent with a single valid signature of the corresponding private key.
-If the same address is used for several UTXOs, it means that the same private key can spend all these coins.
-It is very easy to find all the UTXOs with the same address, and thus to find out how many bitcoin this private key holds. 
+If the an address is used more than once, it means that the same private key can spend all its coins.
+It is very easy to find all the UTXOs of an address, and thus to find out how many bitcoin the private key holds.
 
-Further, in a transaction in which one output has a reused address, then it is very likely that this output is the payment destination, and not the change.
+Further, in a transaction where one output has a reused address, then it is very likely that this output is the payment destination, and not the change.
 Most wallets automatically generate new change addresses for every transaction, but payment addresses are selected manually by the user.
 
 Read more about the privacy concerns of address reuse in the [separate entry](https://en.bitcoin.it/wiki/Address_reuse) and the [privacy chapter](https://en.bitcoin.it/Privacy#Address_reuse) of the Bitcoin wiki.
 
-There are different types of address reuse.
+There are different types of address reuse:
 
 ### Publicly advertised addresses (donations)
 
@@ -39,7 +39,7 @@ Here, one person sends one address to a public forum, like in the bio of a socia
 
 ### Dusting
 
-With a [forced address reuse attack](https://en.bitcoin.it/Privacy#Forced_address_reuse), an attacker sends a small amount of bitcoin to an already existing address of an old coin.
+With a [forced address reuse attack](https://en.bitcoin.it/Privacy#Forced_address_reuse), an attacker sends a small amount of bitcoin to an already existing address.
 The attacker hopes that this dust coin is consolidated with another coin, thus linking the two in a cluster.
 
 ### Intentionally malicious
@@ -49,11 +49,11 @@ This is someone intentionally deanonymizing himself, such a behavior might have 
 
 ## Wasabi's Solution
 
-_**Remove used address from GUI**_
+#### Remove used address from GUI
 
 Wasabi uses the industry best practice [BIP 44 hierarchical deterministic wallet](/using-wasabi/BIPs.md#bip-44-multi-account-hierarchy-for-deterministic-wallets) where, from one master secret, a tree structure of child private keys are generated.
-It is deterministic because the same parent secret always calculates the same child private keys. When given a hardened child private key, then the parent private key cannot be calculated.
-In the `Receive` tab, a new address is generated every time, and as soon as a coin is sent to it, this specific address is removed from the GUI. 
+It is deterministic because the same parent secret always calculates the same child private keys.
+When given a hardened child private key, then the parent private key cannot be calculated.
+In the `Receive` tab, a new address is generated every time, and as soon as a coin is sent to it, this specific address is removed from the GUI.
 
 To protect against forced address reuse attack (Dusting), Wasabi has a modifiable dust limit, where the wallet does not show coins below a certain threshold value.
-

--- a/docs/why-wasabi/AddressReuse.md
+++ b/docs/why-wasabi/AddressReuse.md
@@ -1,0 +1,60 @@
+---
+{
+  "title": "Address Reuse",
+  "description": "On the nuances of address reuse, why it is bad and how to fix it. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+}
+---
+
+# Address Reuse
+
+[[toc]]
+
+The first rule of Bitcoin privacy:
+
+> Never reuse addresses!
+
+The second rule of Bitcoin privacy:
+
+> NEVER reuse addresses!!
+
+## Problem
+
+_**Easy wallet clustering**_
+
+A Bitcoin address commits to the spending condition of this UTXO.
+For example in Wasabi, each address is a [native SegWit pay to witness public key hash P2WPKH](https://programmingblockchain.gitbook.io/programmingblockchain/other_types_of_ownership/p2wpkh_pay_to_witness_public_key_hash), meaning that this coin can only be spent with a single valid signature of the corresponding private key.
+When the same address is used for several UTXOs, then this means that the same private key can spend all these coins.
+It is very easy to find all the UTXOs with the same address, and thus to find out how many bitcoin this private key holds. 
+
+Further, when in a transaction one output has a reused address, then it is very likely that this output is the payment destination, and not the change.
+Most wallets automatically generate new change addresses for every transaction, but payment addresses are selected manually by the user.
+
+Read more about the privacy concerns of address reuse in the [separate entry](https://en.bitcoin.it/wiki/Address_reuse) and the [privacy chapter](https://en.bitcoin.it/Privacy#Address_reuse) of the Bitcoin wiki.
+
+There are different types of address reuse.
+
+### Publicly advertised addresses (donations)
+
+Here one person sends one address to a public forum, like in the bio of a social media network or on a website, and anyone can send bitcoin to this address.
+
+### Dusting
+
+With a [forced address reuse attack](https://en.bitcoin.it/Privacy#Forced_address_reuse), an attacker sends a small amount of bitcoin to an already existing address of an old coin.
+The hope is that this dust coin is consolidated with another coin, thus linking the two in a cluster.
+
+### Intentionally malicious
+
+Since Wasabi is libre and open source, anyone can modify a fork of Wasabi to make sure the same two addresses are recycled in every CoinJoin registration.
+This is someone intentionally deanonymizing himself, such a behavior might have quite dubious motives.
+
+## Wasabi's Solution
+
+_**Remove used address from GUI**_
+
+Wasabi uses the industry best practice [BIP 44 hierarchical deterministic wallet](/using-wasabi/BIPs.md#bip-44-multi-account-hierarchy-for-deterministic-wallets), where out of one master secret a tree structure of child private keys are generated.
+It is deterministic because the same parent secret always calculates the same child private keys. When given a hardened child private key, then the parent private key cannot be calculated.
+In the `Receive` tab, a new address is generated every time, and as soon as a coin is sent to it, this specific address is removed from the GUI. 
+
+To protect against forced address reuse attack (Dusting), Wasabi has a modifiable dust limit, where the wallet does not show coins below a certain threshold value.
+
+

--- a/docs/why-wasabi/AddressReuse.md
+++ b/docs/why-wasabi/AddressReuse.md
@@ -53,6 +53,6 @@ Wasabi uses the industry best practice [BIP 44 hierarchical deterministic wallet
 It is deterministic because the same parent secret always calculates the same child private keys.
 BIP 44 HD wallets use an alternative key derivation function called "hardened derivation", which alters the relationship between parent keys and child keys in a way that increases security significantly.
 When given a hardened child private key, then the parent private key cannot be calculated.
-In the `Receive` tab, a new address is generated every time, and as soon as a coin is sent to it, this specific address is removed from the GUI.
+An address gets removed from the GUI in the `Receive` tab as soon as a coin is received to it.
 
 To protect against forced address reuse attack (Dusting), Wasabi has a modifiable dust limit, where the wallet does not show coins below a certain threshold value.

--- a/docs/why-wasabi/Coins.md
+++ b/docs/why-wasabi/Coins.md
@@ -16,19 +16,19 @@ Each UTXO is the tip of the chain of links between inputs and outputs, all the w
 
 _**UTXOs are not fungible**_
 
-Each UTXO is a unique snow flake with a public transaction history.
+Each UTXO is a unique snowflake with a public transaction history.
 For example, when Alice sends a coin to Bob, then Bob does not just have any random UTXO, but he has specifically the coin that Alice has sent him.
 When Bob sends this coin to Charlie, than Charlie can look back two hops to see the transaction from Alice to Bob.
 If Bob does not want Charlie to know that the transaction between Alice and Bob happened, then Bob needs to send Charlie a different coin.
 
-Further, when Alice has one non-private coin and one private coin, and she selects both of them as the input of one transaction, then it might be clear that the previously private coin also belongs to Alice.
+Further, when Alice has one non-private coin and one private coin, and she selects both of them as the input of one transaction, the linking of these two coins strongly suggests that the coin that was private also belongs to Alice.
 This means that coin consolidation can lead to an overall decrease of privacy, especially when using an automatic coin selection algorithm.
 
 ## Wasabi's Solution
 
 _**Manual coin labeling and selection**_
 
-Contrarily to many other wallets, Wasabi does not show only the total value of bitcoins in the wallet. Rather, in the `Send` and `CoinJoin` tab is a list of all the UTXOs individually.
-Because it is required to label every receiving address, the history of this coin is clear at first glance.
-In order to spend a specific coin, it is manually selected, which prevents the wrong coin being included in the transaction.
-
+Contrary to many other wallets, Wasabi does not show only the total value of bitcoins in the wallet. 
+Rather, in both the `Send` and `CoinJoin` tabs there is a list of all the individual UTXOs.
+Because Wasabi requires users to label every receiving address, the history of each coin is clear at first glance.
+In order to spend a specific coin, it must be manually selected, which prevents the wrong coin from being included in the transaction.

--- a/docs/why-wasabi/Coins.md
+++ b/docs/why-wasabi/Coins.md
@@ -18,7 +18,7 @@ Each UTXO is the tip of the chain of links between inputs and outputs, all the w
 
 Each UTXO is a unique snowflake with a public transaction history.
 For example, when Alice sends a coin to Bob, then Bob does not just have any random UTXO, but he has specifically the coin that Alice has sent him.
-When Bob sends this coin to Charlie, then Charlie can look back two hops to see the transaction from Alice to Bob.
+When Bob sends this coin to Charlie, then Charlie can check the history of the coin and see the transaction from Alice to Bob.
 
 Further, when Alice has one non-private coin and one private coin, and she selects both of them as the inputs of a transaction, the linking of these two coins strongly suggests that the coin that was private also belongs to Alice.
 This means that coin consolidation can lead to an overall decrease of privacy, especially when using an automatic coin selection algorithm.
@@ -27,7 +27,7 @@ This means that coin consolidation can lead to an overall decrease of privacy, e
 
 #### Manual coin labeling and selection
 
-Contrary to many other wallets, Wasabi does not show only the total value of bitcoins in the wallet.
+Contrary to many other wallets, Wasabi does not show only the total value of bitcoin in the wallet.
 Rather, in both the `Send` and `CoinJoin` tabs there is a list of all the individual UTXOs.
 Because Wasabi requires users to label every receiving address, the history of each coin is clear at first glance.
 In order to spend a specific coin, it must be manually selected, which prevents the wrong coin from being included in the transaction.

--- a/docs/why-wasabi/Coins.md
+++ b/docs/why-wasabi/Coins.md
@@ -7,28 +7,27 @@
 
 # Coins
 
-Bitcoin has an accounting model of [unspent transaction outputs [UTXO]](https://bitcoin.org/en/blockchain-guide#introduction).
+Bitcoin has an accounting model of [unspent transaction output [UTXO]](https://bitcoin.org/en/blockchain-guide#introduction).
 A transaction has inputs: the coins that are spent, and outputs: the coins that are received.
-The input of one transaction has to be an output of a previous transaction that is not yet spent.
+The input of a transaction has to be an unspent output of a previous transaction.
 Each UTXO is the tip of the chain of links between inputs and outputs, all the way back to a [coinbase transaction](https://en.bitcoin.it/wiki/Coinbase) that pays the miner.
 
 ## Problem
 
-_**UTXOs are not fungible**_
+#### UTXOs are not fungible
 
 Each UTXO is a unique snowflake with a public transaction history.
 For example, when Alice sends a coin to Bob, then Bob does not just have any random UTXO, but he has specifically the coin that Alice has sent him.
-When Bob sends this coin to Charlie, than Charlie can look back two hops to see the transaction from Alice to Bob.
-If Bob does not want Charlie to know that the transaction between Alice and Bob happened, then Bob needs to send Charlie a different coin.
+When Bob sends this coin to Charlie, then Charlie can look back two hops to see the transaction from Alice to Bob.
 
-Further, when Alice has one non-private coin and one private coin, and she selects both of them as the input of one transaction, the linking of these two coins strongly suggests that the coin that was private also belongs to Alice.
+Further, when Alice has one non-private coin and one private coin, and she selects both of them as the inputs of a transaction, the linking of these two coins strongly suggests that the coin that was private also belongs to Alice.
 This means that coin consolidation can lead to an overall decrease of privacy, especially when using an automatic coin selection algorithm.
 
 ## Wasabi's Solution
 
-_**Manual coin labeling and selection**_
+#### Manual coin labeling and selection
 
-Contrary to many other wallets, Wasabi does not show only the total value of bitcoins in the wallet. 
+Contrary to many other wallets, Wasabi does not show only the total value of bitcoins in the wallet.
 Rather, in both the `Send` and `CoinJoin` tabs there is a list of all the individual UTXOs.
 Because Wasabi requires users to label every receiving address, the history of each coin is clear at first glance.
 In order to spend a specific coin, it must be manually selected, which prevents the wrong coin from being included in the transaction.

--- a/docs/why-wasabi/Coins.md
+++ b/docs/why-wasabi/Coins.md
@@ -19,6 +19,7 @@ Each UTXO is the tip of the chain of links between inputs and outputs, all the w
 Each UTXO is a unique snowflake with a public transaction history.
 For example, when Alice sends a coin to Bob, then Bob does not just have any random UTXO, but he has specifically the coin that Alice has sent him.
 When Bob sends this coin to Charlie, then Charlie can check the history of the coin and see the transaction from Alice to Bob.
+But due to the pseudonymity of Bitcoin, he does not necessarily find out that Alice is involved.
 
 Further, when Alice has one non-private coin and one private coin, and she selects both of them as the inputs of a transaction, the linking of these two coins strongly suggests that the coin that was private also belongs to Alice.
 This means that coin consolidation can lead to an overall decrease of privacy, especially when using an automatic coin selection algorithm.

--- a/docs/why-wasabi/Coins.md
+++ b/docs/why-wasabi/Coins.md
@@ -1,0 +1,34 @@
+---
+{
+  "title": "Coins",
+  "description": "On the nuances of Bitcoin's coin model with unspent transaction outputs, the privacy problems and how to fix it. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+}
+---
+
+# Coins
+
+Bitcoin has an accounting model of [unspent transaction outputs [UTXO]](https://bitcoin.org/en/blockchain-guide#introduction).
+A transaction has inputs: the coins that are spent, and outputs: the coins that are received.
+The input of one transaction has to be an output of a previous transaction that is not yet spent.
+Each UTXO is the tip of the chain of links between inputs and outputs, all the way back to a [coinbase transaction](https://en.bitcoin.it/wiki/Coinbase) that pays the miner.
+
+## Problem
+
+_**UTXOs are not fungible**_
+
+Each UTXO is a unique snow flake with a public transaction history.
+For example, when Alice sends a coin to Bob, then Bob does not just have any random UTXO, but he has specifically the coin that Alice has sent him.
+When Bob sends this coin to Charlie, than Charlie can look back two hops to see the transaction from Alice to Bob.
+If Bob does not want Charlie to know that the transaction between Alice and Bob happened, then Bob needs to send Charlie a different coin.
+
+Further, when Alice has one non-private coin and one private coin, and she selects both of them as the input of one transaction, then it might be clear that the previously private coin also belongs to Alice.
+This means that coin consolidation can lead to an overall decrease of privacy, especially when using an automatic coin selection algorithm.
+
+## Wasabi's Solution
+
+_**Manual coin labeling and selection**_
+
+Contrarily to many other wallets, Wasabi does not show only the total value of bitcoins in the wallet. Rather, in the `Send` and `CoinJoin` tab is a list of all the UTXOs individually.
+Because it is required to label every receiving address, the history of this coin is clear at first glance.
+In order to spend a specific coin, it is manually selected, which prevents the wrong coin being included in the transaction.
+

--- a/docs/why-wasabi/Coins.md
+++ b/docs/why-wasabi/Coins.md
@@ -8,7 +8,7 @@
 # Coins
 
 Bitcoin has an accounting model of [unspent transaction output [UTXO]](https://bitcoin.org/en/blockchain-guide#introduction).
-A transaction has inputs: the coins that are spent, and outputs: the coins that are received.
+A transaction has inputs: the coins that are being spent, and outputs: the corresponding newly created coins (unspent).
 The input of a transaction has to be an unspent output of a previous transaction.
 Each UTXO is the tip of the chain of links between inputs and outputs, all the way back to a [coinbase transaction](https://en.bitcoin.it/wiki/Coinbase) that pays the miner.
 

--- a/docs/why-wasabi/NetworkLevelPrivacy.md
+++ b/docs/why-wasabi/NetworkLevelPrivacy.md
@@ -11,17 +11,17 @@
 
 ---
 
-Bitcoin is a peer to peer network of full nodes, who define, verify and enforce the Nakamoto consensus rules.
+Bitcoin is a peer to peer network of full nodes which define, verify, and enforce the Nakamoto consensus rules.
 There is a lot of communication between them and metadata can be used to de-anonymize Bitcoin users.
 
 ## Problem
 
-_**Clear net light clients**_
+_**Clearnet light clients**_
 
-When the communication to the network is unencrypted over clear net, then there is a easy correlation of the Bitcoin transactions to the IP address of the peer who sent it.
-The IP address can be used to even find out about the physical location of the user!
+When the communication to the network is unencrypted over clearnet, then there is an easy correlation of the Bitcoin transactions to the IP address of the peer who sent it.
+The IP address can even be used to find the physical location of the user!
 
-A Bitcoin full node broadcasts not just the transaction of its user, but also it gossips all the other transactions it has received from its peers.
+A Bitcoin full node broadcasts not just the transaction of its user, but it also gossips all of the other transactions that it has received from its peers.
 Thus it is very difficult to find out which transactions are sent from which full node.
 However, when a node or wallet does not gossip all transactions, but only the transactions of the user, then it is easier to find out which node has sent that specific transaction.
 
@@ -30,13 +30,13 @@ However, when a node or wallet does not gossip all transactions, but only the tr
 _**Full node by default & block filters over tor**_
 
 Wasabi checks if there is a local Tor instance installed, and if so, it uses this to onion-route all the traffic to and from the network.
-If Tor is not already installed, then it is installed automatically within Wasabi.
+If Tor is not already installed, then it is accessed automatically from within Wasabi.
 This means that by default, all network communication is secured from outside snooping and the IP address is hidden.
 
 In order to fully verify everything, running a full node is essential.
 If [bitcoind](https://github.com/bitcoin/bitcoin) is installed on the same computer as Wasabi, then it will automatically and by default connect to the full node.
 It is also possible to connect Wasabi to a remote full node on another computer by specifying the local IP address or Tor hidden service in the settings.
-Now Wasabi pulls the verified blocks from the full node, and it also broadcasts the transactions to the P2P network from this full node.
+Then, Wasabi pulls the verified blocks from the full node, and it also broadcasts the transactions to the P2P network from this full node.
 
 However, even if no full node is installed, Wasabi has a light client mode based on [BIP 158 block filters](/using-wasabi/BIPs.md#bip-158-compact-block-filters-for-light-clients).
 When the user sends the extended public key, or a filter of all the addresses to the central server, then the server can **COMPLETELY** deanonymize the users.
@@ -53,7 +53,7 @@ Wasabi is per default [as private as a Bitcoin full node](/why-wasabi/NetworkLev
 
 ## In Depth
 
-Bitcoin Core, more specifically full nodes are considered to be the pinnacle of network level privacy in Bitcoin wallets that no other wallet type can come close to.
+Bitcoin Core, more specifically full nodes, are considered to be the pinnacle of network level privacy in Bitcoin wallets that no other wallet type can come close to.
 It is not difficult to see why: full nodes download the whole Blockchain and establish your wallet balances locally, so there is zero chance of any third party figuring out which addresses are in your wallet and which addresses are not.
 
 Compare this to other light wallets, which query a backend server to get information regarding specific addresses or use [BIP 37](/using-wasabi/BIPs.md#bip-37-connection-bloom-filtering) bloom filtering SPV wallet protocol, which is probably [even worse](https://jonasnick.github.io/blog/2015/02/12/privacy-in-bitcoinj/).

--- a/docs/why-wasabi/NetworkLevelPrivacy.md
+++ b/docs/why-wasabi/NetworkLevelPrivacy.md
@@ -11,30 +11,30 @@
 
 ---
 
-Bitcoin is a peer to peer network of full nodes which define, verify, and enforce the Nakamoto consensus rules.
+Bitcoin is a peer to peer network of full nodes which define, verify, and enforce the Bitcoin consensus rules.
 There is a lot of communication between them and metadata can be used to de-anonymize Bitcoin users.
 
 ## Problem
 
-_**Clearnet light clients**_
+#### Clearnet light clients
 
 When the communication to the network is unencrypted over clearnet, then there is an easy correlation of the Bitcoin transactions to the IP address of the peer who sent it.
 The IP address can even be used to find the physical location of the user!
 
-A Bitcoin full node broadcasts not just the transaction of its user, but it also gossips all of the other transactions that it has received from its peers.
-Thus it is very difficult to find out which transactions are sent from which full node.
-However, when a node or wallet does not gossip all transactions, but only the transactions of the user, then it is easier to find out which node has sent that specific transaction.
+A Bitcoin full node broadcasts not just the transactions of its user, but it also gossips all of the other transactions that it has received from its peers.
+Thus it is very difficult to find out which transactions originated from which full node.
+However, when a node or a wallet does not gossip all transactions, but only the transactions of its user, then it is easier to find out which node has sent those specific transactions.
 
 ## Wasabi's Solution
 
-_**Full node by default & block filters over tor**_
+#### Full node by default & block filters over tor
 
 Wasabi checks if there is a local Tor instance installed, and if so, it uses this to onion-route all the traffic to and from the network.
 If Tor is not already installed, then it is accessed automatically from within Wasabi.
 This means that by default, all network communication is secured from outside snooping and the IP address is hidden.
 
 In order to fully verify everything, running a full node is essential.
-If [bitcoind](https://github.com/bitcoin/bitcoin) is installed on the same computer as Wasabi, then it will automatically and by default connect to the full node.
+If [bitcoind](https://github.com/bitcoin/bitcoin) is installed and run on the same computer as Wasabi, then it will automatically and by default connect to the full node.
 It is also possible to connect Wasabi to a remote full node on another computer by specifying the local IP address or Tor hidden service in the settings.
 Then, Wasabi pulls the verified blocks from the full node, and it also broadcasts the transactions to the P2P network from this full node.
 
@@ -42,11 +42,12 @@ However, even if no full node is installed, Wasabi has a light client mode based
 When the user sends the extended public key, or a filter of all the addresses to the central server, then the server can **COMPLETELY** deanonymize the users.
 An extended public (xPub) key is a part of the Bitcoin standard [BIP32](/using-wasabi/BIPs.md#bip-32-hierarchical-deterministic-wallets).
 It can be thought of as a master view into a wallet.
-By using the extended public key it's possible to derive all past and future public addresses and unspent transaction outputs (UTXOs).
+By using the extended public key it's possible to derive all past and future addresses and unspent transaction outputs (UTXOs).
 
 Therefore the Wasabi server sends a filter of all the transactions in each block to all the users.
-Now they check locally if the block contains a transaction with their address.
-If not, then the filter is stored for later reference, and no block is downloaded. However, if there is a user transaction in that block, then Wasabi connects to a random Bitcoin P2P node over Tor, and asks for this entire block, not only one transaction.
+Now they check locally if the block contains any transactions with their addresses.
+If not, then the filter is stored for later reference, and no block is downloaded.
+However, if there is a user transaction in that block, then Wasabi connects to a random Bitcoin P2P node over Tor, and asks for this entire block, not only one transaction.
 This block request is indistinguishable from the regular P2P gossip, and thus nobody, neither the server nor the full node, know which addresses belong to the user.
 
 Wasabi is per default [as private as a Bitcoin full node](/why-wasabi/NetworkLevelPrivacy.md).

--- a/docs/why-wasabi/NetworkLevelPrivacy.md
+++ b/docs/why-wasabi/NetworkLevelPrivacy.md
@@ -11,6 +11,48 @@
 
 ---
 
+Bitcoin is a peer to peer network of full nodes, who define, verify and enforce the Nakamoto consensus rules.
+There is a lot of communication between them and metadata can be used to de-anonymize Bitcoin users.
+
+## Problem
+
+_**Clear net light clients**_
+
+When the communication to the network is unencrypted over clear net, then there is a easy correlation of the Bitcoin transactions to the IP address of the peer who sent it.
+The IP address can be used to even find out about the physical location of the user!
+
+A Bitcoin full node broadcasts not just the transaction of its user, but also it gossips all the other transactions it has received from its peers.
+Thus it is very difficult to find out which transactions are sent from which full node.
+However, when a node or wallet does not gossip all transactions, but only the transactions of the user, then it is easier to find out which node has sent that specific transaction.
+
+## Wasabi's Solution
+
+_**Full node by default & block filters over tor**_
+
+Wasabi checks if there is a local Tor instance installed, and if so, it uses this to onion-route all the traffic to and from the network.
+If Tor is not already installed, then it is installed automatically within Wasabi.
+This means that by default, all network communication is secured from outside snooping and the IP address is hidden.
+
+In order to fully verify everything, running a full node is essential.
+If [bitcoind](https://github.com/bitcoin/bitcoin) is installed on the same computer as Wasabi, then it will automatically and by default connect to the full node.
+It is also possible to connect Wasabi to a remote full node on another computer by specifying the local IP address or Tor hidden service in the settings.
+Now Wasabi pulls the verified blocks from the full node, and it also broadcasts the transactions to the P2P network from this full node.
+
+However, even if no full node is installed, Wasabi has a light client mode based on [BIP 158 block filters](/using-wasabi/BIPs.md#bip-158-compact-block-filters-for-light-clients).
+When the user sends the extended public key, or a filter of all the addresses to the central server, then the server can **COMPLETELY** deanonymize the users.
+An extended public (xPub) key is a part of the Bitcoin standard [BIP32](/using-wasabi/BIPs.md#bip-32-hierarchical-deterministic-wallets).
+It can be thought of as a master view into a wallet.
+By using the extended public key it's possible to derive all past and future public addresses and unspent transaction outputs (UTXOs).
+
+Therefore the Wasabi server sends a filter of all the transactions in each block to all the users.
+Now they check locally if the block contains a transaction with their address.
+If not, then the filter is stored for later reference, and no block is downloaded. However, if there is a user transaction in that block, then Wasabi connects to a random Bitcoin P2P node over Tor, and asks for this entire block, not only one transaction.
+This block request is indistinguishable from the regular P2P gossip, and thus nobody, neither the server nor the full node, know which addresses belong to the user.
+
+Wasabi is per default [as private as a Bitcoin full node](/why-wasabi/NetworkLevelPrivacy.md).
+
+## In Depth
+
 Bitcoin Core, more specifically full nodes are considered to be the pinnacle of network level privacy in Bitcoin wallets that no other wallet type can come close to.
 It is not difficult to see why: full nodes download the whole Blockchain and establish your wallet balances locally, so there is zero chance of any third party figuring out which addresses are in your wallet and which addresses are not.
 

--- a/docs/why-wasabi/NetworkLevelPrivacy.md
+++ b/docs/why-wasabi/NetworkLevelPrivacy.md
@@ -36,7 +36,7 @@ This means that by default, all network communication is secured from outside sn
 In order to fully verify everything, running a full node is essential.
 If [bitcoind](https://github.com/bitcoin/bitcoin) is installed and run on the same computer as Wasabi, then it will automatically and by default connect to the full node.
 It is also possible to connect Wasabi to a remote full node on another computer by specifying the local IP address or Tor hidden service in the settings.
-Then, Wasabi pulls the verified blocks from the full node, and it also broadcasts the transactions to the P2P network from this full node.
+Then, Wasabi pulls the verified blocks and queries the mempool from the full node.
 
 However, even if no full node is installed, Wasabi has a light client mode based on [BIP 158 block filters](/using-wasabi/BIPs.md#bip-158-compact-block-filters-for-light-clients).
 When the user sends the extended public key, or a filter of all the addresses to the central server, then the server can **COMPLETELY** deanonymize the users.

--- a/docs/why-wasabi/NetworkLevelPrivacy.md
+++ b/docs/why-wasabi/NetworkLevelPrivacy.md
@@ -11,7 +11,7 @@
 
 ---
 
-Bitcoin is a peer to peer network of full nodes which define, verify, and enforce the Bitcoin consensus rules.
+Bitcoin is a peer-to-peer network of full nodes which define, verify, and enforce the Bitcoin consensus rules.
 There is a lot of communication between them and metadata can be used to de-anonymize Bitcoin users.
 
 ## Problem
@@ -45,7 +45,7 @@ It can be thought of as a master view into a wallet.
 By using the extended public key it's possible to derive all past and future addresses and unspent transaction outputs (UTXOs).
 
 Therefore the Wasabi server sends a filter of all the transactions in each block to all the users.
-Now they check locally if the block contains any transactions with their addresses.
+Then, they check locally if the block contains any transactions with their addresses.
 If not, then the filter is stored for later reference, and no block is downloaded.
 However, if there is a user transaction in that block, then Wasabi connects to a random Bitcoin P2P node over Tor, and asks for this entire block, not only one transaction.
 This block request is indistinguishable from the regular P2P gossip, and thus nobody, neither the server nor the full node, know which addresses belong to the user.

--- a/docs/why-wasabi/README.md
+++ b/docs/why-wasabi/README.md
@@ -13,7 +13,14 @@ And why Wasabi can make Bitcoin an even better tool of self defense by default.
 
 ### Chapters
 
+#### Why Privacy
+
 - [Why Privacy is Important](/why-wasabi/WhyPrivacyImportant.md)
-- [Privacy in Bitcoin](/why-wasabi/BitcoinPrivacy.md)
+- [Why Financial Privacy is Especially Important](/why-wasabi/WhyFinancialPrivacy.md)
+
+#### Privacy in Bitcoin
+- [Address Reuse](/why-wasabi/AddressReuse.md)
+- [Coins](/why-wasabi/Coins.md)
+- [Transaction Graph](/TransactionGraph.md)
 - [Network Level Privacy](/why-wasabi/NetworkLevelPrivacy.md)
 - [Transaction Surveillance Companies](/why-wasabi/TransactionSurveillanceCompanies.md)

--- a/docs/why-wasabi/TransactionGraph.md
+++ b/docs/why-wasabi/TransactionGraph.md
@@ -1,0 +1,31 @@
+---
+{
+  "title": "Transaction Graph",
+  "description": "On how Bitcoin transactions are interconnected, how this is dangereous for privacy, and how to fix it. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+}
+---
+
+# Transaction Graph
+
+## Problem
+
+_**Public transaction history**_
+
+Because of the input and output model of Bitcoin, there is a chain of digital signatures all the way from the coinbase reward, to the current UTXO.
+This transaction history can reveal sensitive information of the spending patterns of individuals.
+The receiver of a coin can look back into the transaction history of the sender.
+And the sender can see the future spending of the receiver.
+
+## Wasabi's Solution
+
+_**Zero Link CoinJoins**_
+
+In order to obfuscate the link between outputs and inputs, Wasabi uses the [Zero Link](https://github.com/nopara73/zerolink) CoinJoin protocol.
+The Wasabi central coordinator cannot steal and cannot spy, he simply helps many peers to build a huge transaction, with many inputs, and many outputs.
+The non-private inputs can be linked to their previous transaction history.
+However, the equal value CoinJoin outputs with an anonymity set can not be tied to the inputs.
+
+This means that when sending an anonset coin, the receiver does not know about the transaction history before the CoinJoin.
+And when the receiver does a CoinJoin himself, then the sender cannot spy on the later spending patterns.
+An outside observer can only guess the correct link at a rate of 1 in the anonset, for example 1-in-100, or 1%.
+

--- a/docs/why-wasabi/TransactionGraph.md
+++ b/docs/why-wasabi/TransactionGraph.md
@@ -1,7 +1,7 @@
 ---
 {
   "title": "Transaction Graph",
-  "description": "On how Bitcoin transactions are interconnected, how this is dangereous for privacy, and how to fix it. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+  "description": "On how Bitcoin transactions are interconnected, how this is dangerous for privacy, and how to fix it. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
 }
 ---
 
@@ -9,7 +9,7 @@
 
 ## Problem
 
-_**Public transaction history**_
+#### Public transaction history
 
 Because of the input and output model of Bitcoin, there is a chain of digital signatures all the way from the coinbase reward, to the current UTXO.
 This transaction history can reveal sensitive information of the spending patterns of individuals.
@@ -18,14 +18,13 @@ And the sender can see the future spending of the receiver.
 
 ## Wasabi's Solution
 
-_**Zero Link CoinJoins**_
+#### Zero Link CoinJoins
 
-In order to obfuscate the link between outputs and inputs, Wasabi uses the [Zero Link](https://github.com/nopara73/zerolink) CoinJoin protocol.
-The Wasabi central coordinator cannot steal and cannot spy, he simply helps many peers to build a huge transaction, with many inputs, and many outputs.
+In order to obfuscate the link between inputs and outputs, Wasabi uses the [Zero Link](https://github.com/nopara73/zerolink) CoinJoin protocol.
+The Wasabi central coordinator cannot steal and cannot spy, it simply helps many peers to build a huge transaction, with many inputs, and many outputs.
 The non-private inputs can be linked to their previous transaction history.
-However, the equal value CoinJoin outputs with an anonymity set can not be tied to the inputs.
+However, the equal value CoinJoin outputs with an anonymity set cannot be tied to the inputs.
 
 This means that when sending an anonset coin, the receiver does not know about the transaction history before the CoinJoin.
 And when the receiver does a CoinJoin himself, then the sender cannot spy on the later spending patterns.
 An outside observer can only guess the correct link at a rate of 1 in the anonset, for example 1-in-100, or 1%.
-

--- a/docs/why-wasabi/WhyFinancialPrivacy.md
+++ b/docs/why-wasabi/WhyFinancialPrivacy.md
@@ -8,8 +8,8 @@
 # Why Financial Privacy is Especially Important
 
 > The possibility to be anonymous or pseudonymous relies on you not revealing any identifying information about yourself in connection with the bitcoin addresses you use.
-If you post your bitcoin address on the web, then you’re associating that address and any transactions with it with the name you posted under.
-If you posted under a handle that you haven’t associated with your real identity, then you’re still pseudonymous.
+If you post your bitcoin address on the web, then you're associating that address and any transactions with it with the name you posted under.
+If you posted under a handle that you haven't associated with your real identity, then you're still pseudonymous.
 For greater privacy, it's best to use bitcoin addresses only once.
 
 By Satoshi Nakamoto in [How anonymous are bitcoins? - Bitcointalk](https://bitcointalk.org/index.php?topic=8.msg34#msg34)
@@ -27,15 +27,15 @@ One of the apparent contradictions of Bitcoin is the notion that your transactio
 As a financial system, Bitcoin functions completely differently from the established banking network.
 Bitcoin allows you to store funds yourself, without the need for a third party, and therefore places the burden on you of keeping said funds secure and accessible.
 
-While opening an account with a traditional bank or other financial institution requires significant cost and effort, creating a Bitcoin account is quick and easy to do on your home computer.
-This speedy process makes it possible to create hundreds of separate accounts if you wish.
+While opening an account with a traditional bank or other financial institution requires significant cost and effort, creating a Bitcoin wallet is quick and easy to do on your home computer.
+This speedy process makes it possible to create hundreds of separate wallets if you wish.
 
-Two aspects in particular—privacy and identity—function very differently with Bitcoin than in the legacy financial system.
+Two aspects —in particular privacy and identity— function very differently with Bitcoin than in the legacy financial system.
 
 ## Pseudonyms protect your identity in Bitcoin
 
-A bank account, PayPal account, or credit card is always tied to a real identity, making it difficult for many people to open them. 
-Bitcoin allows you to use any persona or online identity you wish.
+A bank account, PayPal account, or credit card is always tied to a real identity, making it difficult for many people to open one.
+Bitcoin doesn't require any identity to be part of this network.
 
 Being able to use the internet anonymously or pseudonymously is the only way for many people to truly be themselves.
 Hundreds of millions of people around the globe are not accepted in their societies for reasons they cannot control.
@@ -53,13 +53,13 @@ This clearly makes no sense, and has potentially dangerous ramifications.
 ## How Bitcoin empowers anonymity
 
 Bitcoin is an important, empowering technology.
-Using a Bitcoin account with a pseudonym protects your right to remain anonymous on the internet.
+Using Bitcoin protects your right to remain anonymous on the internet.
 It allows anonymous or pseudonymous fundraising.
 Groups can collectively control Bitcoin accounts and choose to either hide or reveal financial information at will.
 
 There are many positive reasons for a private and secure banking system like Bitcoin.
 
-For example, a workers’ rights group could raise funds with Bitcoin.
+For example, a workers' rights group could raise funds with Bitcoin.
 The money could be used for servers, flyers, remote helpers… and all without tying any transaction to the real identities of the volunteers.
 
 Likewise, a domestic abuse victim might use Bitcoin to securely stack away funds to prepare for an independent life.
@@ -71,7 +71,7 @@ They (try to) ensure that your bank balance stays a secret.
 This puts them in a powerful position, where only they have complete oversight as to what is going on.
 
 In the Bitcoin ecosystem, everyone can see the history of every account balance, but they cannot see who controls an account.
-All addresses and transactions are recorded in Bitcoin’s publicly distributed database, the blockchain.
+All addresses and transactions are recorded in Bitcoin's publicly distributed database, the blockchain.
 The addresses do not have names or IP addresses attached to them, so it is not always possible to know which transaction belongs to which individual.
 
 ## Threat model
@@ -88,6 +88,6 @@ You could still use this to communicate with a social media website to write you
 Anybody on the internet could view that information so your privacy would be ruined even though you were using perfectly private technology.
 
 For details read the talk [Opsec for Hackers by grugq](https://www.slideshare.net/grugq/opsec-for-hackers).
-The talk is aimed mostly at political activists who need privacy from governments, but much the advice generally applies to all of us.
+The talk is aimed mostly at political activists who need privacy from governments, but the advice generally applies to all of us.
 
-Much of the time plausible deniability is not good enough because lots of spying methods only need to work on a statistical level (e.g. targeted advertising).
+Most of the time plausible deniability is not good enough because lots of spying methods only need to work on a statistical level (e.g. targeted advertising).

--- a/docs/why-wasabi/WhyFinancialPrivacy.md
+++ b/docs/why-wasabi/WhyFinancialPrivacy.md
@@ -1,0 +1,93 @@
+---
+{
+  "title": "Why Financial Privacy is Especially Important",
+  "description": "An introduction to the positive and negative side of Privacy in Bitcoin today. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+}
+---
+
+# Why Financial Privacy is Especially Important
+
+> The possibility to be anonymous or pseudonymous relies on you not revealing any identifying information about yourself in connection with the bitcoin addresses you use.
+If you post your bitcoin address on the web, then you’re associating that address and any transactions with it with the name you posted under.
+If you posted under a handle that you haven’t associated with your real identity, then you’re still pseudonymous.
+For greater privacy, it's best to use bitcoin addresses only once.
+
+By Satoshi Nakamoto in [How anonymous are bitcoins? - Bitcointalk](https://bitcointalk.org/index.php?topic=8.msg34#msg34)
+
+[[toc]]
+
+![](/InfographicWhyWasabi.png)
+
+---
+
+## Why it is important to keep your funds private
+
+One of the apparent contradictions of Bitcoin is the notion that your transactions can be private but have a public transaction record.
+
+As a financial system, Bitcoin functions completely differently from the established banking network.
+Bitcoin allows you to store funds yourself, without the need for a third party, and therefore places the burden of keeping said funds secure and accessible on you.
+
+While opening an account with a traditional bank or other financial institution requires significant cost and effort, creating a Bitcoin account is quick and easy to do on your home computer.
+This speedy process makes it possible to create hundreds of separate accounts if you wish.
+
+Two aspects in particular—privacy and identity—function very differently with Bitcoin than in the legacy financial system.
+
+## Pseudonyms protect your identity in Bitcoin
+
+A bank account, PayPal account, or credit card is always tied to a real identity, making it difficult for many people to open them. 
+Bitcoin allows you to use any persona or online identity you wish.
+
+Being able to use the internet anonymously or pseudonymously is the only way for many people to truly be themselves.
+Hundreds of millions of people around the globe are not accepted in their societies for reasons they cannot control.
+
+Pseudonyms are used by women speaking up for their rights, atheists living in religious societies, and people critical of their governments to spread their thoughts, empower their causes, and encourage those around them to do the same.
+
+These courageous men and women put their own safety and well-being at risk to defend who they are and what they believe in. 
+Technology empowers them to become leaders of social change in societies by providing this very pseudonymity.
+Technology also connects like-minded individuals so they can form the communities for which they strive.
+
+Maintaining an identity with a large following might require paid services such as blogs, logo designs, stock photos, VPNs, or translations.
+Without the ability to pay for these services anonymously, you would be forced to reveal your true identity in order to maintain your pseudonym situation which clearly makes no sense, and one with potentially dangerous ramifications.
+
+## How Bitcoin empowers anonymity
+
+Bitcoin is an important, empowering technology.
+Using a Bitcoin account with a pseudonym protects your right to remain anonymous on the internet.
+It allows anonymous or pseudonymous fundraising.
+Groups can collectively control Bitcoin accounts and choose to either hide or reveal financial information at will.
+
+There are many positive reasons for a private and secure banking system like Bitcoin.
+
+For example, a workers’ rights group could raise funds with Bitcoin.
+The money could be used for servers, flyers, remote helpers… and all without tying any transaction to the real identities of the volunteers.
+
+Likewise, a domestic abuse victim might use Bitcoin to securely stack away funds to prepare for an independent life.
+
+## Privacy through pseudonymous accounts
+
+Privacy in traditional banking is guaranteed by the institutions that make up the system, such as banks, credit card companies, and governments.
+They (try to) ensure that your bank balance stays a secret.
+This puts them in a powerful position, where only they have complete oversight as to what is going on.
+
+In the Bitcoin ecosystem, everyone can see the history of every account balance, but they cannot see who controls an account.
+All addresses and transactions are recorded in Bitcoin’s publicly distributed database, the blockchain.
+The addresses do not have names or IP addresses attached to them, so it is not always possible to know which transaction belongs to which individual.
+
+## Threat model
+
+When considering privacy you need to think about exactly who you're hiding from.
+You must examine how a hypothetical adversary could spy on you, what kind of information is most important to you and which technology you need to use to protect your privacy.
+The kind of behaviour needed to protect your privacy therefore depends on your threat model.
+
+Newcomers to privacy often think that they can simply download some software and all their privacy concerns will be solved.
+This is not so.
+Privacy requires a change in behaviour, however slight.
+For example, imagine if you had a perfectly private internet where who you're communicating with and what you say are completely private.
+You could still use this to communicate with a social media website to write your real name, upload a selfie and talk about what you're doing right now.
+Anybody on the internet could view that information so your privacy would be ruined even though you were using perfectly private technology.
+
+For details read the talk [Opsec for Hackers by grugq](https://www.slideshare.net/grugq/opsec-for-hackers).
+The talk is aimed mostly at political activists who need privacy from governments, but much the advice generally applies to all of us.
+
+Much of the time plausible deniability is not good enough because lots of spying methods only need to work on a statistical level (e.g. targeted advertising).
+

--- a/docs/why-wasabi/WhyFinancialPrivacy.md
+++ b/docs/why-wasabi/WhyFinancialPrivacy.md
@@ -25,7 +25,7 @@ By Satoshi Nakamoto in [How anonymous are bitcoins? - Bitcointalk](https://bitco
 One of the apparent contradictions of Bitcoin is the notion that your transactions can be private but have a public transaction record.
 
 As a financial system, Bitcoin functions completely differently from the established banking network.
-Bitcoin allows you to store funds yourself, without the need for a third party, and therefore places the burden of keeping said funds secure and accessible on you.
+Bitcoin allows you to store funds yourself, without the need for a third party, and therefore places the burden on you of keeping said funds secure and accessible.
 
 While opening an account with a traditional bank or other financial institution requires significant cost and effort, creating a Bitcoin account is quick and easy to do on your home computer.
 This speedy process makes it possible to create hundreds of separate accounts if you wish.
@@ -47,7 +47,8 @@ Technology empowers them to become leaders of social change in societies by prov
 Technology also connects like-minded individuals so they can form the communities for which they strive.
 
 Maintaining an identity with a large following might require paid services such as blogs, logo designs, stock photos, VPNs, or translations.
-Without the ability to pay for these services anonymously, you would be forced to reveal your true identity in order to maintain your pseudonym situation which clearly makes no sense, and one with potentially dangerous ramifications.
+Without the ability to pay for these services anonymously, you would be forced to reveal your true identity in order to maintain your pseudonym situation.
+This clearly makes no sense, and has potentially dangerous ramifications.
 
 ## How Bitcoin empowers anonymity
 
@@ -90,4 +91,3 @@ For details read the talk [Opsec for Hackers by grugq](https://www.slideshare.ne
 The talk is aimed mostly at political activists who need privacy from governments, but much the advice generally applies to all of us.
 
 Much of the time plausible deniability is not good enough because lots of spying methods only need to work on a statistical level (e.g. targeted advertising).
-

--- a/docs/why-wasabi/WhyFinancialPrivacy.md
+++ b/docs/why-wasabi/WhyFinancialPrivacy.md
@@ -40,12 +40,6 @@ Bitcoin doesn't require any identity to be part of this network.
 Being able to use the internet anonymously or pseudonymously is the only way for many people to truly be themselves.
 Hundreds of millions of people around the globe are not accepted in their societies for reasons they cannot control.
 
-Pseudonyms are used by women speaking up for their rights, atheists living in religious societies, and people critical of their governments to spread their thoughts, empower their causes, and encourage those around them to do the same.
-
-These courageous men and women put their own safety and well-being at risk to defend who they are and what they believe in. 
-Technology empowers them to become leaders of social change in societies by providing this very pseudonymity.
-Technology also connects like-minded individuals so they can form the communities for which they strive.
-
 Maintaining an identity with a large following might require paid services such as blogs, logo designs, stock photos, VPNs, or translations.
 Without the ability to pay for these services anonymously, you would be forced to reveal your true identity in order to maintain your pseudonym situation.
 This clearly makes no sense, and has potentially dangerous ramifications.


### PR DESCRIPTION
This ready for review branch brings a rather big change, by separating the chapter `Privacy in Bitcoin` into several independent chapters [without changing content], to make `why-bitcoin`:
```
#### Why Privacy
- Why Privacy is Important
- Why Financial Privacy is Especially Important

#### Privacy in Bitcoin
- Address Reuse
- Coins
- Transaction Graph
- Network Level Privacy
- Transaction Surveillance Companies
```

this allows us to more clearly describe these concepts, and have independent chapters of various depth for each. This does break a bunch of internal links, which I can fix in a follow up commit before merge, if there is general concept ACK. This also needs a follow up PR decluttering of `Network Level Privacy`. 