### PR TITLE
[USING] fix PayJoin

### DIFF
--- a/docs/using-wasabi/BIPs.md
+++ b/docs/using-wasabi/BIPs.md
@@ -54,6 +54,15 @@ Here is a list of all the supported and integrated Bitcoin Improvement Proposals
 :::
 
 :::details
+### BIP 79: Bustapay: A Practical CoinJoin Protocol
+
+[BIP 79: Bustapay: A Practical CoinJoin Protocol](https://github.com/bitcoin/bips/blob/master/bip-0079.mediawiki)
+
+Wasabi deviates from BIP 79 in some aspects.
+The exact details of the implementation are [documented here](https://docs.btcpayserver.org/features/payjoin/payjoin-spec)
+:::
+
+:::details
 ### BIP 84: Derivation scheme for P2WPKH Based Accounts
 
 [BIP 84](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki) defines a standard derivation scheme for hierarchical deterministic wallets BIP 32, specifically for segregated witness P2WPKH [BIP 173](BIPs.md#bip-173-base32-address-format-for-native-v0-16-witness-outputs).

--- a/docs/using-wasabi/PayJoin.md
+++ b/docs/using-wasabi/PayJoin.md
@@ -32,9 +32,10 @@ Further, it reduces the transaction fees paid by the merchant due to consolidati
 ## Coordination
 
 The coordination of this CoinJoin is done with the PayToEndPoint [P2EP] concept.
-The receiver opens a Tor hidden service, and accepts incoming connections to it.
+The receiver is reachable over the internet, either over a Tor hidden service or clearnet IP address, and accepts incoming connections to it.
 The link is included in a BIP21 Bitcoin URI, and is provided to the sender as the payment invoice.
-The sender uses this hidden service to connect to the server of the receiver and communicate the further protocol.
+The sender uses this hidden service or IP address to connect to the server of the receiver and communicate the further protocol.
+The coordination is usually done within seconds, and will abort to the fallback transaction after for example two minutes if the connection breaks.
 
 ## Fallback transaction
 
@@ -66,12 +67,12 @@ The sender broadcasts this transaction to the Bitcoin network.
 
 First and foremost, the common input ownership heuristic is broken, meaning that the inputs do not belong to one single entity, but to several of them.
 This breaks one of the most important assumptions of transaction surveillance companies.
-Contrarily to other CoinJoin implementations, the outputs are not of equal value, so it is not obvious that this transaction is in fact a CoinJoin.
+Contrarily to other CoinJoin implementations, the outputs are not of equal value, so it is not obvious that this transaction is in fact a CoinJoin, and that the assumption is wrong.
 
 Further, the outputs do not reflect the actual value of the transaction.
 In our example, the economic transfer is of `0.2 bitcoin` from Alice to Bob, but the outputs are worth `0.7 bitcoin` and `0.8 bitcoin`.
 This is obfuscating the actual amount payed.
 
-Finally, the receiver is consolidating his coins, which is a way for him to save on future transaction fees.
+Finally, the receiver is consolidating his coins, thus saving on future transaction fees.
 Without the PayJoin, the receiver would have two coins, worth `0.2 bitcoin` and `0.5 bitcoin`, and he would have to pay twice the transaction fee to spend these coins.
 But because of using PayJoin, he only has one coin, worth `0.7 bitcoin`, thus reducing his future transaction costs when spending this coin.

--- a/docs/using-wasabi/PayJoin.md
+++ b/docs/using-wasabi/PayJoin.md
@@ -34,10 +34,10 @@ Wasabi diverges from [the initial BIP 79 Bustapay proposal](https://github.com/b
 ## Coordination
 
 The coordination of this CoinJoin is done with the PayToEndPoint [P2EP] concept.
-The receiver is reachable over the internet, either over a Tor hidden service or clearnet IP address, and accepts incoming connections to it.
+The receiver is reachable over the internet, either over a Tor hidden service or clearnet IP address.
 The link is included in a BIP21 Bitcoin URI, and is provided to the sender as the payment invoice.
 The sender uses this hidden service or IP address to connect to the server of the receiver and communicate the further protocol.
-The coordination is usually done within seconds, and will abort to the fallback transaction after for example two minutes if the connection breaks.
+The coordination is usually done within seconds, and will abort to the fallback transaction after some time if the connection breaks.
 
 ## Fallback transaction
 
@@ -69,7 +69,7 @@ The sender broadcasts this transaction to the Bitcoin network.
 
 First and foremost, the common input ownership heuristic is broken, meaning that the inputs do not belong to one single entity, but to several of them.
 This breaks one of the most important assumptions of transaction surveillance companies.
-Contrarily to other CoinJoin implementations, the outputs are not of equal value, so it is not obvious that this transaction is in fact a CoinJoin, and that the assumption is wrong.
+Contrarily to other CoinJoin implementations, the outputs are not of equal value, so it is not obvious that this transaction is in fact a CoinJoin.
 
 Further, the outputs do not reflect the actual value of the transaction.
 In our example, the economic transfer is of `0.2 bitcoin` from Alice to Bob, but the outputs are worth `0.7 bitcoin` and `0.8 bitcoin`.

--- a/docs/using-wasabi/PayJoin.md
+++ b/docs/using-wasabi/PayJoin.md
@@ -25,9 +25,11 @@
 
 ## The goal of PayJoin
 
-[PayJoin](https://docs.btcpayserver.org/features/payjoin/payjoin-spec) is a collaborative transaction between the sender and the receiver of a payment, for example the merchant and the customer.
+PayJoin is a collaborative transaction between the sender and the receiver of a payment, for example the merchant and the customer.
 The goal of the protocol is to break the common input ownership heuristic, while making it difficult to fingerprint that the transaction is in fact a CoinJoin.
 Further, it reduces the transaction fees paid by the merchant due to consolidation of coins.
+
+Wasabi diverges from [the initial BIP 79 Bustapay proposal](https://github.com/bitcoin/bips/blob/master/bip-0079.mediawiki), the details of the implemented specification are [documented here](https://docs.btcpayserver.org/features/payjoin/payjoin-spec).
 
 ## Coordination
 

--- a/docs/using-wasabi/PayJoin.md
+++ b/docs/using-wasabi/PayJoin.md
@@ -15,7 +15,7 @@
 
 1. Load a wallet and open the `Send` tab.
 
-2. Copy a [BIP21 Bitcoin URI](/using-wasabi/BIPs.md#bip-21-uri-scheme): with the flag `pj=` and paste it into the address field of the `Send` tab.
+2. Request from the receiver a [BIP21 Bitcoin URI](/using-wasabi/BIPs.md#bip-21-uri-scheme) with the flag `pj=` and paste it into the address field of the `Send` tab.
 
 3. Select the coins you want to send.
 


### PR DESCRIPTION
This ready for review branch adds some minor fixes to the PayJoin chapter, mainly that it works over clearnet too.
also adds a link to bip79 with a link to the btcpay spec for how our implementation differs.