### PR TITLE
[FAQ] Import watch only xpub wallet

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -148,7 +148,7 @@ Open the `UiConfig.json` file inside your [Wasabi data folder](/FAQ/FAQ-UseWasab
 :::details
 ### Can I import a watch-only extended public key?
 
-Yes, but not yet in the GUI, you will need to create your own wallet file.
+Yes, but not yet in the GUI, you will need to manually create a new wallet file.
 Open a text editor and paste the following wallet structure:
 
 ```

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -169,17 +169,17 @@ Open a text editor and paste the following wallet structure:
 }
 ```
 
-Then paste your extended public key inbetween the quotes of the field `"ExtPubKey": "<paste xpub here>",`.
+Then paste your extended public key in-between the quotes of the field `"ExtPubKey": "paste xpub here",`.
 You can also change the `"AccountKeyPath": "84'/0'/0'",` field if you want to import a different derivation path.
 But notice that Wasabi only works with native SegWit bech32 addresses.
 
-Save this file in your [`Wallets` data folder](/FAQ/FAQ-UseWasabi.html#where-can-i-find-the-wasabi-data-folder) with `WalletName.json`.
+Save this file in your [`Wallets` data folder](/FAQ/FAQ-UseWasabi.html#where-can-i-find-the-wasabi-data-folder) as a json file like this: `WalletName.json`.
 The `WalletName` will be displayed in the GUI.
 
 Then start Wasabi and load the wallet to synchronize it.
 For watch only wallets, the `Send` tab is disabled.
 However, you can use the `Build Transaction` tab in the `Advanced` section of the `Wallet Explorer` to build an unsigned PSBT transaction.
-When this is signed on the device with the private key (like an offline laptop running Electrum wallet), then you can use the `Broadcast Transaction` tab in the `Tools` menu.
+When this is signed on the device with the private key (like an offline laptop running Electrum wallet or a hardware wallet), then you can broadcast the signed transaction using the `Broadcast Transaction` tab in the `Tools` menu.
 :::
 
 ## Synchronization

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -145,6 +145,43 @@ Open the `UiConfig.json` file inside your [Wasabi data folder](/FAQ/FAQ-UseWasab
 ```
 :::
 
+:::details
+### Can I import a watch-only extended public key?
+
+Yes, but not yet in the GUI, you will need to create your own wallet file.
+Open a text editor and paste the following wallet structure:
+
+```
+{
+  "EncryptedSecret": null,
+  "ChainCode": null,
+  "MasterFingerprint": null,
+  "ExtPubKey": "",
+  "PasswordVerified": true,
+  "MinGapLimit": 21,
+  "AccountKeyPath": "84'/0'/0'",
+  "BlockchainState": {
+    "Network": "Main",
+    "Height": "0"
+  },
+  "HdPubKeys": [
+  ]
+}
+```
+
+Then paste your extended public key inbetween the quotes of the field `"ExtPubKey": "<paste xpub here>",`.
+You can also change the `"AccountKeyPath": "84'/0'/0'",` field if you want to import a different derivation path.
+But notice that Wasabi only works with native SegWit bech32 addresses.
+
+Save this file in your [`Wallets` data folder](/FAQ/FAQ-UseWasabi.html#where-can-i-find-the-wasabi-data-folder) with `WalletName.json`.
+The `WalletName` will be displayed in the GUI.
+
+Then start Wasabi and load the wallet to synchronize it.
+For watch only wallets, the `Send` tab is disabled.
+However, you can use the `Build Transaction` tab in the `Advanced` section of the `Wallet Explorer` to build an unsigned PSBT transaction.
+When this is signed on the device with the private key (like an offline laptop running Electrum wallet), then you can use the `Broadcast Transaction` tab in the `Tools` menu.
+:::
+
 ## Synchronization
 
 @[youtube](qguwAvA5Fx4)


### PR DESCRIPTION
This ready for review branch adds a tutorial on how to import an xpub into a wasabi watch only wallet.

I just found out it is possible, and this is awesome! 

Tested, it works.