### PR TITLE
[FAQ] add Dan as maintainer

### DIFF
--- a/docs/FAQ/FAQ-Contribution.md
+++ b/docs/FAQ/FAQ-Contribution.md
@@ -46,10 +46,10 @@ Especially review by experienced C# developers are vitally important, yet even t
 There are four developers who have the ability to merge code into master branch.
 Per default, they [require at least one approving review](https://help.github.com/en/github/administering-a-repository/about-required-reviews-for-pull-requests) by one of the other maintainers before a pull request can be merged.
 However, since all three are administrators, they can still force the merge without the approval of others, but this will be noticed by many contributors.
-- [Ádám Ficsor](https://github.com/nopara73) [co-founder and former CTO of [zkSNACKs Ltd](https://zksnacks.com/), co-author of the [zero link Bitcoin fungibility framework](https://github.com/nopara73/ZeroLink)].
-- [Lucas Ontivero](https://github.com/lontivero) [lead engineer of [zkSNACKs Ltd](https://zksnacks.com/)].
-- [Dávid Molnár](https://github.com/molnard) [CTO of [zkSNACKs Ltd](https://zksnacks.com/)].
-- [Dan Walmsley](https://github.com/danwalmsley) [co-maintainer of [Avalonia](https://github.com/AvaloniaUI/Avalonia/)].
+- [Ádám Ficsor](https://github.com/nopara73) co-founder and former CTO of [zkSNACKs Ltd](https://zksnacks.com/), co-author of the [zero link Bitcoin fungibility framework](https://github.com/nopara73/ZeroLink).
+- [Lucas Ontivero](https://github.com/lontivero) lead engineer of [zkSNACKs Ltd](https://zksnacks.com/).
+- [Dávid Molnár](https://github.com/molnard) CTO of [zkSNACKs Ltd](https://zksnacks.com/).
+- [Dan Walmsley](https://github.com/danwalmsley) co-maintainer of [Avalonia](https://github.com/AvaloniaUI/Avalonia/).
 :::
 
 :::details

--- a/docs/FAQ/FAQ-Contribution.md
+++ b/docs/FAQ/FAQ-Contribution.md
@@ -43,12 +43,13 @@ The review of any Wasabika is not just deeply appreciated, but desperately neede
 Wasabi is cutting-edge, high security software, and there can never be enough eyes seeking and squashing bugs.
 Especially review by experienced C# developers are vitally important, yet even typo and grammar fixes are necessary.
 
-There are three developers who have the ability to merge code into master branch.
+There are four developers who have the ability to merge code into master branch.
 Per default, they [require at least one approving review](https://help.github.com/en/github/administering-a-repository/about-required-reviews-for-pull-requests) by one of the other maintainers before a pull request can be merged.
 However, since all three are administrators, they can still force the merge without the approval of others, but this will be noticed by many contributors.
-- [Ádám Ficsor](https://github.com/nopara73) [co-founder and former CTO of [zkSNACKs Ltd](https://zksnacks.com/), co-author of the [zero link Bitcoin fungibility framework](https://github.com/nopara73/ZeroLink)] is the [admin](https://help.github.com/en/articles/repository-permission-levels-for-an-organization) of the [Wasabi Wallet repository](https://github.com/zksnacks/walletwasabi).
-- [Lucas Ontivero](https://github.com/lontivero) [lead engineer of [zkSNACKs Ltd](https://zksnacks.com/)] is also [admin](https://help.github.com/en/articles/repository-permission-levels-for-an-organization) of the [Wasabi Wallet repository](https://github.com/zksnacks/walletwasabi).
-- [Dávid Molnár](https://github.com/molnard) [CTO of [zkSNACKs Ltd](https://zksnacks.com/)] is also [admin](https://help.github.com/en/articles/repository-permission-levels-for-an-organization) of the [Wasabi Wallet repository](https://github.com/zksnacks/walletwasabi).
+- [Ádám Ficsor](https://github.com/nopara73) [co-founder and former CTO of [zkSNACKs Ltd](https://zksnacks.com/), co-author of the [zero link Bitcoin fungibility framework](https://github.com/nopara73/ZeroLink)].
+- [Lucas Ontivero](https://github.com/lontivero) [lead engineer of [zkSNACKs Ltd](https://zksnacks.com/)].
+- [Dávid Molnár](https://github.com/molnard) [CTO of [zkSNACKs Ltd](https://zksnacks.com/)].
+- [Dan Walmsley](https://github.com/danwalmsley) [co-maintainer of [Avalonia](https://github.com/AvaloniaUI/Avalonia/)].
 :::
 
 :::details

--- a/docs/FAQ/FAQ-Contribution.md
+++ b/docs/FAQ/FAQ-Contribution.md
@@ -46,10 +46,10 @@ Especially review by experienced C# developers are vitally important, yet even t
 There are four developers who have the ability to merge code into master branch.
 Per default, they [require at least one approving review](https://help.github.com/en/github/administering-a-repository/about-required-reviews-for-pull-requests) by one of the other maintainers before a pull request can be merged.
 However, since all three are administrators, they can still force the merge without the approval of others, but this will be noticed by many contributors.
-- [Ádám Ficsor](https://github.com/nopara73) co-founder and former CTO of [zkSNACKs Ltd](https://zksnacks.com/), co-author of the [zero link Bitcoin fungibility framework](https://github.com/nopara73/ZeroLink).
-- [Lucas Ontivero](https://github.com/lontivero) lead engineer of [zkSNACKs Ltd](https://zksnacks.com/).
-- [Dávid Molnár](https://github.com/molnard) CTO of [zkSNACKs Ltd](https://zksnacks.com/).
-- [Dan Walmsley](https://github.com/danwalmsley) co-maintainer of [Avalonia](https://github.com/AvaloniaUI/Avalonia/).
+- [Ádám Ficsor](https://github.com/nopara73), co-founder and former CTO of [zkSNACKs Ltd](https://zksnacks.com/), co-author of the [zero link Bitcoin fungibility framework](https://github.com/nopara73/ZeroLink).
+- [Lucas Ontivero](https://github.com/lontivero), lead engineer of [zkSNACKs Ltd](https://zksnacks.com/).
+- [Dávid Molnár](https://github.com/molnard), CTO of [zkSNACKs Ltd](https://zksnacks.com/).
+- [Dan Walmsley](https://github.com/danwalmsley), co-maintainer of [Avalonia](https://github.com/AvaloniaUI/Avalonia/).
 :::
 
 :::details


### PR DESCRIPTION
This adds @danwalmsley as co-maintainer and admin of the main repo!
He was appointed a couple months back, as [mentioned here](https://github.com/zkSNACKs/WalletWasabi/pull/3165#issuecomment-592495642).

This also removes the redundant mention in the bullet points that all the maintainers are admins. All of them are, and this is said above.