### PR TITLE
Remove HWI from supported BIPs

### DIFF
--- a/docs/using-wasabi/BIPs.md
+++ b/docs/using-wasabi/BIPs.md
@@ -31,7 +31,6 @@ Here is a list of all the supported and integrated Bitcoin Improvement Proposals
 - [BIP 158: Block filters](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki)
 - [BIP 173: Base32 address format for native v0-16 witness outputs](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
 - [BIP 174: Partially Signed Bitcoin Transaction Format](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki)
-- [Hardware Wallet Interface](https://github.com/bitcoin-core/HWI)
 
 ## What is not supported
 


### PR DESCRIPTION
HWI is not a BIP and we have it in here https://docs.wasabiwallet.io/using-wasabi/IndustryStandards.html