### PR TITLE
Clarify Ledger Live information regarding public address privacy

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1124,7 +1124,7 @@ You can't do that directly, you have to send the bitcoins (in small portions > 0
 :::
 
 :::details
-### Does Ledger Live send my public addresses to a third party server?
+### Does Ledger Live send my public keys and addresses to a third party server?
 
 Only if you add your accounts in the app, but not if you update your device firmware or install apps. 
 When using the Ledger Live software wallet to manage your coins, you send all of your used, and 20 unused addresses to Ledger's nodes. [Source](https://support.ledger.com/hc/en-us/articles/360010892360)

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1127,11 +1127,11 @@ You can't do that directly, you have to send the bitcoins (in small portions > 0
 ### Does Ledger Live send my public addresses to a third party server?
 
 Only if you add your accounts in the app, but not if you update your device firmware or install apps. 
-When using the Ledger Live software wallet to manage your coins, you send all of your used, and 20 unused public addresses to Ledger's nodes. [Source](https://support.ledger.com/hc/en-us/articles/360010892360)
+When using the Ledger Live software wallet to manage your coins, you send all of your used, and 20 unused addresses to Ledger's nodes. [Source](https://support.ledger.com/hc/en-us/articles/360010892360)
 Ledger says it does not use this information to track its users' coins and transactions, but as a user you cannot verify this.
 Your extended public key, however, is not shared with Ledger's node, but rather stored encrypted on your local machine. [Source](https://support.ledger.com/hc/en-us/articles/360011069619)
 
-To avoid this privacy leak, you can use a Ledger hardware wallet in combination with Wasabi as a software interface, and because Wasabi does not leak your public addresses, your transaction history is not shared with anyone.
+To avoid this privacy leak, you can use a Ledger hardware wallet in combination with Wasabi as a software interface, and because Wasabi does not leak your addresses, your transaction history is not shared with anyone.
 
 If you have already used Ledger Live, make sure you are generating a completely new wallet with a new seed phrase backup so that the compromised old wallet is no longer an issue.
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1132,9 +1132,9 @@ When using the Ledger Live software wallet to manage your coins, you send all of
 Your extended public key, however, is not shared with Ledger's node, but rather stored encrypted on your local machine.
 Read more [here](https://support.ledger.com/hc/en-us/articles/360011069619).
 
-Though Ledger says it does not use this information to try to identify how much bitcoin you have and what your transactions you make, Ledger could potentially do so.
+Ledger could potentially analyze information from API calls to their nodes to link addresses to individual users, though Ledger says no logs are kept during normal operation.
 
-To avoid this privacy leak, you can use a Ledger hardware wallet in combination with Wasabi as a software interface, and because Wasabi does not leak your addresses, your transaction history is not shared with anyone.
+To avoid any privacy leak, you can use a Ledger hardware wallet in combination with Wasabi as a software interface, and because Wasabi does not leak your addresses, your transaction history is not shared with anyone.
 
 :::
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1129,7 +1129,8 @@ You can't do that directly, you have to send the bitcoins (in small portions > 0
 Only if you add your accounts in the app, but not if you update your device firmware or install apps. 
 When using the Ledger Live software wallet to manage your coins, you send all of your used, and 20 unused addresses to Ledger's nodes. [Source](https://support.ledger.com/hc/en-us/articles/360010892360)
 Ledger says it does not use this information to track its users' coins and transactions, but as a user you cannot verify this.
-Your extended public key, however, is not shared with Ledger's node, but rather stored encrypted on your local machine. [Source](https://support.ledger.com/hc/en-us/articles/360011069619)
+Your extended public key, however, is not shared with Ledger's node, but rather stored encrypted on your local machine.
+Read more [here](https://support.ledger.com/hc/en-us/articles/360011069619).
 
 To avoid this privacy leak, you can use a Ledger hardware wallet in combination with Wasabi as a software interface, and because Wasabi does not leak your addresses, your transaction history is not shared with anyone.
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1128,9 +1128,11 @@ You can't do that directly, you have to send the bitcoins (in small portions > 0
 
 Only if you add your accounts in the app, but not if you update your device firmware or install apps. 
 When using the Ledger Live software wallet to manage your coins, you send all of your used, and 20 unused addresses to Ledger's nodes. [Source](https://support.ledger.com/hc/en-us/articles/360010892360)
-Ledger says it does not use this information to track its users' coins and transactions, but as a user you cannot verify this.
+
 Your extended public key, however, is not shared with Ledger's node, but rather stored encrypted on your local machine.
 Read more [here](https://support.ledger.com/hc/en-us/articles/360011069619).
+
+Though Ledger says it does not use this information to try to identify how much bitcoin you have and what your transactions you make, Ledger could potentially do so.
 
 To avoid this privacy leak, you can use a Ledger hardware wallet in combination with Wasabi as a software interface, and because Wasabi does not leak your addresses, your transaction history is not shared with anyone.
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1133,8 +1133,6 @@ Your extended public key, however, is not shared with Ledger's node, but rather 
 
 To avoid this privacy leak, you can use a Ledger hardware wallet in combination with Wasabi as a software interface, and because Wasabi does not leak your addresses, your transaction history is not shared with anyone.
 
-If you have already used Ledger Live, make sure you are generating a completely new wallet with a new seed phrase backup so that the compromised old wallet is no longer an issue.
-
 :::
 
 :::details

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1124,19 +1124,17 @@ You can't do that directly, you have to send the bitcoins (in small portions > 0
 :::
 
 :::details
-### Does Ledger Live send my public keys and addresses to a third party server?
+### Does Ledger Live send my public addresses to a third party server?
 
-Yes.
-When using the Ledger Live software wallet to manage your coins, you send all of your used, and 20 unused public keys to the Ledger company server. [Source](https://support.ledger.com/hc/en-us/articles/360010892360)
-With this information they know exactly how many bitcoins you have and in what transactions you spend them.
-Your extended public key, however, is not shared with this server, but rather stored encrypted on your local machine. [Source](https://support.ledger.com/hc/en-us/articles/360011069619)
+Only if you add your accounts in the app, but not if you update your device firmware or install apps. 
+When using the Ledger Live software wallet to manage your coins, you send all of your used, and 20 unused public addresses to Ledger's nodes. [Source](https://support.ledger.com/hc/en-us/articles/360010892360)
+Ledger says it does not use this information to track its users' coins and transactions, but as a user you cannot verify this.
+Your extended public key, however, is not shared with Ledger's node, but rather stored encrypted on your local machine. [Source](https://support.ledger.com/hc/en-us/articles/360011069619)
 
-To avoid this privacy leak, you can use a Ledger hardware in combination with Wasabi as a software interface, and because Wasabi does not leak your public keys, your transaction history is not shared with anyone.
+To avoid this privacy leak, you can use a Ledger hardware wallet in combination with Wasabi as a software interface, and because Wasabi does not leak your public addresses, your transaction history is not shared with anyone.
 
 If you have already used Ledger Live, make sure you are generating a completely new wallet with a new seed phrase backup so that the compromised old wallet is no longer an issue.
 
-If you need to use Ledger Live, for example to update your firmware, then only connect to it with a passphrase that leads to an unused and empty wallet.
-Then use your Ledger hardware with the correct passphrase with Wasabi Wallet without having concerns about your privacy.
 :::
 
 :::details


### PR DESCRIPTION
- Clarify that Ledger Live does not send public addresses if you don't add an account. 
- By extension, there's no need to use the passphrase functionality for installing apps and updating the firmware to protect privacy.