### PR TITLE
Add Tip about fee selection to Send/MiningFees.

### DIFF
--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -111,7 +111,7 @@ If you have a transaction that is high-priority and you really want it to be con
 
 1. Go into your Wasabi `Settings` and change to `Manual Fees`.
 2. Use [a mempool monitor](https://mempool.space) to see what fees are likely to get a transaction to be confirmed in the next block.
-3. Select a fee that is well above the current highest fee....perhaps double or triple it....the extra cost is likely to be not that much, especially if it's very important to you that the transaction is confirmed soon.
+3. Select a fee that is well above the current highest fee....perhaps double or triple it....if it is very important to you that the transaction is confirmed soon.
 :::
 
 ## Custom Change Address

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -99,7 +99,7 @@ In some cases, there is very little demand for block space, and then Wasabi will
 
 :::tip High-priority transaction fees
 
-When using Bitcoin Core's `smart fee` algorithm to estimate the time a transaction will take to confirm given the current mempool, keep in mind that the algorithm can only make a fee estimate based on the mempool and fees at the time you are sending your coins.
+When using Bitcoin Core's `smart fee` algorithm to estimate the time a transaction will take to confirm given the current mempool, the algorithm considers the historic data for transactions in the mempool and in recent blocks.
 
 If, after you select the highest fee for a `send`, other people decide to send coins using even higher fees than you selected, their transactions will be placed ahead of yours in the mempool.
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -110,7 +110,7 @@ As such, a fee that is high enough to be confirmed in the next block when you cr
 If you have a transaction that is high-priority and you really want it to be confirmed ASAP:
 
 1. Go into your Wasabi `Settings` and change to `Manual Fees`.
-2. Use [a mempool monitor](https://mempool.space) to see what fees are currently being confirmed in the next block.
+2. Use [a mempool monitor](https://mempool.space) to see what fees are likely to get a transaction to be confirmed in the next block.
 3. Select a fee that is well above the current highest fee....perhaps double or triple it....the extra cost is likely to be not that much, especially if it's very important to you that the transaction is confirmed soon.
 :::
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -114,8 +114,6 @@ If you have a transaction that is high-priority and you really want it to be con
 3. Select a fee that is well above the current highest fee....perhaps double or triple it....the extra cost is likely to be not that much, especially if it's very important to you that the transaction is confirmed soon.
 :::
 
-
-
 ## Custom Change Address
 
 In the `Settings` tab you can activate the option to set a custom change address.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -110,7 +110,7 @@ As such, a fee that is high enough to be confirmed in the next block when you cr
 If you have a transaction that is high-priority and you really want it to be confirmed ASAP:
 
 1. Go into your Wasabi `Settings` and turn on `Manual fee entry`.
-2. Use [a mempool monitor](https://mempool.space) to see what fees are likely to get a transaction to be confirmed in the next block.
+2. Use [a mempool monitor](https://mempool.space) (available [Tor onion website](http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/)) to see what fees are likely to get a transaction to be confirmed in the next block.
 3. Select a fee that is well above the current highest fee....perhaps double or triple it....if it is very important to you that the transaction is confirmed soon.
 
 For a deeper dive into the fee estimation process, [this article](https://bitcointechtalk.com/an-introduction-to-bitcoin-core-fee-estimation-27920880ad0) is worth reading.

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -97,8 +97,7 @@ In some cases, there is very little demand for block space, and then Wasabi will
 
 ![](/SendNoFee.png)
 
-:::tip
-High-priority transaction fees:
+:::tip High-priority transaction fees
 
 When using Bitcoin Core's `smart fee` algorithm to estimate the time a transaction will take to confirm given the current mempool, keep in mind that the algorithm can only make a fee estimate based on the mempool and fees at the time you are sending your coins.
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -112,6 +112,8 @@ If you have a transaction that is high-priority and you really want it to be con
 1. Go into your Wasabi `Settings` and change to `Manual Fees`.
 2. Use [a mempool monitor](https://mempool.space) to see what fees are likely to get a transaction to be confirmed in the next block.
 3. Select a fee that is well above the current highest fee....perhaps double or triple it....if it is very important to you that the transaction is confirmed soon.
+
+For a deeper dive into the fee estimation process, [this article](https://bitcointechtalk.com/an-introduction-to-bitcoin-core-fee-estimation-27920880ad0) is worth reading.
 :::
 
 ## Custom Change Address

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -109,7 +109,7 @@ As such, a fee that is high enough to be confirmed in the next block when you cr
 
 If you have a transaction that is high-priority and you really want it to be confirmed ASAP:
 
-1. Go into your Wasabi `Settings` and change to `Manual Fees`.
+1. Go into your Wasabi `Settings` and turn on `Manual fee entry`.
 2. Use [a mempool monitor](https://mempool.space) to see what fees are likely to get a transaction to be confirmed in the next block.
 3. Select a fee that is well above the current highest fee....perhaps double or triple it....if it is very important to you that the transaction is confirmed soon.
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -97,6 +97,26 @@ In some cases, there is very little demand for block space, and then Wasabi will
 
 ![](/SendNoFee.png)
 
+:::tip
+High-priority transaction fees:
+
+When using Bitcoin Core's `smart fee` algorithm to estimate the time a transaction will take to confirm given the current mempool, keep in mind that the algorithm can only make a fee estimate based on the mempool and fees at the time you are sending your coins.
+
+If, after you select the highest fee for a `send`, other people decide to send coins using even higher fees than you selected, their transactions will be placed ahead of yours in the mempool.
+
+The placement of a transaction in line to be confirmed in the mempool is an ongoing auction for block space.
+
+As such, a fee that is high enough to be confirmed in the next block when you create a transaction can be outbid by people sending coins after you who also want to be in the next block, which places your transaction farther back in line to be confirmed.
+
+If you have a transaction that is high-priority and you really want it to be confirmed ASAP:
+
+1. Go into your Wasabi `Settings` and change to `Manual Fees`.
+2. Use [a mempool monitor](https://mempool.space) to see what fees are currently being confirmed in the next block.
+3. Select a fee that is well above the current highest fee....perhaps double or triple it....the extra cost is likely to be not that much, especially if it's very important to you that the transaction is confirmed soon.
+:::
+
+
+
 ## Custom Change Address
 
 In the `Settings` tab you can activate the option to set a custom change address.


### PR DESCRIPTION
The Telegram channel has been full lately with people complaining that they used the Fee Estimator to select the highest fee, yet their tx took hours or days because later tx's in the mempool had even higher fees.

It seems clear that many people dont understand that the fee/mempool process is dynamic....a continuous auction for blockspace, so what may be a high bid/fee now can easily be outbid by others, and thereby placed farther behind in the mempool.

I added a "tip" to the Mining Fee section to try to explain the process in more detail.

I thought about placing this in "Best Practices" or "Advanced", but it seemed best to me to place it where it is most relevant: Mining Fees.