### PR TITLE
Update .NET 5.0 sdk

### DIFF
--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -176,7 +176,7 @@ There's no difference in the code, the same binaries are being delivered in diff
 
 If you cannot wait until the next release, and you want to experience the most cutting-edge version of Wasabi, then you can [build the source code](/using-wasabi/BuildSource.md).
 
-The only two required tools are [Git](https://git-scm.com/downloads) and [.NET ${dotnetVersion} SDK](https://www.microsoft.com/net/download) for "Building Apps".
+The only two required tools are [Git](https://git-scm.com/downloads) and [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for "Build Apps".
 You can download every line of the Wasabi code by `git clone https://github.com/zkSNACKs/WalletWasabi.git`, this will create a new directory called `WalletWasabi`.
 In order to build and run the Wallet software, change directory to `cd WalletWasabi/WalletWasabi.Gui`.
 Wasabi is written in C# with the .NET framework, and it is very easy to run it.

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -176,7 +176,7 @@ There's no difference in the code, the same binaries are being delivered in diff
 
 If you cannot wait until the next release, and you want to experience the most cutting-edge version of Wasabi, then you can [build the source code](/using-wasabi/BuildSource.md).
 
-The only two required tools are [Git](https://git-scm.com/downloads) and [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for "Build Apps".
+The only two required tools are [Git](https://git-scm.com/downloads) and [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download) for "Build apps".
 You can download every line of the Wasabi code by `git clone https://github.com/zkSNACKs/WalletWasabi.git`, this will create a new directory called `WalletWasabi`.
 In order to build and run the Wallet software, change directory to `cd WalletWasabi/WalletWasabi.Gui`.
 Wasabi is written in C# with the .NET framework, and it is very easy to run it.

--- a/docs/using-wasabi/BuildSource.md
+++ b/docs/using-wasabi/BuildSource.md
@@ -19,7 +19,7 @@ Be aware that these branches might be unstable and can include bugs that lead to
 ## Get The Requirements
 
 1. Install [Git](https://git-scm.com/downloads)
-2. Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for "Build Apps"
+2. Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download) for "Build apps"
 
 	:::tip Optional for privacy
 	You can disable .NET's telemetry, which is sending some usage information to Microsoft, by typing:

--- a/docs/using-wasabi/BuildSource.md
+++ b/docs/using-wasabi/BuildSource.md
@@ -19,7 +19,7 @@ Be aware that these branches might be unstable and can include bugs that lead to
 ## Get The Requirements
 
 1. Install [Git](https://git-scm.com/downloads)
-2. Install [.NET ${dotnetVersion} SDK](https://www.microsoft.com/net/download) for "Building Apps"
+2. Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for "Build Apps"
 
 	:::tip Optional for privacy
 	You can disable .NET's telemetry, which is sending some usage information to Microsoft, by typing:

--- a/docs/using-wasabi/WasabiSetupVM.md
+++ b/docs/using-wasabi/WasabiSetupVM.md
@@ -67,7 +67,7 @@ Update the `template-wasabi`.
 [user@template-wasabi ~]$ sudo apt dist-upgrade
 ```
 
-Install [.NET ${dotnetVersion} SDK](https://www.microsoft.com/net/download) for "Building Apps" in `template-wasabi`.
+Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for "Build Apps" in `template-wasabi`.
 
 :::tip Optional for privacy
 You can disable .NET's telemetry, which is sending some usage information to Microsoft:
@@ -192,7 +192,7 @@ Finally, you can add any other tools that you prefer, such as Visual Studio / Vi
 
 Start your template VM and open a terminal window.
 
-Install [.NET ${dotnetVersion} SDK](https://www.microsoft.com/net/download) for "Building Apps".
+Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for "Build Apps".
 
 :::tip Optional for privacy
 You can disable .NET's telemetry, which is sending some usage information to Microsoft.

--- a/docs/using-wasabi/WasabiSetupVM.md
+++ b/docs/using-wasabi/WasabiSetupVM.md
@@ -67,7 +67,7 @@ Update the `template-wasabi`.
 [user@template-wasabi ~]$ sudo apt dist-upgrade
 ```
 
-Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for "Build Apps" in `template-wasabi`.
+Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download) for "Build apps" in `template-wasabi`.
 
 :::tip Optional for privacy
 You can disable .NET's telemetry, which is sending some usage information to Microsoft:

--- a/docs/using-wasabi/WasabiSetupVM.md
+++ b/docs/using-wasabi/WasabiSetupVM.md
@@ -192,7 +192,7 @@ Finally, you can add any other tools that you prefer, such as Visual Studio / Vi
 
 Start your template VM and open a terminal window.
 
-Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for "Build Apps".
+Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download) for "Build apps".
 
 :::tip Optional for privacy
 You can disable .NET's telemetry, which is sending some usage information to Microsoft.

--- a/docs/using-wasabi/WasabiSetupWhonix.md
+++ b/docs/using-wasabi/WasabiSetupWhonix.md
@@ -158,7 +158,7 @@ Then, make sure that the VM is updated.
 [user@whonix-template ~]$ sudo apt-get dist-upgrade
 ```
 
-Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for "Build Apps" in the `whonix-template`.
+Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download) for "Build apps" in the `whonix-template`.
 
 :::tip Optional for privacy
 To disable .NET's telemetry, which sends some usage information to Microsoft:

--- a/docs/using-wasabi/WasabiSetupWhonix.md
+++ b/docs/using-wasabi/WasabiSetupWhonix.md
@@ -158,7 +158,7 @@ Then, make sure that the VM is updated.
 [user@whonix-template ~]$ sudo apt-get dist-upgrade
 ```
 
-Install [.NET ${dotnetVersion} SDK](https://www.microsoft.com/net/download) for "Building Apps" in the `whonix-template`.
+Install [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for "Build Apps" in the `whonix-template`.
 
 :::tip Optional for privacy
 To disable .NET's telemetry, which sends some usage information to Microsoft:


### PR DESCRIPTION
This PR updates links and replace `Building Apps` to `Build Apps`.
After https://github.com/zkSNACKs/WalletWasabi/issues/5067, I realized that Microsoft changed the .NET download landing page and they removed the SDK/Building Apps section.

After this PR, links are correct and the user can easily find the `Build Apps` column.