### PR TITLE
Replace `hidden service` with `onion service`

### DIFF
--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -14,7 +14,7 @@
 
 It's always best to download software directly from the official source acknowledged by the developers.
 You can find the recent version of the compiled packages for Linux, Windows and Mac available on the official [wasabiwallet.io](https://wasabiwallet.io).
-In order to preserve your network level privacy from the very first step on, please consider visiting the Tor hidden service [wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
+In order to preserve your network level privacy from the very first step on, please consider visiting the Tor onion service [wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 The old versions of the software can be found in the [releases](https://github.com/zksnacks/walletwasabi/releases) of the GitHub repository, [here](https://github.com/zksnacks/walletwasabi) you also find the libre & open source code for when you want to [build it yourself](/using-wasabi/BuildSource.md).
 Please take special care to verify the PGP signatures of zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) over the software packages and code commits.
 :::
@@ -55,7 +55,7 @@ For an in-depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.md#de
 :::details
 ### How do I install Wasabi on Debian and Ubuntu?
 
-[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.deb` package and the `.deb.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
+[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.deb` package and the `.deb.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadDeb.png)
 
@@ -70,7 +70,7 @@ Check out the main documentation for a [step-by-step guide](/using-wasabi/Instal
 :::details
 ### How do I install Wasabi on other Linux?
 
-[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.tar.gz` package and the `.tar.gz.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
+[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.tar.gz` package and the `.tar.gz.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadTar.png)
 
@@ -82,7 +82,7 @@ Check out the main documentation for a [step-by-step guide](/using-wasabi/Instal
 :::details
 ### How do I install Wasabi on Windows?
 
-[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.msi` package and the `.msi.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
+[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.msi` package and the `.msi.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadWindows.png)
 
@@ -98,7 +98,7 @@ Check out the main documentation for a [step-by-step guide](/using-wasabi/Instal
 :::details
 ### How do I install Wasabi on macOS?
 
-[Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.dmg` package and the `.dmg.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
+[Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.dmg` package and the `.dmg.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadMac.png)
 

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -55,7 +55,7 @@ For an in-depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.md#de
 :::details
 ### How do I install Wasabi on Debian and Ubuntu?
 
-[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.deb` package and the `.deb.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
+[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.deb` package and the `.deb.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [Tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadDeb.png)
 
@@ -70,7 +70,7 @@ Check out the main documentation for a [step-by-step guide](/using-wasabi/Instal
 :::details
 ### How do I install Wasabi on other Linux?
 
-[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.tar.gz` package and the `.tar.gz.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
+[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.tar.gz` package and the `.tar.gz.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [Tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadTar.png)
 
@@ -82,7 +82,7 @@ Check out the main documentation for a [step-by-step guide](/using-wasabi/Instal
 :::details
 ### How do I install Wasabi on Windows?
 
-[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.msi` package and the `.msi.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
+[Download](/FAQ/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.msi` package and the `.msi.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [Tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadWindows.png)
 
@@ -98,7 +98,7 @@ Check out the main documentation for a [step-by-step guide](/using-wasabi/Instal
 :::details
 ### How do I install Wasabi on macOS?
 
-[Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.dmg` package and the `.dmg.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
+[Download](/FAQ-Installation.md#where-can-i-download-wasabi) the most recent `.dmg` package and the `.dmg.asc` signature file from the [wasabiwallet.io](https://wasabiwallet.io) or the [Tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 
 ![](/DownloadMac.png)
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -625,7 +625,7 @@ Wasabi will automatically build a transaction with the best combination of the s
 :::details
 ### How is the transaction broadcast?
 
-Wasabi connects only to Bitcoin nodes that provide a Tor hidden service, so end-to-end encryption is enforced between the peers, without involving any exit node.
+Wasabi connects only to Bitcoin nodes that provide a Tor onion service, so end-to-end encryption is enforced between the peers, without involving any exit node.
 Each peer is connected to through a different Tor stream.
 Transactions are broadcast to only one random peer over Tor and immediately after that this peer is disconnected.
 
@@ -1319,7 +1319,7 @@ You can use the [Wasabi RPC server `gethistory` call](/using-wasabi/RPC.md#gethi
 There are three different ways of using your [Bitcoin full node with Wasabi](/using-wasabi/BitcoinFullNode.md):
 
 - If you have a full node already running on the same computer as Wasabi, it will automatically be detected and used by default.
-- If you have a full node on a remote computer, then you can connect to it by specifying the local network IP address or Tor hidden service in the Wasabi `Settings` tab.
+- If you have a full node on a remote computer, then you can connect to it by specifying the local network IP address or Tor onion service in the Wasabi `Settings` tab.
 
 ![](/SettingsBitcoinCoreRemote.png)
 

--- a/docs/building-wasabi/TechnicalOverview.md
+++ b/docs/building-wasabi/TechnicalOverview.md
@@ -83,7 +83,7 @@ The user can also opt to use their own Tor instance.
 All Internet traffic goes through Tor, and by default all this traffic stays inside the onion network.
 Exit nodes are only involved in fallback scenarios.
 
-For example, if the Tor hidden service of the backend becomes unavailable for the user, the wallet falls back to communicating with the backend's clearnet endpoint, still over Tor.
+For example, if the Tor onion service of the backend becomes unavailable for the user, the wallet falls back to communicating with the backend's clearnet endpoint, still over Tor.
 Wasabi also frequently utilizes multiple Tor streams where applicable.
 
 Importantly, registration of CoinJoin inputs and outputs is done through different Tor streams to avoid linking.

--- a/docs/glossary/Glossary-PrivacyWasabi.md
+++ b/docs/glossary/Glossary-PrivacyWasabi.md
@@ -156,7 +156,7 @@ Read more: [The importance of labeling](/using-wasabi/Receive.md#the-importance-
 ### Pay to EndPoint (P2EP)
 
 Pay to EndPoint is when the receiver is reachable over the internet and the sender communicates with the receiver to coordinate a more advanced transaction.
-The Tor hidden service, IP address or domain of the receiver is included in a BIP21 Bitcoin URI payment link.
+The Tor onion service, IP address or domain of the receiver is included in a BIP21 Bitcoin URI payment link.
 :::
 
 :::details

--- a/docs/using-wasabi/10Commandments.md
+++ b/docs/using-wasabi/10Commandments.md
@@ -17,7 +17,7 @@ Wasabi is a powerful free and open-source Bitcoin wallet, and it is used to prot
 
 ## 2. Verify the integrity of your software
 
-When installing the wallet, you may choose to [download the package](/using-wasabi/InstallPackage.md) from the official [clearnet](https://wasabiwallet.io) or the [tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion), or to [compile the source code](/using-wasabi/BuildSource.md) from the official [GitHub repository](https://github.com/zkSNACKs/WalletWasabi)
+When installing the wallet, you may choose to [download the package](/using-wasabi/InstallPackage.md) from the official [clearnet](https://wasabiwallet.io) or the [tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion), or to [compile the source code](/using-wasabi/BuildSource.md) from the official [GitHub repository](https://github.com/zkSNACKs/WalletWasabi)
 Please [verify the signatures](/using-wasabi/InstallPackage.md) after completing downloads.
 The concern here is that you may accidentally fall for a phishing attempt and be on a malicious site downloading a malicious piece of software.
 

--- a/docs/using-wasabi/10Commandments.md
+++ b/docs/using-wasabi/10Commandments.md
@@ -17,7 +17,7 @@ Wasabi is a powerful free and open-source Bitcoin wallet, and it is used to prot
 
 ## 2. Verify the integrity of your software
 
-When installing the wallet, you may choose to [download the package](/using-wasabi/InstallPackage.md) from the official [clearnet](https://wasabiwallet.io) or the [tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion), or to [compile the source code](/using-wasabi/BuildSource.md) from the official [GitHub repository](https://github.com/zkSNACKs/WalletWasabi)
+When installing the wallet, you may choose to [download the package](/using-wasabi/InstallPackage.md) from the official [clearnet](https://wasabiwallet.io) or the [Tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion), or to [compile the source code](/using-wasabi/BuildSource.md) from the official [GitHub repository](https://github.com/zkSNACKs/WalletWasabi)
 Please [verify the signatures](/using-wasabi/InstallPackage.md) after completing downloads.
 The concern here is that you may accidentally fall for a phishing attempt and be on a malicious site downloading a malicious piece of software.
 

--- a/docs/using-wasabi/BitcoinFullNode.md
+++ b/docs/using-wasabi/BitcoinFullNode.md
@@ -67,7 +67,7 @@ This is especially useful to save on bandwidth, as you have already downloaded a
 ## Using an already existing remote Bitcoin full node
 
 If you have a Bitcoin full node already on a remote computer, then Wasabi Wallet can use this, too.
-In the settings specify the local IP address and port, or the tor hidden service .onion of your full node.
+In the settings specify the local IP address and port, or the tor onion service of your full node.
 
 ![](/SettingsBitcoinCoreRemote.png)
 

--- a/docs/using-wasabi/BitcoinFullNode.md
+++ b/docs/using-wasabi/BitcoinFullNode.md
@@ -67,7 +67,7 @@ This is especially useful to save on bandwidth, as you have already downloaded a
 ## Using an already existing remote Bitcoin full node
 
 If you have a Bitcoin full node already on a remote computer, then Wasabi Wallet can use this, too.
-In the settings specify the local IP address and port, or the tor onion service of your full node.
+In the settings specify the local IP address and port, or the Tor onion service of your full node.
 
 ![](/SettingsBitcoinCoreRemote.png)
 

--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -16,7 +16,7 @@ This is a version of the software that is thoroughly reviewed by the contributor
 The package has the binary code that is needed to run the Wasabi Wallet client including the graphical user interface.
 For compiling the open-source code with cutting edge development features, also including the backend server, see this [tutorial here](/using-wasabi/BuildSource.md).
 
-Download the packages either from the official [WasabiWallet.io](https://wasabiwallet.io/) clearnet website or for your privacy's sake, from the official tor onion service [http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/).
+Download the packages either from the official [WasabiWallet.io](https://wasabiwallet.io/) clearnet website or for your privacy's sake, from the official Tor onion service [http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/).
 
 ![](/DownloadAll.png)
 

--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -16,7 +16,7 @@ This is a version of the software that is thoroughly reviewed by the contributor
 The package has the binary code that is needed to run the Wasabi Wallet client including the graphical user interface.
 For compiling the open-source code with cutting edge development features, also including the backend server, see this [tutorial here](/using-wasabi/BuildSource.md).
 
-Download the packages either from the official [WasabiWallet.io](https://wasabiwallet.io/) clearnet website or for your privacy's sake, from the official tor hidden service [http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/).
+Download the packages either from the official [WasabiWallet.io](https://wasabiwallet.io/) clearnet website or for your privacy's sake, from the official tor onion service [http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/).
 
 ![](/DownloadAll.png)
 

--- a/docs/using-wasabi/PayJoin.md
+++ b/docs/using-wasabi/PayJoin.md
@@ -35,9 +35,9 @@ The details of the implemented specification are documented [here](https://docs.
 ## Coordination
 
 The coordination of this CoinJoin is done with the PayToEndPoint [P2EP] concept.
-The receiver is reachable over the internet, either over a Tor hidden service or clearnet IP address.
+The receiver is reachable over the internet, either over a Tor onion service or clearnet IP address.
 The link is included in a BIP21 Bitcoin URI, and is provided to the sender as the payment invoice.
-The sender uses this hidden service or IP address to connect to the server of the receiver and communicate the further protocol.
+The sender uses this onion service or IP address to connect to the server of the receiver and communicate the further protocol.
 The coordination is usually done within seconds, and will abort to the fallback transaction after some time if the connection breaks.
 
 ## Fallback transaction

--- a/docs/using-wasabi/WasabiSetupTails.md
+++ b/docs/using-wasabi/WasabiSetupTails.md
@@ -32,7 +32,7 @@ This way, you can launch Wasabi from the terminal via `./wassabee` command, and 
 
 ## Download
 
-Download Wasabi for Debian/Ubuntu from the [Tor hidden service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion) or [clearnet](https://www.wasabiwallet.io/#download).
+Download Wasabi for Debian/Ubuntu from the [Tor onion service](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion) or [clearnet](https://www.wasabiwallet.io/#download).
 
 Verify the PGP signature of the downloaded package, the zkSNACKs' PGP public key fingerprint is:
 

--- a/docs/why-wasabi/NetworkLevelPrivacy.md
+++ b/docs/why-wasabi/NetworkLevelPrivacy.md
@@ -42,7 +42,7 @@ This means that by default, all network communication is secured from outside sn
 
 In order to fully verify everything, running a full node is essential.
 If [bitcoind](https://github.com/bitcoin/bitcoin) is installed and run on the same computer as Wasabi, then it will automatically and by default connect to the full node.
-It is also possible to connect Wasabi to a remote full node on another computer by specifying the local IP address or Tor hidden service in the settings.
+It is also possible to connect Wasabi to a remote full node on another computer by specifying the local IP address or Tor onion service in the settings.
 Then, Wasabi pulls the verified blocks and queries the mempool from the full node.
 
 :::tip Wasabi ships with Bitcoin Knots!


### PR DESCRIPTION
For a couple of years, Tor documentation has made the term `hidden service` obsolete, in favor of `onion service`: [Tor Project | Onion Services](https://community.torproject.org/onion-services/)

This PR updates references for Payjoin alerts.

Follows https://github.com/zkSNACKs/WalletWasabi/pull/4111