### PR TITLE
Clickable elements too close together

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -56,7 +56,7 @@ body
     font-weight 700
 
   details
-    margin -4rem 0 0 0
+    margin -3.5rem 0 0 0
     &[open]
       > :last-child
         margin-bottom 3rem


### PR DESCRIPTION
Touch elements are so close to each other that a mobile user cannot easily tap a desired element with their finger without also tapping a neighboring element.

This was reported by Google Smartphone crawler and this PR should help overall SEO and mobile usability:
![Wasabi-docs-gsc](https://user-images.githubusercontent.com/46527252/83566495-6299bb00-a520-11ea-9523-a04e0741c66c.png)
