### PR TITLE
[USING] add cd to daemon

### DIFF
--- a/docs/using-wasabi/Daemon.md
+++ b/docs/using-wasabi/Daemon.md
@@ -43,6 +43,7 @@ If the package is installed, execute in the command line in any directory:
 If the source code is built, navigate to the WalletWasabi.Gui folder (inside the cloned repo) and execute:
 
 ```bash
+~$ cd ~/WalletWasabi/WalletWasabi.Gui
 ~/WalletWasabi/WalletWasabi.Gui$ dotnet run -- mix --wallet:MyFirstWallet --destination:MySecondWallet --keepalive
 ```
 
@@ -51,12 +52,14 @@ If the source code is built, navigate to the WalletWasabi.Gui folder (inside the
 If the package is installed, navigate to the Applications directory and execute: 
 
 ```bash
+~$ cd ~/Applications/Wasabi\ Wallet.app/Contents/MacOs
 ~/Applications/Wasabi\ Wallet.app/Contents/MacOs $ wassabee mix --wallet:MyFirstWallet --destination:MySecondWallet --keepalive
 ```
 
 If the source code is built, navigate to the WalletWasabi.Gui folder (inside the cloned repo) and execute:
 
 ```bash
+~$ cd ~/WalletWasabi/WalletWasabi.Gui
 ~/WalletWasabi/WalletWasabi.Gui$ dotnet run -- mix --wallet:MyFirstWallet --destination:MySecondWallet --keepalive
 ```
 

--- a/docs/using-wasabi/Daemon.md
+++ b/docs/using-wasabi/Daemon.md
@@ -40,7 +40,7 @@ If the package is installed, execute in the command line in any directory:
 ~$ wassabee mix --wallet:MyFirstWallet --destination:MySecondWallet --keepalive
 ```
 
-If the source code is built, navigate to the WalletWasabi.Gui folder (inside the cloned repo) and execute:
+If the source code is built:
 
 ```bash
 ~$ cd ~/WalletWasabi/WalletWasabi.Gui
@@ -49,14 +49,14 @@ If the source code is built, navigate to the WalletWasabi.Gui folder (inside the
 
 ### MacOS
 
-If the package is installed, navigate to the Applications directory and execute: 
+If the package is installed:
 
 ```bash
 ~$ cd ~/Applications/Wasabi\ Wallet.app/Contents/MacOs
 ~/Applications/Wasabi\ Wallet.app/Contents/MacOs$ ./wassabee mix --wallet:MyFirstWallet --destination:MySecondWallet --keepalive
 ```
 
-If the source code is built, navigate to the WalletWasabi.Gui folder (inside the cloned repo) and execute:
+If the source code is built:
 
 ```bash
 ~$ cd ~/WalletWasabi/WalletWasabi.Gui

--- a/docs/using-wasabi/Daemon.md
+++ b/docs/using-wasabi/Daemon.md
@@ -53,7 +53,7 @@ If the package is installed, navigate to the Applications directory and execute:
 
 ```bash
 ~$ cd ~/Applications/Wasabi\ Wallet.app/Contents/MacOs
-~/Applications/Wasabi\ Wallet.app/Contents/MacOs $ wassabee mix --wallet:MyFirstWallet --destination:MySecondWallet --keepalive
+~/Applications/Wasabi\ Wallet.app/Contents/MacOs$ ./wassabee mix --wallet:MyFirstWallet --destination:MySecondWallet --keepalive
 ```
 
 If the source code is built, navigate to the WalletWasabi.Gui folder (inside the cloned repo) and execute:


### PR DESCRIPTION
This ready for review branch fixes some uncertainty of the daemon chapter, based on user reports.

mainly, it adds the `cd` instructions for macOS and Linux. @yahiheb, how do you change directory in Windows?

There are still reports it doesn't work with `wassabee mix` on Mac, even when in the Application directory. So do not yet merge, still trouble shooting.