### PR TITLE
macOS instead of MacOS

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -87,7 +87,7 @@ A secure password manager software might also be used, but be careful here.
 
 * Windows: `/Users/{your username}/AppData/Roaming/WalletWasabi/Client`
 * Linux: `/Home/.walletwasabi/client`
-* MacOS: `/Users/{your username}/.walletwasabi/client`
+* macOS: `/Users/{your username}/.walletwasabi/client`
 
 :::tip
 You need to mark the “show hidden files” setting to see it.

--- a/docs/using-wasabi/Daemon.md
+++ b/docs/using-wasabi/Daemon.md
@@ -46,7 +46,7 @@ If the source code is built, navigate to the WalletWasabi.Gui folder (inside the
 ~/WalletWasabi/WalletWasabi.Gui$ dotnet run -- mix --wallet:MyFirstWallet --destination:MySecondWallet --keepalive
 ```
 
-### MacOS
+### macOS
 
 If the package is installed, navigate to the Applications directory and execute: 
 


### PR DESCRIPTION
macOS is never written with first letter upper case.
https://www.apple.com/macos/catalina/
https://en.wikipedia.org/wiki/MacOS