### PR TITLE
[USING] explain bip 69

### DIFF
--- a/docs/using-wasabi/BIPs.md
+++ b/docs/using-wasabi/BIPs.md
@@ -138,5 +138,8 @@ This was quite brilliant of an idea at the time, but has since been proven to no
 :::details
 ### BIP 69: Lexicographical Indexing of Transaction Inputs and Outputs
 
-[BIP 69: Lexicographical Indexing of Transaction Inputs and Outputs](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki)
+[BIP 69: Lexicographical Indexing of Transaction Inputs and Outputs](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki) is a standard to sort inputs and outputs deterministically.
+This was intended to improve privacy, but it only does if all the wallets use this standard.
+Because only a minority of wallets do however, this leads to an easy wallet fingerprint.
+Thus, Wasabi doesn't support this standard.
 :::

--- a/docs/using-wasabi/BIPs.md
+++ b/docs/using-wasabi/BIPs.md
@@ -139,7 +139,7 @@ This was quite brilliant of an idea at the time, but has since been proven to no
 ### BIP 69: Lexicographical Indexing of Transaction Inputs and Outputs
 
 [BIP 69: Lexicographical Indexing of Transaction Inputs and Outputs](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki) is a standard to sort inputs and outputs deterministically.
-This was intended to improve privacy, but it only does if all the wallets use this standard.
-Because only a minority of wallets do however, this leads to an easy wallet fingerprint.
+This was intended to improve privacy, but it only does so if all wallets use this standard.
+Because only a small number of wallets do use it however, this leads to an easy wallet fingerprint.
 Thus, Wasabi doesn't support this standard.
 :::


### PR DESCRIPTION
this ready for review branch explains bip69 deterministic input output sorting, and why it is not used in wasabi.