### PR TITLE
add WabiSabi to glossary

### DIFF
--- a/docs/glossary/Glossary-PrivacyWasabi.md
+++ b/docs/glossary/Glossary-PrivacyWasabi.md
@@ -226,6 +226,7 @@ Similarly, Tumbler is the synonym of 'Mixer'.
 
 WabiSabi is a protocol for constructing coinjoin transactions with the aid of a centralized coordinator.
 It utilizes keyed-verification anonymous credentials, homomorphic value commitments, and zero knowledge proofs to achieve privacy and flexibility.
+Read more: [WabiSabi](https://github.com/zkSNACKs/WabiSabi)
 :::
 
 :::details

--- a/docs/glossary/Glossary-PrivacyWasabi.md
+++ b/docs/glossary/Glossary-PrivacyWasabi.md
@@ -222,6 +222,13 @@ Similarly, Tumbler is the synonym of 'Mixer'.
 :::
 
 :::details
+### WabiSabi
+
+WabiSabi is a protocol for constructing coinjoin transactions with the aid of a centralized coordinator.
+It utilizes keyed-verification anonymous credentials, homomorphic value commitments, and zero knowledge proofs to achieve privacy and flexibility.
+:::
+
+:::details
 ### Wallet fingerprinting
 
 A careful analyst sometimes deduces which software created a certain transaction, because many different wallet softwares don't always create transactions in exactly the same way.

--- a/docs/glossary/Glossary-PrivacyWasabi.md
+++ b/docs/glossary/Glossary-PrivacyWasabi.md
@@ -226,7 +226,7 @@ Similarly, Tumbler is the synonym of 'Mixer'.
 
 WabiSabi is a protocol for constructing coinjoin transactions with the aid of a centralized coordinator.
 It utilizes keyed-verification anonymous credentials, homomorphic value commitments, and zero knowledge proofs to achieve privacy and flexibility.
-Read more: [WabiSabi](https://github.com/zkSNACKs/WabiSabi)
+Read more: [WabiSabi](https://github.com/zkSNACKs/WabiSabi/releases/latest/download/WabiSabi.pdf)
 :::
 
 :::details


### PR DESCRIPTION
the `Read more` could link to a future explainer in the docs
I think it is ok for now.