### PR TITLE
Update InstallPackage.md

### DIFF
--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -12,7 +12,7 @@
 ---
 
 The easiest way to start with Wasabi is to download, verify and install the released package.
-This is a version of the software that is thoroughly reviewed by the contributors and it should be stable.
+This is a version of the software that is thoroughly reviewed by the contributors.
 The package has the binary code that is needed to run the Wasabi Wallet client including the graphical user interface.
 For compiling the open source code with cutting edge development features, also including the backend server, see this [tutorial here](/using-wasabi/BuildSource.md).
 


### PR DESCRIPTION
So I'm reading through the docs and keeping sort of a "new user perspective".
I'd definitely take out the "it should be stable part"
I can totally picture the following in my mind:

The new user is going through the very first steps, and he is reading:
The easiest way to start with Wasabi is to download, verify and install the released package. This is a version of the software that is thoroughly reviewed by the contributors and it should be stable.

And he thinks to himself:
"Should be stable? What the fuck? Is it stable or not? And you tell me this in the very beginning that it's just should-be-stable?"
That's not very appealing. I get it why it was there, but the newcomer user doesn't need to know that, it's not relevant information to him. He just wants to get started.