### PR TITLE
[USING] make clear daemon needs keepalive for destination

### DIFF
--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -171,7 +171,7 @@ Alternatively, go to the `Build Transaction` tab and do the Coldcard SD card wor
 
 ### Mix to Another Wallet
 
-Use the [daemon](/using-wasabi/Daemon.md) and run `wassabee mix --wallet:hotWasabi --destination:coldWasabi`.
+Use the [daemon](/using-wasabi/Daemon.md) and run `wassabee mix --wallet:hotWasabi --destination:coldWasabi --keepalive`.
 
 The daemon stops when all coins have reached the target anonymity set, or if you press `CTRL+C` (`CMD+C` on macOS) to stop it.
 The target anonymity set is by default `50`, but it can be changed in the `Settings` tab.

--- a/docs/using-wasabi/Daemon.md
+++ b/docs/using-wasabi/Daemon.md
@@ -26,6 +26,7 @@ This daemon is especially useful for power users mixing bitcoin in the backend o
 A coin will be coinjoined into the first wallet until anonymity set target is reached, then there will be one additional CoinJoin into the `destination` wallet.
 
 `--keepalive` keeps the daemon running after all coins have reached the anonymity set target, and continue to CoinJoin when new coins are received into the wallet.
+This flag is needed if the daemon should mix into the `destination` wallet.
 
 `--help` displays help page and exit.
 


### PR DESCRIPTION
This makes it clear that currently, the `--keepalive` flag is required for using the daemon.
This should be reverted when/if this gets changed/fixed.
https://github.com/zkSNACKs/WalletWasabi/issues/3690