### PR TITLE
[USING] add synchronization to load wallet

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -163,15 +163,15 @@ If yes, then the wallet connects to a random Bitcoin peer-to-peer full node over
 :::details
 ### How does Wasabi download a relevant block?
 
-Wasabi uses [BIP 158](/using-wasabi/BIPs.md#bip-158-compact-block-filters-for-light-clients) block filter to find out if a specific block contains a transaction of a specific wallet.
-If so, then by default Wasabi connects to a random Bitcoin peer to peer full node over Tor, and requests only to download this block.
-For each block, it generates a new and separate tor identity.
+There are three ways Wasabi can get a block:
 
-If you are running [your own node](/using-wasabi/BitcoinFullNode.md), then you can pull this block directly from the blockchain that you have fully verified your self.
-If the node is on the same computer, then it is connected automatically by default.
-You can also specify the local IP or tor hidden service of your remote full node.
+1. If you are connected to [your own full node](/using-wasabi/BitcoinFullNode.md) then it will fetch the block from there.
 
-The Wasabi client never downloads a block from the Wasabi backend server.
+2. By default from a random Bitcoin P2P node, connected through a new Tor identity only for this one download request.
+
+3. If both cases fail, then the fallback is to connect to the backend server with a new Tor identity and download the block there.
+
+Read more [ħere](/using-wasabi/WalletLoad.md)
 :::
 
 :::details
@@ -194,7 +194,7 @@ You have to wait until the status bar is `Ready`.
 
 It usually only takes a couple seconds to scan the block filters, and to download and parse the blocks.
 However, for large wallets with many transactions, this synchronization can take up to several minutes.
-The speed and reliability of the loading process is constantly improved.
+The speed and reliability of the loading process is constantly improved, for example a 70x increase with v1.1.11.
 For especially old wallets, it might be worth considering to generate a new wallet with a shorter transaction history.
 :::
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -169,7 +169,7 @@ There are three ways Wasabi can get a block:
 
 2. By default from a random Bitcoin P2P node, connected through a new Tor identity only for this one download request.
 
-3. If both cases fail, then the fallback is to connect to the backend server with a new Tor identity and download the block there.
+3. If both cases fail, then the fallback is to connect to the backend server with a new Tor identity and download the block from there.
 
 Read more [ħere](/using-wasabi/WalletLoad.md)
 :::
@@ -194,7 +194,7 @@ You have to wait until the status bar is `Ready`.
 
 It usually only takes a couple seconds to scan the block filters, and to download and parse the blocks.
 However, for large wallets with many transactions, this synchronization can take up to several minutes.
-The speed and reliability of the loading process is constantly improved, for example a 70x increase with v1.1.11.
+The speed and reliability of the loading process is constantly improved.
 For especially old wallets, it might be worth considering to generate a new wallet with a shorter transaction history.
 :::
 

--- a/docs/using-wasabi/WalletLoad.md
+++ b/docs/using-wasabi/WalletLoad.md
@@ -8,24 +8,48 @@
 # Wallet Load
 
 There are two ways of loading your wallets in Wasabi, and you can load multiple wallets at the same time.
+The synchronizing of your wallet happens fast and is very private by default.
 
 [[toc]]
 
 ---
 
-## Wallet Explorer
+## Loading wallet step-by-step
 
-On the right side of Wasabi is the `Wallet Explorer`, where you see an alphabetically sorted list of all the previously [generated](/using-wasabi/WalletGeneration.md) wallets.
+### Wallet Explorer
+
+1. On the right side of Wasabi is the `Wallet Explorer`, where you see an alphabetically sorted list of all the previously [generated](/using-wasabi/WalletGeneration.md) wallets.
 
 ![](/WalletExplorerUnloaded.png)
 
-You can load a wallet simply by double clicking on it or by right-clicking on it and then choosing `Load Wallet`.
+2. You can load a wallet simply by double clicking on it or by right-clicking on it and then choosing `Load Wallet`.
 A coin will appear on the wallet icon to indicate the loaded wallets.
 
 ![](/WalletExplorerLoaded.png)
 
-## Wallet Manager
+### Wallet Manager
 
-Alternatively, you can select a wallet in the `Load Wallet` tab, and click the `load wallet` button.
+3. Alternatively, you can select a wallet in the `Load Wallet` tab, and click the `load wallet` button.
 
 ![](/WalletManagerLoadWallet.png)
+
+## Synchronization
+
+### Filter download
+
+As soon as you start Wasabi, it connects to the backend server with a new Tor identity and requests the [BIP 158 block filters](/using-wasabi/BIPs.md#bip-158-compact-block-filters-for-light-clients).
+At the first start this can take a couple minutes because all filters need to be downloaded, but for the subsequent starts this is faster as only the most recent filters are requested.
+
+### Filter scanning
+
+When you load a wallet, it checks if the generated addresses within the gap limit hit against a block filter.
+Most filter do not, and then the wallet is certain that this block does not contain a transaction of yours.
+If a transaction of yours is in a block, then the corresponding filter will always be hit, and the wallet will know this is a relevant block for you.
+There can be a small chance for a false positive where the filter matches, but the block actually does not contain a transaction.
+
+### Block download
+
+When a block filter hits, either a true match or a false positive, then this block is interesting for you and the wallet will get it.
+If you have [a Bitcoin full node connected](/using-wasabi/BitcoinFullNode.md), then it will fetch the verified block locally.
+If not, then Wasabi will connect to a random Bitcoin P2P node with a new Tor identity, request only this block for download, and then disconnect.
+In this step, your Wasabi behaves like any other full node, and cannot be differentiated. 

--- a/docs/using-wasabi/WalletLoad.md
+++ b/docs/using-wasabi/WalletLoad.md
@@ -18,18 +18,18 @@ The synchronizing of your wallet happens fast and is very private by default.
 
 ### Wallet Explorer
 
-1. On the right side of Wasabi is the `Wallet Explorer`, where you see an alphabetically sorted list of all the previously [generated](/using-wasabi/WalletGeneration.md) wallets.
+On the right side of Wasabi is the `Wallet Explorer`, where you see an alphabetically sorted list of all the previously [generated](/using-wasabi/WalletGeneration.md) wallets.
 
 ![](/WalletExplorerUnloaded.png)
 
-2. You can load a wallet simply by double clicking on it or by right-clicking on it and then choosing `Load Wallet`.
+You can load a wallet simply by double clicking on it or by right-clicking on it and then choosing `Load Wallet`.
 A coin will appear on the wallet icon to indicate the loaded wallets.
 
 ![](/WalletExplorerLoaded.png)
 
 ### Wallet Manager
 
-3. Alternatively, you can select a wallet in the `Load Wallet` tab, and click the `load wallet` button.
+Alternatively, you can select a wallet in the `Load Wallet` tab, and click the `load wallet` button.
 
 ![](/WalletManagerLoadWallet.png)
 
@@ -43,13 +43,13 @@ At the first start this can take a couple minutes because all filters need to be
 ### Filter scanning
 
 When you load a wallet, it checks if the generated addresses within the gap limit hit against a block filter.
-Most filter do not, and then the wallet is certain that this block does not contain a transaction of yours.
+Most filters do not hit, and then the wallet is certain that this block does not contain a transaction of yours so it will not download it.
 If a transaction of yours is in a block, then the corresponding filter will always be hit, and the wallet will know this is a relevant block for you.
 There can be a small chance for a false positive where the filter matches, but the block actually does not contain a transaction.
 
 ### Block download
 
-When a block filter hits, either a true match or a false positive, then this block is interesting for you and the wallet will get it.
+When a block filter hits, either a true match or a false positive, then this block is important for you, so the wallet will download it.
 If you have [a Bitcoin full node connected](/using-wasabi/BitcoinFullNode.md), then it will fetch the verified block locally.
 If not, then Wasabi will connect to a random Bitcoin P2P node with a new Tor identity, request only this block for download, and then disconnect.
-In this step, your Wasabi behaves like any other full node, and cannot be differentiated. 
+In this step, your Wasabi behaves like any other full node, and cannot be differentiated.


### PR DESCRIPTION
This ready for review branch follows up on #704 and adds explanation of the synchronization when a wallet is loaded. It is similar content to the [FAQ](https://docs.wasabiwallet.io/FAQ/FAQ-UseWasabi.html#synchronization), which is also decluttered in this PR.