### PR TITLE
[DECLUTTER WHY USING] move change heuristics to why

### DIFF
--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -72,83 +72,9 @@ Change is not inherently bad, it's a fundamental part of how Bitcoin and the UTX
 However, when sending a coin that is change from an earlier transaction, then the receiver can easily deduce that the sender was also part of the previous transaction that generated the change.
 
 Whenever you are merging coins in one transaction, it becomes clear to any outside observer that these coins belong to the same entity, thus linking the previous transaction history.
+Thus [identifying change](/why-wasabi/Coins.md#heuristics-identifying-change) based on some heuristics is a top goal of transaction surveillance.
 
 You want to avoid merging `anonymity set 1` coins with `anonymity set > 1` mixed coins whenever possible, because this will link these coins, and negate the privacy of the mixed coins that was gained through the CoinJoin.
-
-## Heuristics identifying change
-
-One prime goal of [transaction surveillance companies](/why-wasabi/TransactionSurveillanceCompanies.md) is to identify the change coin of a Bitcoin transaction, as this is vital information for building a cluster of coins belonging to one entity.
-There are several heuristics, practical assumptions which are not guaranteed to be accurate or optimal, that are used to deanonymize users.
-
-### Address reuse
-
-When several coins have the same address, then they are owned by the same entity.
-Thus if a transaction has a reused address in the output, it is very likely to be the payment amount from one entity to another.
-Thus the other output of this transaction, is likely to be the change of the entity providing the inputs of the transaction.
-
-:::warning Remember
-Never [reuse addresses](/why-wasabi/BitcoinPrivacy.md#address-reuse)!
-:::
-
-### Wallet fingerprinting
-
-Different software wallets have different methods of creating Bitcoin transactions.
-So if it is known that a transaction was created by a specific wallet, then it can be checked how this wallet handles change.
-
-Wasabi tries to build the most common form of transaction structure, thus reducing the likelihood of identifying any given transaction as being from Wasabi.
-However, Wasabi CoinJoins are very easily fingerprinted, and any coin associated is clearly managed with Wasabi Wallet.
-
-### Round numbers
-
-When making a payment, then often the destination address receives a round number of bitcoin.
-Because the input is usually a non-round number, the other output will also be non-round number.
-This makes it clear that the non-round number output is the change back to the sender.
-
-```
-A [0.1293 0112 btc]  -->  B [0.0500 0000 btc]
-                          C [0.0792 9962 btc] (= change)
-```
-
-:::tip
-In order to protect your privacy, add (or remove when possible) a couple sats from the payment amount to obfuscate your change.
-:::
-
-### CoinJoin
-
-A CoinJoin has many unequal value inputs, and creates several equal value anonset outputs, as well as unequal value outputs, making it clear that these are the change outputs.
-
-:::tip
-This is why the CoinJoin change has only 1 anonset <img src="/ShieldRed.png" alt="red" class="shield" />.
-:::
-
-```
-                C [1 btc]
-A [6 btc]  -->  D [1 btc]
-B [3 btc]       E [5 btc] (= change A)
-                F [2 btc] (= change B)
-
-```
-
-### Replace by Fee
-
-[BIP 125](/using-wasabi/BIPs.md#bip-125-opt-in-full-replace-by-fee-signaling) allows for one unconfirmed transaction to be double spent and replaced by a second transaction that pays a higher fee.
-However, the output that is reduced in the second transaction is likely to be the change output, as the sender pays the fee.
-
-```
-First tranaction
-
-A [1.3576 1516 btc]  -->  B [1.0135 6515 btc]
-                          C [0.3440 4861 btc] 
-
-Second transaction (RBF)
-
-A [1.3576 1516 btc]  -->  B [1.0135 6515 btc]
-                          C [0.3440 4721 btc] (= change)
-```
-
-:::tip
-Because of this privacy leak, Wasabi does not utilize RBF fee bumping.
-:::
 
 ## Your options to use change privately
 

--- a/docs/why-wasabi/Coins.md
+++ b/docs/why-wasabi/Coins.md
@@ -32,3 +32,79 @@ Contrary to many other wallets, Wasabi does not show only the total value of bit
 Rather, in both the `Send` and `CoinJoin` tabs there is a list of all the individual UTXOs.
 Because Wasabi requires users to label every receiving address, the history of each coin is clear at first glance.
 In order to spend a specific coin, it must be manually selected, which prevents the wrong coin from being included in the transaction.
+
+## Heuristics identifying change
+
+One prime goal of [transaction surveillance companies](/why-wasabi/TransactionSurveillanceCompanies.md) is to identify the change coin of a Bitcoin transaction, as this is vital information for building a cluster of coins belonging to one entity.
+There are several heuristics, practical assumptions which are not guaranteed to be accurate or optimal, that are used to deanonymize users.
+
+### Address reuse
+
+When several coins have the same address, then they are owned by the same entity.
+Thus if a transaction has a reused address in the output, it is very likely to be the payment amount from one entity to another.
+Thus the other output of this transaction, is likely to be the change of the entity providing the inputs of the transaction.
+
+:::warning Remember
+Never [reuse addresses](/why-wasabi/BitcoinPrivacy.md#address-reuse)!
+:::
+
+### Wallet fingerprinting
+
+Different software wallets have different methods of creating Bitcoin transactions.
+So if it is known that a transaction was created by a specific wallet, then it can be checked how this wallet handles change.
+
+Wasabi tries to build the most common form of transaction structure, thus reducing the likelihood of identifying any given transaction as being from Wasabi.
+However, Wasabi CoinJoins are very easily fingerprinted, and any coin associated is clearly managed with Wasabi Wallet.
+
+### Round numbers
+
+When making a payment, then often the destination address receives a round number of bitcoin.
+Because the input is usually a non-round number, the other output will also be non-round number.
+This makes it clear that the non-round number output is the change back to the sender.
+
+```
+A [0.1293 0112 btc]  -->  B [0.0500 0000 btc]
+                          C [0.0792 9962 btc] (= change)
+```
+
+:::tip
+In order to protect your privacy, add (or remove when possible) a couple sats from the payment amount to obfuscate your change.
+:::
+
+### CoinJoin
+
+A CoinJoin has many unequal value inputs, and creates several equal value anonset outputs, as well as unequal value outputs, making it clear that these are the change outputs.
+
+:::tip
+This is why the CoinJoin change has only 1 anonset <img src="/ShieldRed.png" alt="red" class="shield" />.
+:::
+
+```
+                C [1 btc]
+A [6 btc]  -->  D [1 btc]
+B [3 btc]       E [5 btc] (= change A)
+                F [2 btc] (= change B)
+
+```
+
+### Replace by Fee
+
+[BIP 125](/using-wasabi/BIPs.md#bip-125-opt-in-full-replace-by-fee-signaling) allows for one unconfirmed transaction to be double spent and replaced by a second transaction that pays a higher fee.
+However, the output that is reduced in the second transaction is likely to be the change output, as the sender pays the fee.
+
+```
+First tranaction
+
+A [1.3576 1516 btc]  -->  B [1.0135 6515 btc]
+                          C [0.3440 4861 btc] 
+
+Second transaction (RBF)
+
+A [1.3576 1516 btc]  -->  B [1.0135 6515 btc]
+                          C [0.3440 4721 btc] (= change)
+```
+
+:::tip
+Because of this privacy leak, Wasabi does not utilize RBF fee bumping.
+:::
+


### PR DESCRIPTION
This ready for review branch moves the part `Heuristics identifying change` from `using-wasabi/ChangeCoins.md` to `why-wasabi/Coins.md`, because it describes a general scenario of bitcoin privacy, and not specifically how it is used in Wasabi.