### PR TITLE
[USING] WalletGeneration.md : Correct factual errors, and move some info to new/advanced password chapter

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -223,6 +223,7 @@ module.exports = {
             "/using-wasabi/Daemon.md",
             "/using-wasabi/RPC.md",
             "/using-wasabi/LurkingWifeMode.md",
+            "/using-wasabi/PasswordBestPractices.md",
             "/using-wasabi/BIPs.md"
          ]
         },

--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -79,13 +79,8 @@ It is crucial to understand that Wasabi is not a fool-proof solution if you negl
 :::details
 ### Do I need to run Tor?
 
-All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself.
+No you don't need to set up Tor yourself, all Wasabi network traffic goes via Tor by default.
 If you do already have Tor, and it is running, then Wasabi will try to use that first.
-
-You can turn off Tor in the `Settings`.
-Note that in this case you are still private, except when you CoinJoin and when you broadcast a transaction.
-In the first case, the coordinator would know the links between your inputs and outputs based on your IP address.
-In the second case, if you happen to broadcast a transaction of yours to a full node that is spying on you, it will know the link between your transaction and your IP address.
 :::
 
 :::details

--- a/docs/building-wasabi/HardwareWalletTestingGuide.md
+++ b/docs/building-wasabi/HardwareWalletTestingGuide.md
@@ -49,6 +49,6 @@ Follow this step-by-step [guide](../using-wasabi/BuildSource.md).
 
 ## Step 3: Report Results
 
-Report the results on GitHub by commenting under [this pull request](https://github.com/zkSNACKs/WalletWasabi/pull/1341).
+Report the results on GitHub by commenting under one of the following pull requests: [PR #1341](https://github.com/zkSNACKs/WalletWasabi/pull/1341) or [PR #1905](https://github.com/zkSNACKs/WalletWasabi/pull/1905).
 
 Please include your OS version and your hardware wallet type.

--- a/docs/building-wasabi/TechnicalOverview.md
+++ b/docs/building-wasabi/TechnicalOverview.md
@@ -375,7 +375,7 @@ Nevertheless [this question](https://github.com/zkSNACKs/Meta/issues/20) deserve
 
 ### Hardware Wallet
 
-Wasabi has [hardware wallet integration](https://github.com/zkSNACKs/WalletWasabi/pull/134) however in this mode CoinJoining is not possible.
+Wasabi uses the [Bitcoin Core Hardware Wallet Interface [HWI]](https://github.com/bitcoin-core/HWI) ([PR #1341](https://github.com/zkSNACKs/WalletWasabi/pull/1341) & [PR #1905](https://github.com/zkSNACKs/WalletWasabi/pull/1905)) however in this mode coinjoining is not possible.
 
 ### Bitcoin Core
 

--- a/docs/using-wasabi/PasswordBestPractices.md
+++ b/docs/using-wasabi/PasswordBestPractices.md
@@ -24,7 +24,7 @@ Rolling dice is an easy and effective way to get high entropy and randomness in 
 The Diceware method is a great strategy for your most precious passwords (e.g. the password to your computer, your backups, or your encryption key).
 You can even use Diceware to create secure wallets.
 
-To generate a password using Diceware, you just need a good di, a pen, and some paper.
+To generate a password using Diceware, you just need a good die, a pen, and some paper.
 You can find the diceware list at the [Electronic Frontier Foundation website](https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases).
 Make sure you are alone and there are no cameras nearby.
 For maximum protection, disconnect your computer from the internet (after you save the Diceware list) and cover your webcam.
@@ -112,7 +112,7 @@ Including special characters in the same password: `jW0DNro$qF` raises (C) to 95
 Example: The EFF diceware wordlist contains 7776 words.
 Randomly selecting 5 words from the list results in 7776^5 possible passphrases = 28,400,000,000,000,000,000 (28.4 quintillion).
 
-Just knowing how to do these basic calculation allows you to compare the strength of different randomly-generated passwords or phrases.
+Just knowing how to do these basic calculations allows you to compare the strength of different randomly-generated passwords or phrases.
 
 ### "Bits" of entropy
 
@@ -121,10 +121,11 @@ This is, of course, because computers can only process 0's and 1's, or bits, so 
 To calculate bits of entropy, use a [calculator that does logarithms](https://miniwebtool.com/log-base-2-calculator/?num1=7776) and compute log2(x), where x = the total number of possible outcomes for an event.
 
 For example, there are 7776 words on the EFF wordlist commonly used with dice to create passphrases.
-Plugging 7776 into the calulator to get log2(7776), it is shown that each word taken randomly from the list contributes 12.92 bits of entropy to the strength of the passphrase.
+Plugging 7776 into the calculator to get log2(7776), it is shown that each word taken randomly from the list contributes 12.92 bits of entropy to the strength of the passphrase.
 So, a 5-word passphrase selected randomly from the EFF list will have 5 x 12.92 = 64 bits of entropy.
 
 Since the combination of: lower + uppercase letters, numbers, and special characters = 95, a password constructed using all of these will have log2(95), or 6.57 bits of entropy for each character that comprises the password.
+
 From that, we can now calculate that, in order to get the same level of entropy with a password instead of a 5-word passphrase, the password must be at least 10 characters in length.
 
 ### How much entropy is needed

--- a/docs/using-wasabi/PasswordBestPractices.md
+++ b/docs/using-wasabi/PasswordBestPractices.md
@@ -24,8 +24,8 @@ Rolling dice is an easy and effective way to get high entropy and randomness in 
 The Diceware method is a great strategy for your most precious passwords (e.g. the password to your computer, your backups, or your encryption key).
 You can even use Diceware to create secure wallets.
 
-To generate a password using Diceware, you just need a good die, a pen, and some paper.
-You can find the diceware list at the [Electronic Frontier Foundation website](https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases).
+To generate a password using Diceware, you just need a high-quality die, a pen, and some paper.
+You can find EFF's Diceware list at the [Electronic Frontier Foundation website](https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases).
 Make sure you are alone and there are no cameras nearby.
 For maximum protection, disconnect your computer from the internet (after you save the Diceware list) and cover your webcam.
 
@@ -49,10 +49,12 @@ Best practices for being secure against any adversary [currently recommend](http
 
 ## Use a dictionary
 
-All of the major languages have at least 100,000 words in their dictionaries. Most have over 300,000 words.
+All of the major languages have at least 100,000 words in their dictionaries.
+Most have over 300,000 words.
 You can take a dictionary in any language that you are comfortable with and create a very strong password by randomly selecting as few as 5 words from it.
 
-The quick, but not technically random way would be to flip open your chosen dictionary to any seemingly random page, close your eyes, and put your fingertip down on the page. Choose the word nearest your fingertip that has at least 4 letters.
+The quick, but not technically random way would be to flip open your chosen dictionary to any seemingly random page, close your eyes, and put your fingertip down on the page.
+Choose the word nearest your fingertip that has at least 4 letters.
 Repeat this process at least 4 more times.
 
 If you'd prefer a truly random way to select pages, and you are using either Windows or Linux, you can easily create random numbers in a selected range (such as the number of pages in your dictionary) from your terminal.
@@ -104,12 +106,13 @@ Assuming a password or passphrase is constructed randomly, its level of entropy 
 
 - For a password, the total number of possible outcomes given a specific length (L), and number of characters used (C), is:
 C raised to the power of L, or C^L.<br>
-Example: `jwodnrosqf` is lower-case only (C = 26) and 10 characters long (L = 10). So, 26^10 = 141,000,000,000,000 (141 trillion).<br><br>
+Example: `jwodnrosqf` is lower-case only (C = 26) and 10 characters long (L = 10).
+So, 26^10 = 141,000,000,000,000 (141 trillion).<br><br>
 Including upper-case letters in the same password: `jWoDNrosqF` to double (C), results in 52^10 possible passwords = 145,000,000,000,000,000 (145 quadrillion).<br><br>
 Including special characters in the same password: `jW0DNro$qF` raises (C) to 95, resulting in 95^10 possibilities = 59,900,000,000,000,000,000 (59.9 quintillion).
 
 - For a passphrase chosen randomly from a list of words, the total number of possible outcomes given a specific number of words (N) and wordlist size (S) is: S raised to the power of N, or S^N.<br>
-Example: The EFF diceware wordlist contains 7776 words.
+Example: The EFF Diceware list contains 7776 words.
 Randomly selecting 5 words from the list results in 7776^5 possible passphrases = 28,400,000,000,000,000,000 (28.4 quintillion).
 
 Just knowing how to do these basic calculations allows you to compare the strength of different randomly-generated passwords or phrases.
@@ -118,7 +121,7 @@ Just knowing how to do these basic calculations allows you to compare the streng
 
 Password entropy is often discussed and compared in a context of `bits of entropy`.
 This is, of course, because computers can only process 0's and 1's, or bits, so everything related is expressed that way.
-To calculate bits of entropy, use a [calculator that does logarithms](https://miniwebtool.com/log-base-2-calculator/?num1=7776) and compute log2(x), where x = the total number of possible outcomes for an event.
+To calculate bits of entropy, use a [calculator that does logarithms](https://miniwebtool.com/log-base-2-calculator/) and compute log2(x), where x = the total number of possible outcomes for an event.
 
 For example, there are 7776 words on the EFF wordlist commonly used with dice to create passphrases.
 Plugging 7776 into the calculator to get log2(7776), it is shown that each word taken randomly from the list contributes 12.92 bits of entropy to the strength of the passphrase.
@@ -134,14 +137,12 @@ Entropy matters because it allows one to compare the required `search-space` of 
 In doing so, it is possible to then know how long it would take an adversary with known resources to attempt every mathematically possible password or passphrase for a given level of entropy.
 
 Edward Snowden revealed in 2013 that the NSA had the ability to guess passwords at a rate of 1 trillion guesses/second.
-At that speed of guessing, the password in the above example (28.4 quintillion possibilities) could be guessed in an average of 5 months.
+At that speed of guessing, the password in the above example (28.4 quintillion possibilities) could be guessed in at most, 11 months.
 
 Since there is an equal chance of finding the password in the first half of the total number of guesses as there is in finding it in the second half of the total number, it is accurate to assume that on average, a password will be found in 1/2 of the time required to do an exhaustive search.
-That means just over 11 months for the example just mentioned.
+That means just over 5 months for the example just mentioned.
 
 Keep in mind that Snowden's information in quite old, in a processing-power context.
 We have no way of knowing what is currently possible, so if a State-Level attacker is a part of your assumed threat-model, it would be wise to assume that their tools are now much more powerful.
 
 Even if a given threat-model does not include State-Level attackers, it is still important to consider that there are GPU-based password hacking tools publicly available that are capable of guessing well into the billions of guesses/second.
-
-

--- a/docs/using-wasabi/PasswordBestPractices.md
+++ b/docs/using-wasabi/PasswordBestPractices.md
@@ -1,0 +1,146 @@
+---
+{
+  "title": "Password Best Practices",
+  "description": "A detailed guide about how to create and evaluate a strong password. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+}
+---
+
+# Password best practices
+
+:::tip
+Don't "roll your own" crypto.
+:::
+
+You shouldn't try to re-invent the wheel for something as complicated and nuanced as cryptography, and especially in regards to entropy.
+
+These are some of the industry best practices:
+
+[[toc]]
+
+## Use Diceware
+
+Rolling dice is an easy and effective way to get high entropy and randomness in a password that can even be memorized.
+
+The Diceware method is a great strategy for your most precious passwords (e.g. the password to your computer, your backups, or your encryption key).
+You can even use Diceware to create secure wallets.
+
+To generate a password using Diceware, you just need a good di, a pen, and some paper.
+You can find the diceware list at the [Electronic Frontier Foundation website](https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases).
+Make sure you are alone and there are no cameras nearby.
+For maximum protection, disconnect your computer from the internet (after you save the Diceware list) and cover your webcam.
+
+To start, roll the die five times.
+Record the number from each roll using the pen and paper.
+You will end up with a five-digit number.
+We got `52611`.
+Now search on the Diceware list for the five digit number you just created.
+Write down the word the number corresponds to, in our case it is `salvo`.
+This word by itself is not a good password, it would only take about a thousandth of a second to crack.
+Repeat the dice rolling process at least five more times.
+
+After six sets of five rolls, we ended up with `52611` `51631` `63432` `43123` `21641` and `14146`.
+This corresponds to the password `salvo rhoda walton mudd croft bride`.
+
+This six-word passphrase, even though easy to remember, is just one of 2.21 x 10^23, or 221 sextillion possible six-word combinations taken from the list of 7776 words.
+A computer capable of 1 trillion guesses/second would take, on average, over 3500 years to correctly guess this or any six-word combination of words from the list, if they are chosen randomly.
+
+A 6-word passphrase derived as just discussed has 77 [bits of entropy](/using-wasabi/PasswordBestPractices.md#how-to-calculate-entropy).
+Best practices for being secure against any adversary [currently recommend](https://blog.securityevaluators.com/understanding-password-complexity-5e0d23643a2a) a minimum of near 80 bits of entropy, so this example phrase barely qualifies.
+
+## Use a dictionary
+
+All of the major languages have at least 100,000 words in their dictionaries. Most have over 300,000 words.
+You can take a dictionary in any language that you are comfortable with and create a very strong password by randomly selecting as few as 5 words from it.
+
+The quick, but not technically random way would be to flip open your chosen dictionary to any seemingly random page, close your eyes, and put your fingertip down on the page. Choose the word nearest your fingertip that has at least 4 letters.
+Repeat this process at least 4 more times.
+
+If you'd prefer a truly random way to select pages, and you are using either Windows or Linux, you can easily create random numbers in a selected range (such as the number of pages in your dictionary) from your terminal.
+
+Assuming your dictionary has, for example, 854 pages:
+
+Windows:
+Open a Powershell terminal and enter:
+
+```sh
+[C:\User>] get-random -maximum 854
+```
+
+Linux:
+Open a terminal and enter:
+
+```sh
+[user@you:~$] echo $(( $RANDOM % 854 ))
+```
+
+Each time you repeat this command, your operating system will return a random number somewhere in the range of available pages of your dictionary.
+
+Use this function to pick pages in a truly random manner, and select the needed words in the same way as before.
+
+Both this and the Diceware method are good ways to create a password with sufficient randomness that was generated completely off-line.
+
+## Use an open-source password manager
+
+There are several well-known, cross-platform, and open-source password managers available.
+The main requirement besides being open-source, is a cryptographically secure random number generator, with the ability to generate significant entropy while using letters, numbers, and special characters.
+
+It is recommended that you use all available characters when generating a password, and the length of the password should be at least 12 characters for minimally sufficient entropy.
+
+It is up to the user to choose between a password manager that stores its data in the cloud, making it easy to stay in sync across various devices, or one that only stores its data locally.
+
+As it so often happens, more convenience means less security in this decision.
+
+## Password entropy
+
+"Entropy" is a term commonly used to define password strength.
+It is typically used to describe the combined effect of randomness, length, and number of characters (lower-case/upper-case letters, numbers, and special characters) or words in a password or passphrase.
+
+Calculating entropy allows the strength of different randomly constructed passwords or phrases to be compared.
+It also defines the size of the search-space an attacker would need to cover to find the password by trying all possibilities.
+
+### How to calculate entropy
+
+Assuming a password or passphrase is constructed randomly, its level of entropy can be calculated in this way:
+
+- For a password, the total number of possible outcomes given a specific length (L), and number of characters used (C), is:
+C raised to the power of L, or C^L.<br>
+Example: `jwodnrosqf` is lower-case only (C = 26) and 10 characters long (L = 10). So, 26^10 = 141,000,000,000,000 (141 trillion).<br><br>
+Including upper-case letters in the same password: `jWoDNrosqF` to double (C), results in 52^10 possible passwords = 145,000,000,000,000,000 (145 quadrillion).<br><br>
+Including special characters in the same password: `jW0DNro$qF` raises (C) to 95, resulting in 95^10 possibilities = 59,900,000,000,000,000,000 (59.9 quintillion).
+
+- For a passphrase chosen randomly from a list of words, the total number of possible outcomes given a specific number of words (N) and wordlist size (S) is: S raised to the power of N, or S^N.<br>
+Example: The EFF diceware wordlist contains 7776 words.
+Randomly selecting 5 words from the list results in 7776^5 possible passphrases = 28,400,000,000,000,000,000 (28.4 quintillion).
+
+Just knowing how to do these basic calculation allows you to compare the strength of different randomly-generated passwords or phrases.
+
+### "Bits" of entropy
+
+Password entropy is often discussed and compared in a context of `bits of entropy`.
+This is, of course, because computers can only process 0's and 1's, or bits, so everything related is expressed that way.
+To calculate bits of entropy, use a [calculator that does logarithms](https://miniwebtool.com/log-base-2-calculator/?num1=7776) and compute log2(x), where x = the total number of possible outcomes for an event.
+
+For example, there are 7776 words on the EFF wordlist commonly used with dice to create passphrases.
+Plugging 7776 into the calulator to get log2(7776), it is shown that each word taken randomly from the list contributes 12.92 bits of entropy to the strength of the passphrase.
+So, a 5-word passphrase selected randomly from the EFF list will have 5 x 12.92 = 64 bits of entropy.
+
+Since the combination of: lower + uppercase letters, numbers, and special characters = 95, a password constructed using all of these will have log2(95), or 6.57 bits of entropy for each character that comprises the password.
+From that, we can now calculate that, in order to get the same level of entropy with a password instead of a 5-word passphrase, the password must be at least 10 characters in length.
+
+### How much entropy is needed
+
+Entropy matters because it allows one to compare the required `search-space` of a potential password with the `search-speed` known to be availble to various potential adversaries.
+In doing so, it is possible to then know how long it would take an adversary with known resources to attempt every mathematically possible password or passphrase for a given level of entropy.
+
+Edward Snowden revealed in 2013 that the NSA had the ability to guess passwords at a rate of 1 trillion guesses/second.
+At that speed of guessing, the password in the above example (28.4 quintillion possibilities) could be guessed in an average of 5 months.
+
+Since there is an equal chance of finding the password in the first half of the total number of guesses as there is in finding it in the second half of the total number, it is accurate to assume that on average, a password will be found in 1/2 of the time required to do an exhaustive search.
+That means just over 11 months for the example just mentioned.
+
+Keep in mind that Snowden's information in quite old, in a processing-power context.
+We have no way of knowing what is currently possible, so if a State-Level attacker is a part of your assumed threat-model, it would be wise to assume that their tools are now much more powerful.
+
+Even if a given threat-model does not include State-Level attackers, it is still important to consider that there are GPU-based password hacking tools publicly available that are capable of guessing well into the billions of guesses/second.
+
+

--- a/docs/using-wasabi/README.md
+++ b/docs/using-wasabi/README.md
@@ -48,6 +48,7 @@ Further tutorials about the different parts of the wallet, for newbies and power
 - [Cold-Wasabi Protocol](/using-wasabi/ColdWasabi.md)
 - [Headless Wasabi Daemon](/using-wasabi/Daemon.md)
 - [RPC Interface](/using-wasabi/RPC.md)
+- [Password Best Practices](/using-wasabi/PasswordBestPractices.md)
 - [Lurking Wife Mode](/using-wasabi/LurkingWifeMode.md)
 - [Supported BIPs](/using-wasabi/BIPs.md)
 

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -24,7 +24,8 @@ The very first time you run the software the `Generate Wallet` tab will be open 
 This label is not shared with anyone, it is only stored locally on your computer.
 
 3. Write a long and random password and _back it up_.
-It encrypts your secrets, and you will need it every time you want to spend bitcoin from this wallet, or recover your wallet.<br>
+It encrypts your secrets, and you will need it every time you want to spend bitcoin from this wallet, or recover your wallet.
+
 If you are uncertain about how to create a secure password, refer to [Password basics](/using-wasabi/WalletGeneration.md#password-basics) and [Password Best Practices](/using-wasabi/PasswordBestPractices.md) for helpful information.
 
 

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -24,9 +24,9 @@ The very first time you run the software the `Generate Wallet` tab will be open 
 This label is not shared with anyone, it is only stored locally on your computer.
 
 3. Write a long and random password and _back it up_.
-It encrypts your secrets, and you will need it every time you want to spend bitcoin from this wallet, or recover your wallet.
+It encrypts your secrets, and you will need it every time you want to spend bitcoin from this wallet, or recover your wallet.<br>
+If you are uncertain about how to create a secure password, refer to [Password basics](/using-wasabi/WalletGeneration.md#password-basics) and [Password Best Practices](/using-wasabi/PasswordBestPractices.md) for helpful information.
 
-Consider using [diceware wordlists](https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases) or a secure password generator to protect yourself against brute force attacks.
 
 :::danger Backup your password!
 Without the password, you cannot spend your bitcoin or recover your wallet, even if you have the recovery words (Seed phrase).
@@ -52,22 +52,17 @@ Make sure the backup of your recovery words is stored separately from the passwo
 
 ![](/WalletManagerRecoveryWords.png)
 
-7. Test the password before you can load the wallet, to make sure that your backup password is correct.
+7. You must test the password before you can load the wallet, to make sure that your backup password is correct.
 So, type or paste the password in the text box, and click `Load Wallet`.
 
 ![](/TestPassword.png)
 
-## Creating your wallet password
+## Important info about your wallet password
 
 Wasabi integrates [BIP 38: Password-Protected Private Key](/using-wasabi/BIPs.md#bip-38-password-protected-private-key), which means that the secrets needed to spend the bitcoin are encrypted on the computer.
 If someone has compromised your operating system and hardware and he only has the encrypted secrets, then no bitcoin can be spent by him.
 You need **both** the encrypted secrets, and the password in order to enable the private key which can sign a spending transaction.
 This means that the password is your last line of defense against anyone who tries to steal your bitcoin.
-
-:::tip
-A good password or passphrase should be both randomly constructed, and long.
-It is the last line of defense between an attacker and your bitcoins!
-:::
 
 ### Password basics
 
@@ -75,13 +70,8 @@ It is the last line of defense between an attacker and your bitcoins!
 This makes it impossible to crack without doing an exhaustive, "brute-force" attack.
 2. Assuming a password is constructed randomly, its length has the most impact on its strength.
 However, a password that is very long, but not randomly constructed, such as: `thequickbrownfoxjumpedoverthelazydogsback`, or a passage from literature, is certain to be on every serious hacker's guess list.
-3. "Entropy" is a term commonly used to define password strength.
-It is typically used to describe the combined effect of randomness, length, and number of characters (lower-case/upper-case letters, numbers, and special characters) or words in a password or passphrase.
-
-Calculating entropy allows the strength of different randomly constructed passwords or phrases to be compared.
-It also defines the size of the search-space an attacker would need to cover to find the password by trying all possibilities.
-
-If you are interested, there is a deeper dive into [how to calculate and evaluate entropy](/using-wasabi/WalletGeneration.md#advanced-password-analysis) later in this chapter.
+3. "Entropy" is a term commonly used to define the strength of a random password.
+There is a tutorial about how to calculate and evaluate entropy in your password [here](/using-wasabi/PasswordBestPractices.md#how-to-calculate-entropy).
 
 ### What not to do
 
@@ -100,102 +90,6 @@ Because if one password is leaked, then other ones are compromised.
 
 4. Do not take a famous quote, or well-known passage from literature and use it for a password.
 It will not fool any serious hacker, even if you throw in substitutions such as: "@" instead of "a", or "$" instead of "s".
-
-### Best practices
-
-:::tip
-Don't "roll your own" crypto.
-:::
-
-You shouldn't try to re-invent the wheel for something as complicated and nuanced as cryptography, and especially in regards to entropy.
-These are some of the industry best practices:
-
-1. Rolling dice might be the easiest way to get high entropy and randomness in numbers.
-You can also use the [Diceware tutorial](/using-wasabi/WalletGeneration.md#create-strong-passwords-with-diceware) to get something similar to your Bitcoin recovery words (Seed phrase).
-Now you have a verbal password that was generated completely off-line with sufficient randomness.
-
-2. Flip through the pages of a book, stopping on an arbitrary page and pick up one word somewhere on that page.
-Although this is not as random as a dice-roll, there is still a large set of possible words in a book.
-You can further increase the randomness by selecting different books.
-
-3. Use a well tested password manager with a cryptographically secure random number generator.
-A good password manager will use sufficient entropy to generate a password with letters, numbers and special characters.
-Although this is on-line and digital, a good password manager should still be secure enough for most cases.
-
-### Create Strong Passwords with Diceware
-
-Diceware is a great way to generate secure, random, and long passwords.
-It’s a great strategy for your most precious passwords (e.g. the password to your computer, your backups, or your encryption key).
-You can even use Diceware to create secure wallets.
-
-To generate a password using Diceware, you just need a good die and some pen and paper.
-You can find the diceware list at the [Electronic Frontier Foundation website](https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases).
-Make sure you are alone and there are no cameras nearby.
-For maximum protection, disconnect your computer from the internet (after you save the Diceware list) and cover your webcam.
-
-To start, roll the die five times.
-Record the number from each roll using the pen and paper.
-You will end up with a five-digit number.
-We got `52611`.
-Now search on the Diceware list for the five digit number you just created.
-Write down the word the number corresponds to, in our case it is `salvo`.
-This word by itself is not a good password, it would only take about a thousandth of a second to crack.
-Repeat the dice rolling process at least five more times.
-
-After six sets of five rolls, we ended up with `52611` `51631` `63432` `43123` `21641` and `14146`.
-This corresponds to the password `salvo rhoda walton mudd croft bride`.
-
-This six-word passphrase, even though easy to remember, is just one of 2.21 x 10^23, or 221 sextillion possible six-word combinations taken from the list of 7776 words.
-A computer capable of 1 trillion guesses/second would take, on average, over 3500 years to correctly guess this or any six-word combination of words from the list, if they are chosen randomly.
-
-A 6-word passphrase derived as just discussed has 77 [bits of entropy](/using-wasabi/WalletGeneration.md#advanced-password-analysis).
-Best practices for being secure against any adversary [currently recommend](https://blog.securityevaluators.com/understanding-password-complexity-5e0d23643a2a) a minimum of near 80 bits of entropy, so this example phrase barely qualifies.
-
-__Once again:__
-Keep a [secure backup](/using-wasabi/ColdWasabi.md#a-list-of-the-more-common-mediums-of-cold-storage-with-some-of-their-weaknesses) of the password, but store it in a separate location from your main 12 recovery words.
-
-### Advanced password analysis
-
-Assuming a password or passphrase is constructed randomly, its level of entropy can be calculated in this way:
-
-- For a password, the total number of possible outcomes given a specific length (L), and number of characters used (C), is:
-C raised to the power of L, or C^L.<br>
-Example: `jwodnrosqf` is lower-case only (C = 26) and 10 characters long (L = 10). So, 26^10 = 141,000,000,000,000 (141 trillion).
-
-- For a passphrase chosen randomly from a list of words, the total number of possible outcomes given a specific number of words (N) and wordlist size (S) is: S raised to the power of N, or S^N.<br>
-Example: The EFF diceware wordlist contains 7776 words.
-Randomly selecting 5 words from the list results in 7776^5 possible passphrases = 28,400,000,000,000,000,000 (28.4 quintillion).
-
-#### How Much Entropy Is Needed
-
-Entropy matters because it allows one to compare the required "search-space" of a potential password with the "search-speed" known to be availble to various potential adversaries.
-In doing so, it is possible to then know how long it would take an adversary with known resources to attempt every mathematically possible password or passphrase for a given level of entropy.
-
-Edward Snowden revealed in 2013 that the NSA had the ability to guess passwords at a rate of 1 trillion guesses/second.
-At that speed of guessing, the password in the above example (28.4 quintillion possibilities) could be guessed in an average of 5 months.
-
-Since there is an equal chance of finding the password in the first half of the total number of guesses as there is in finding it in the second half of the total number, it is accurate to assume that on average, a password will be found in 1/2 of the time required to do an exhaustive search.
-That means just over 11 months for the example just mentioned.
-
-Keep in mind that Snowden's information in quite old, in a processing-power context.
-We have no way of knowing what is currently possible, so if a State-Level attacker is a part of your assumed threat-model, it would be wise to assume that their tools are now much more powerful.
-
-Even if a given threat-model does not include State-Level attackers, it is still important to consider that there are GPU-based password hacking tools publicly available that are capable of guessing well into the billions of guesses/second.
-
-#### "Bits" of entropy
-
-Password entropy is often discussed and compared in a context of `bits of entropy`.
-This is, of course, because computers can only process 0's and 1's, or bits, so everything related is expressed that way.
-To calculate bits of entropy, use a [calculator that does logarithms](https://miniwebtool.com/log-base-2-calculator/?num1=7776) and compute log2(x), where x = the total number of possible outcomes for an event.
-
-For example, there are 7776 words on the EFF wordlist commonly used with dice to create passphrases.
-Plugging 7776 into the calulator to get log2(7776), it is shown that each word taken randomly from the list contributes 12.92 bits of entropy to the strength of the passphrase.
-So, a 5-word passphrase selected randomly from the EFF list will have 5 x 12.92 = 64 bits of entropy.
-
-A password constructed with lower and upper-case letters, numbers, and special characters will have log2(95), or 6.57 bits of entropy for each character that comprises the password.
-From that, we can now calculate that, in order to get the same level of entropy with a password instead of a 5-word passphrase, the password must be at least 10 characters in length.
-
-
 
 ## How are the secrets created
 

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -74,7 +74,7 @@ It is the last line of defense between an attacker and your bitcoins!
 1. Randomness is the single-most important requirement for a strong password, because randomness means that the password has no predictable pattern to it.
 This makes it impossible to crack without doing an exhaustive, "brute-force" attack.
 2. Assuming a password is constructed randomly, its length has the most impact on its strength.
-However, a password that is very long, but not randomly constructed, such as: "thequickbrownfoxjumpedoverthelazydogsback", or a passage from literature, is certain to be on every serious hacker's guess list.
+However, a password that is very long, but not randomly constructed, such as: `thequickbrownfoxjumpedoverthelazydogsback`, or a passage from literature, is certain to be on every serious hacker's guess list.
 3. "Entropy" is a term commonly used to define password strength.
 It is typically used to describe the combined effect of randomness, length, and number of characters (lower-case/upper-case letters, numbers, and special characters) or words in a password or passphrase.
 

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -20,7 +20,7 @@ So, with several wallets you can conveniently manage your bitcoin for different 
 1. Launch Wasabi Wallet.
 The very first time you run the software the `Generate Wallet` tab will be open automatically, but you can also access it by clicking on `File -> Generate Wallet` in the menu bar.
 
-2. Label the new wallet precisely to ensure a proper differentiation from wallets created in the future.
+2. Name the new wallet precisely to ensure a proper differentiation from wallets created in the future.
 This label is not shared with anyone, it is only stored locally on your computer.
 
 3. Write a long and random password and _back it up_.
@@ -79,7 +79,7 @@ However, a password that is very long, but not randomly constructed, such as: "t
 It is typically used to describe the combined effect of randomness, length, and number of characters (lower-case/upper-case letters, numbers, and special characters) or words in a password or passphrase.
 
 Calculating entropy allows the strength of different randomly constructed passwords or phrases to be compared.
-It also defines the size of the search-space an attacker would need cover to find the password by trying all possibilities.
+It also defines the size of the search-space an attacker would need to cover to find the password by trying all possibilities.
 
 If you are interested, there is a deeper dive into [how to calculate and evaluate entropy](/using-wasabi/WalletGeneration.md#advanced-password-analysis) later in this chapter.
 
@@ -247,5 +247,4 @@ Wasabi uses [BIP 38: Password-Protected Private Key](/using-wasabi/BIPs.md#bip-3
                   +--------------------+
 
 ```
-
 

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -198,7 +198,6 @@ The 12 seed words that create a Wasabi wallet come from a standard list of 2084 
 Knowing that, we can calculate that each word contributes log2(2084), or 11 bits of entropy, giving the entire 12 word seed 132 bits of entropy.
 At this level of entropy, an NSA-level search of 1 trillion guesses/second would take, on average, 106,398,614,554,997,456,896 years to correctly guess the seed.
 
-[Return to Password Basics](/using-wasabi/WalletGeneration.md#password-basics)
 
 ## How are the secrets created
 
@@ -247,4 +246,3 @@ Wasabi uses [BIP 38: Password-Protected Private Key](/using-wasabi/BIPs.md#bip-3
                   +--------------------+
 
 ```
-

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -165,7 +165,7 @@ Including upper-case letters in the same password: `jWoDNrosqF` to double (C), r
 
 - For a passphrase chosen randomly from a list of words, the total number of possible outcomes given a specific number of words (N) and wordlist size (S) is: S raised to the power of N, or S^N.<br>
 Example: The EFF diceware wordlist contains 7776 words.
-Randomly selecting 5 words from the list results in 7776^5 possible passphrases = 28,400,000,000,000,000,000 (28.4 quintillion) or: 2.84 x 10^19.
+Randomly selecting 5 words from the list results in 7776^5 possible passphrases = 28,400,000,000,000,000,000 (28.4 quintillion).
 
 #### How Much Entropy Is Needed
 

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -196,7 +196,6 @@ So, a 5-word passphrase selected randomly from the EFF list will have 5 x 12.92 
 A password constructed with lower and upper-case letters, numbers, and special characters will have log2(95), or 6.57 bits of entropy for each character that comprises the password.
 From that, we can now calculate that, in order to get the same level of entropy with a password instead of a 5-word passphrase, the password must be at least 10 characters in length.
 
-Knowing that, we can calculate that each word contributes log2(2084), or 11 bits of entropy, giving the entire 12 word seed 132 bits of entropy.
 
 
 ## How are the secrets created

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -142,7 +142,7 @@ Repeat the dice rolling process at least five more times.
 After six sets of five rolls, we ended up with `52611` `51631` `63432` `43123` `21641` and `14146`.
 This corresponds to the password `salvo rhoda walton mudd croft bride`.
 
-This six-word passphrase, even though easy to remember, is just one of 2.21 x 10^23, or 22.1 sextillion possible six-word combinations taken from the list of 7776 words.
+This six-word passphrase, even though easy to remember, is just one of 2.21 x 10^23, or 221 sextillion possible six-word combinations taken from the list of 7776 words.
 A computer capable of 1 trillion guesses/second would take, on average, over 3500 years to correctly guess this or any six-word combination of words from the list, if they are chosen randomly.
 
 A 6-word passphrase derived as just discussed has 77 [bits of entropy](/using-wasabi/WalletGeneration.md#advanced-password-analysis).

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -197,7 +197,6 @@ A password constructed with lower and upper-case letters, numbers, and special c
 From that, we can now calculate that, in order to get the same level of entropy with a password instead of a 5-word passphrase, the password must be at least 10 characters in length.
 
 Knowing that, we can calculate that each word contributes log2(2084), or 11 bits of entropy, giving the entire 12 word seed 132 bits of entropy.
-At this level of entropy, an NSA-level search of 1 trillion guesses/second would take, on average, 106,398,614,554,997,456,896 years to correctly guess the seed.
 
 
 ## How are the secrets created

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -196,7 +196,6 @@ So, a 5-word passphrase selected randomly from the EFF list will have 5 x 12.92 
 A password constructed with lower and upper-case letters, numbers, and special characters will have log2(95), or 6.57 bits of entropy for each character that comprises the password.
 From that, we can now calculate that, in order to get the same level of entropy with a password instead of a 5-word passphrase, the password must be at least 10 characters in length.
 
-The 12 seed words that create a Wasabi wallet come from a standard list of 2084 words.
 Knowing that, we can calculate that each word contributes log2(2084), or 11 bits of entropy, giving the entire 12 word seed 132 bits of entropy.
 At this level of entropy, an NSA-level search of 1 trillion guesses/second would take, on average, 106,398,614,554,997,456,896 years to correctly guess the seed.
 

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -7,7 +7,7 @@
 
 # Wallet Generation
 
-With Wasabi you can generate an unlimited number of Bitcoin wallets very fast, without any cost, and without asking anyone for permission.
+With Wasabi you can generate an unlimited number of Bitcoin wallets very quickly, without any cost, and without asking anyone for permission.
 Each wallet has separate private and public keys in a unique backup, and they are not at all linked to the other wallets generated on the same computer.
 So, with several wallets you can conveniently manage your bitcoin for different use cases without worrying about revealing that you control them.
 
@@ -18,13 +18,13 @@ So, with several wallets you can conveniently manage your bitcoin for different 
 ## Generating the wallet step-by-step
 
 1. Launch Wasabi Wallet.
-The very first time you run the software the `Generate Wallet` tab will automatically be open, but you can also access it by clicking on `File -> Generate Wallet` in the menu bar.
+The very first time you run the software the `Generate Wallet` tab will be open automatically, but you can also access it by clicking on `File -> Generate Wallet` in the menu bar.
 
-2. Label the new wallet precisely to ensure a proper differentiation at any point in the future.
+2. Label the new wallet precisely to ensure a proper differentiation from wallets created in the future.
 This label is not shared with anyone, it is only stored locally on your computer.
 
 3. Write a long and random password and _back it up_.
-It encrypts your secrets and you will need it every time you want to spend bitcoin from this wallet, or recover your wallet.
+It encrypts your secrets, and you will need it every time you want to spend bitcoin from this wallet, or recover your wallet.
 
 Consider using [diceware wordlists](https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases) or a secure password generator to protect yourself against brute force attacks.
 
@@ -57,7 +57,7 @@ So, type or paste the password in the text box, and click `Load Wallet`.
 
 ![](/TestPassword.png)
 
-## What password to choose
+## Creating your wallet password
 
 Wasabi integrates [BIP 38: Password-Protected Private Key](/using-wasabi/BIPs.md#bip-38-password-protected-private-key), which means that the secrets needed to spend the bitcoin are encrypted on the computer.
 If someone has compromised your operating system and hardware and he only has the encrypted secrets, then no bitcoin can be spent by him.
@@ -65,29 +65,49 @@ You need **both** the encrypted secrets, and the password in order to enable the
 This means that the password is your last line of defense against anyone who tries to steal your bitcoin.
 
 :::tip
-It is strongly recommended to use long and random passwords for everything, especially for your money!.
+A good password or passphrase should be both randomly constructed, and long.
+It is the last line of defense between an attacker and your Bitcoins!
 :::
+
+### Password basics
+
+1. Randomness is the single-most important requirement for a strong password, because randomness means that the password has no predictable pattern to it.
+This makes it impossible to crack without doing an exhaustive, "brute-force" attack.
+2. Assuming a password is constructed randomly, its length has the most impact on its strength.
+However, a password that is very long, but not randomly constructed, such as: "thequickbrownfoxjumpedoverthelazydogsback", or a passage from literature, is certain to be on every serious hacker's guess list.
+3. "Entropy" is a term commonly used to define password strength.
+It is typically used to describe the combined effect of randomness, length, and number of characters (lower-case/upper-case letters, numbers, and special characters) or words in a password or passphrase.
+
+Calculating entropy allows the strength of different randomly constructed passwords or phrases to be compared.
+It also defines the size of the search-space an attacker would need cover to find the password by trying all possibilities.
+
+If you are interested, there is a deeper dive into [how to calculate and evaluate entropy](/using-wasabi/WalletGeneration.md#advanced-password-analysis) later in this chapter.
 
 ### What not to do
 
-Here are a couple of examples that do it completely wrong. 
+Here are a few examples that do it completely wrong.
 You should not generate your password like this:
 
 1. Do not use publicly known information like your grandma's maiden name and the birthday of your dog.
 `Emma1992` is a really, really, really bad password, because it can easily be guessed and it is very short.
+Here is a list of the worst and [most commonly used passwords](https://en.wikipedia.org/wiki/List_of_the_most_common_passwords#SplashData) in recent years.
+Password hackers start with lists like this.
 
 2. Do not use the same password that you have used in other places.
 Because if one password is leaked, then other ones are compromised.
 
 3. Do try to use a mix of uppercase and lowercase letters, numbers, and special characters (&$%@ etc.) in your password.
 
-### Best Practices
+4. Do not take a famous quote, or well-known passage from literature and use it for a password.
+It will not fool any serious hacker, even if you throw in substitutions such as: "@" instead of "a", or "$" instead of "s".
 
-Don't roll your own crypto.
+### Best practices
+
+Don't "roll your own" crypto.
 You shouldn't try to re-invent the wheel for something as complicated and nuanced as cryptography, and especially in regards to entropy.
 These are some of the industry best practices:
 
-1. Rolling a dice might be the easiest way to get high entropy and randomness in numbers.
+1. Rolling dice might be the easiest way to get high entropy and randomness in numbers.
 You can also use the [Diceware tutorial](/using-wasabi/WalletGeneration.md#create-strong-passwords-with-diceware) to get something similar to your Bitcoin recovery words (Seed phrase).
 Now you have a verbal password that was generated completely off-line with sufficient randomness.
 
@@ -99,7 +119,7 @@ You can further increase the randomness by selecting different books.
 A good password manager will use sufficient entropy to generate a password with letters, numbers and special characters.
 Although this is on-line and digital, a good password manager should still be secure enough for most cases.
 
-## Create Strong Passwords with Diceware
+### Create Strong Passwords with Diceware
 
 Diceware is a great way to generate secure, random, and long passwords.
 It’s a great strategy for your most precious passwords (e.g. the password to your computer, your backups, or your encryption key).
@@ -117,15 +137,68 @@ We got `52611`.
 Now search on the Diceware list for the five digit number you just created.
 Write down the word the number corresponds to, in our case it is `salvo`.
 This word by itself is not a good password, it would only take about a thousandth of a second to crack.
-Repeat the dice rolling process at least, four times.
+Repeat the dice rolling process at least five more times.
 
-After five sets of five rolls, we ended up with `52611` `51631` `63432` `43123` `21641`.
-This corresponds to the password `salvo rhoda walton mudd croft`.
+After six sets of five rolls, we ended up with `52611` `51631` `63432` `43123` `21641` and `14146`.
+This corresponds to the password `salvo rhoda walton mudd croft bride`.
 
-It would take a single computer about six nonillion (which is 6*10^30 ) years to crack this.
-It is an unimaginably large number and for comparison, the universe is only 14 x 10 to the power of 9 years old.
-If you had a billion computers, each one a billion times stronger than the computers available today, you would still not be able to crack this password.
-Keep a [secure backup](/using-wasabi/ColdWasabi.md#a-list-of-the-more-common-mediums-of-cold-storage-with-some-of-their-weaknesses) of the password, but store it in a separate location from your main 12 recovery words.
+This six-word passphrase, even though easy to remember, is just one of 2.21 x 10^23, or 22.1 sextillion possible six-word combinations taken from the list of 7776 words.
+A computer capable of 1 trillion guesses/second would take, on average, over 3500 years to correctly guess this or any six-word combination of words from the list, if they are chosen randomly.
+
+A 6-word passphrase derived as just discussed has 77 [bits of entropy](/using-wasabi/WalletGeneration.md#advanced-password-analysis).
+Best practices for being secure against any adversary [currently recommend](https://blog.securityevaluators.com/understanding-password-complexity-5e0d23643a2a) a minimum of near 80 bits of entropy, so this example phrase barely qualifies.
+
+__Once again:__
+Keep a [secure backup](/using-wasabiColdWasabimd#a-list-of-the-more-common-mediums-of-cold-storage-with-some-of-their-weaknesses) of the password, but store it in a separate location from your main 12 recovery words.
+
+### Advanced password analysis
+
+Assuming a password or passphrase is constructed randomly, its level of entropy can be calculated in this way:
+
+- For a password, the total number of possible outcomes given a specific length (L), and number of characters used (C), is:
+C raised to the power of L, or C^L.<br>
+Example: `jwodnrosqf` is lower-case only (C = 26) and 10 characters long (L = 10). So, 26^10 = 141,000,000,000,000 (141 trillion) or: 1.41 x 10^14.<br>
+Including upper-case letters in the same password: `jWoDNrosqF` to double (C), results in 52^10 possible passwords = 145,000,000,000,000,000 (145 quadrillion) or : 1.45 x 10^17.<br>
+Including special characters in the same password: `jW0DNro$qF` raises (C) to 95, resulting in 95^10 possibilities = 59,900,000,000,000,000,000 (59.9 quintillion) or : 5.99 x 10^19.
+
+- For a passphrase chosen randomly from a list of words, the total number of possible outcomes given a specific number of words (N) and wordlist size (S) is: S raised to the power of N, or S^N.<br>
+Example: The EFF diceware wordlist contains 7776 words.
+Randomly selecting 5 words from the list results in 7776^5 possible passphrases = 28,400,000,000,000,000,000 (28.4 quintillion) or: 2.84 x 10^19.
+
+#### How Much Entropy Is Needed
+
+Entropy matters because it allows one to compare the required "search-space" of a potential password with the "search-speed" known to be availble to various potential adversaries.
+In doing so, it is possible to then know how long it would take an adversary with known resources to attempt every mathematically possible password or passphrase for a given level of entropy.
+
+Edward Snowden revealed in 2013 that the NSA had the ability to guess passwords at a rate of 1 trillion guesses/second.
+At that speed of guessing, the strongest password in the above examples (59.9 quintillion possibilities) could be guessed in a maximum of 1.9 years.
+
+Since there is an equal chance of finding the password in the first half of the total number of guesses as there is in finding it in the second half of the total number, it is accurate to assume that on average, a password will be found in 1/2 of the time required to do an exhaustive search.
+That means just over 11 months for the example just mentioned.
+
+Keep in mind that Snowden's information in quite old, in a processing-power context.
+We have no way of knowing what is currently possible, so if a State-Level attacker is a part of your assumed threat-model, it would be wise to assume that their tools are now much more powerful.
+
+Even if a given threat-model does not include State-Level attackers, it is still important to consider that there are GPU-based password hacking tools publicly available that are capable of guessing well into the billions of guesses/second.
+
+#### "Bits" of entropy
+
+Password entropy is often discussed and compared in a context of `bits of entropy`.
+This is, of course, because computers can only process 0's and 1's, or bits, so everything related is expressed that way.
+To calculate bits of entropy, use a [calculator that does logarithms](https://miniwebtool.com/log-base-2-calculator/?num1=7776) and compute log2(x), where x = the total number of possible outcomes for an event.
+
+For example, there are 7776 words on the EFF wordlist commonly used with dice to create passphrases.
+Plugging 7776 into the calulator to get log2(7776), it is shown that each word taken randomly from the list contributes 12.92 bits of entropy to the strength of the passphrase.
+So, a 5-word passphrase selected randomly from the EFF list will have 5 x 12.92 = 64 bits of entropy.
+
+A password constructed with lower and upper-case letters, numbers, and special characters will have log2(95), or 6.57 bits of entropy for each character that comprises the password.
+From that, we can now calculate that, in order to get the same level of entropy with a password instead of a 5-word passphrase, the password must be at least 10 characters in length.
+
+The 12 seed words that create a Wasabi wallet come from a standard list of 2084 words.
+Knowing that, we can calculate that each word contributes log2(2084), or 11 bits of entropy, giving the entire 12 word seed 132 bits of entropy.
+At this level of entropy, an NSA-level search of 1 trillion guesses/second would take, on average, 106,398,614,554,997,456,896 years to correctly guess the seed.
+
+[Return to Password Basics](/using-wasabi/WalletGeneration.md#password-basics)
 
 ## How are the secrets created
 
@@ -174,3 +247,5 @@ Wasabi uses [BIP 38: Password-Protected Private Key](/using-wasabi/BIPs.md#bip-3
                   +--------------------+
 
 ```
+
+

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -160,7 +160,7 @@ Assuming a password or passphrase is constructed randomly, its level of entropy 
 
 - For a password, the total number of possible outcomes given a specific length (L), and number of characters used (C), is:
 C raised to the power of L, or C^L.<br>
-Example: `jwodnrosqf` is lower-case only (C = 26) and 10 characters long (L = 10). So, 26^10 = 141,000,000,000,000 (141 trillion) or: 1.41 x 10^14.<br>
+Example: `jwodnrosqf` is lower-case only (C = 26) and 10 characters long (L = 10). So, 26^10 = 141,000,000,000,000 (141 trillion).
 Including upper-case letters in the same password: `jWoDNrosqF` to double (C), results in 52^10 possible passwords = 145,000,000,000,000,000 (145 quadrillion) or : 1.45 x 10^17.<br>
 
 - For a passphrase chosen randomly from a list of words, the total number of possible outcomes given a specific number of words (N) and wordlist size (S) is: S raised to the power of N, or S^N.<br>

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -152,7 +152,7 @@ A 6-word passphrase derived as just discussed has 77 [bits of entropy](/using-wa
 Best practices for being secure against any adversary [currently recommend](https://blog.securityevaluators.com/understanding-password-complexity-5e0d23643a2a) a minimum of near 80 bits of entropy, so this example phrase barely qualifies.
 
 __Once again:__
-Keep a [secure backup](/using-wasabiColdWasabimd#a-list-of-the-more-common-mediums-of-cold-storage-with-some-of-their-weaknesses) of the password, but store it in a separate location from your main 12 recovery words.
+Keep a [secure backup](/using-wasabi/ColdWasabi.md#a-list-of-the-more-common-mediums-of-cold-storage-with-some-of-their-weaknesses) of the password, but store it in a separate location from your main 12 recovery words.
 
 ### Advanced password analysis
 

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -162,7 +162,6 @@ Assuming a password or passphrase is constructed randomly, its level of entropy 
 C raised to the power of L, or C^L.<br>
 Example: `jwodnrosqf` is lower-case only (C = 26) and 10 characters long (L = 10). So, 26^10 = 141,000,000,000,000 (141 trillion) or: 1.41 x 10^14.<br>
 Including upper-case letters in the same password: `jWoDNrosqF` to double (C), results in 52^10 possible passwords = 145,000,000,000,000,000 (145 quadrillion) or : 1.45 x 10^17.<br>
-Including special characters in the same password: `jW0DNro$qF` raises (C) to 95, resulting in 95^10 possibilities = 59,900,000,000,000,000,000 (59.9 quintillion) or : 5.99 x 10^19.
 
 - For a passphrase chosen randomly from a list of words, the total number of possible outcomes given a specific number of words (N) and wordlist size (S) is: S raised to the power of N, or S^N.<br>
 Example: The EFF diceware wordlist contains 7776 words.

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -66,7 +66,7 @@ This means that the password is your last line of defense against anyone who tri
 
 :::tip
 A good password or passphrase should be both randomly constructed, and long.
-It is the last line of defense between an attacker and your Bitcoins!
+It is the last line of defense between an attacker and your bitcoins!
 :::
 
 ### Password basics

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -161,7 +161,6 @@ Assuming a password or passphrase is constructed randomly, its level of entropy 
 - For a password, the total number of possible outcomes given a specific length (L), and number of characters used (C), is:
 C raised to the power of L, or C^L.<br>
 Example: `jwodnrosqf` is lower-case only (C = 26) and 10 characters long (L = 10). So, 26^10 = 141,000,000,000,000 (141 trillion).
-Including upper-case letters in the same password: `jWoDNrosqF` to double (C), results in 52^10 possible passwords = 145,000,000,000,000,000 (145 quadrillion) or : 1.45 x 10^17.<br>
 
 - For a passphrase chosen randomly from a list of words, the total number of possible outcomes given a specific number of words (N) and wordlist size (S) is: S raised to the power of N, or S^N.<br>
 Example: The EFF diceware wordlist contains 7776 words.

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -103,7 +103,10 @@ It will not fool any serious hacker, even if you throw in substitutions such as:
 
 ### Best practices
 
+:::tip
 Don't "roll your own" crypto.
+:::
+
 You shouldn't try to re-invent the wheel for something as complicated and nuanced as cryptography, and especially in regards to entropy.
 These are some of the industry best practices:
 

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -173,7 +173,7 @@ Entropy matters because it allows one to compare the required "search-space" of 
 In doing so, it is possible to then know how long it would take an adversary with known resources to attempt every mathematically possible password or passphrase for a given level of entropy.
 
 Edward Snowden revealed in 2013 that the NSA had the ability to guess passwords at a rate of 1 trillion guesses/second.
-At that speed of guessing, the strongest password in the above examples (59.9 quintillion possibilities) could be guessed in a maximum of 1.9 years.
+At that speed of guessing, the password in the above example (28.4 quintillion possibilities) could be guessed in an average of 5 months.
 
 Since there is an equal chance of finding the password in the first half of the total number of guesses as there is in finding it in the second half of the total number, it is accurate to assume that on average, a password will be found in 1/2 of the time required to do an exhaustive search.
 That means just over 11 months for the example just mentioned.


### PR DESCRIPTION
The info in this chapter regarding the strength of a 5 word diceware passphrase is incorrect. This PR corrects that, and modifies it to show a more realistic example. 
Also, a section on more advanced password strength analysis is added at the bottom of the password sections for optional further reading.
