### PR TITLE
Fix title, description and add h1 in glossary

### DIFF
--- a/docs/glossary/Glossary-GeneralBitcoin.md
+++ b/docs/glossary/Glossary-GeneralBitcoin.md
@@ -1,11 +1,11 @@
 ---
 {
-  "title": "Bitcoin in general",
-  "description": "Explanations of common words used in Wasabi and regarding Bitcoin privacy with links to the docs for more details. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+  "title": "Bitcoin Glossary",
+  "description": "Explanations of common words used in Bitcoin. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
 }
 ---
 
-## Bitcoin in general
+# Bitcoin Glossary
 
 :::details
 ### Address

--- a/docs/glossary/Glossary-PrivacyWasabi.md
+++ b/docs/glossary/Glossary-PrivacyWasabi.md
@@ -1,7 +1,7 @@
 ---
 {
   "title": "Privacy and Wasabi",
-  "description": "Explanations of common words regarding Bitcoin privacy. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+  "description": "Explanations of common words regarding Wasabi and Bitcoin privacy. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
 }
 ---
 

--- a/docs/glossary/Glossary-PrivacyWasabi.md
+++ b/docs/glossary/Glossary-PrivacyWasabi.md
@@ -1,6 +1,6 @@
 ---
 {
-  "title": "Privacy and Wasabi",
+  "title": "Wasabi and Bitcoin privacy Glossary",
   "description": "Explanations of common words regarding Wasabi and Bitcoin privacy. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
 }
 ---

--- a/docs/glossary/Glossary-PrivacyWasabi.md
+++ b/docs/glossary/Glossary-PrivacyWasabi.md
@@ -1,11 +1,11 @@
 ---
 {
   "title": "Privacy and Wasabi",
-  "description": "Explanations of common words used in Wasabi and regarding Bitcoin privacy with links to the docs for more details. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
+  "description": "Explanations of common words regarding Bitcoin privacy. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
 }
 ---
 
-## Privacy and Wasabi
+# Privacy and Wasabi Glossary
 
 :::details
 ### #twoweeks


### PR DESCRIPTION
The `<h1>` tag was missing because we used `##` (h2) for the title. I also optimized title and description.
(SEO)