### PR TITLE
Rename Download&Install back to InstallPackage

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -165,7 +165,7 @@ module.exports = {
           collapsable: false,
           sidebarDepth: 2,
           children: [
-            "/using-wasabi/Download&Install.md",
+            "/using-wasabi/InstallPackage.md",
             "/using-wasabi/BuildSource.md"
           ]
         },

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -47,7 +47,7 @@ Ensure that you also download the separate signature `.asc` file.
 In the terminal, change the directory to the one with the downloaded files, and verify the signature with `gpg --verify Wasabi-${currentVersion}.deb.asc`.
 Everything is valid if it returns `Good signature from zkSNACKs` and that it was signed with the `Primary key fingerprint: ${zksnacksPublicKeyFingerprint}`.
 
-For an in-depth guide for [Debian and Ubuntu](/using-wasabi/Download&Install.md#debian-and-ubuntu), [other Linux](/using-wasabi/Download&Install.md#other-linux), [Windows](/using-wasabi/Download&Install.md#windows), and [macOS](/using-wasabi/Download&Install.md#macOS) see the main documentation.
+For an in-depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.md#debian-and-ubuntu), [other Linux](/using-wasabi/InstallPackage.md#other-linux), [Windows](/using-wasabi/InstallPackage.md#windows), and [macOS](/using-wasabi/InstallPackage.md#macOS) see the main documentation.
 
 @[youtube](mTrClVA_o5A)
 :::
@@ -62,7 +62,7 @@ For an in-depth guide for [Debian and Ubuntu](/using-wasabi/Download&Install.md#
 Verify the signature of the package with `gpg --verify Wasabi-${currentVersion}.deb` and ensure the software was signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 
 Now install Wasabi with `sudo dpkg -i Wasabi-${currentVersion}.deb`, and run it with `wassabee`.
-Check out the main documentation for a [step-by-step guide](/using-wasabi/Download&Install.md#debian-and-ubuntu).
+Check out the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#debian-and-ubuntu).
 
 @[youtube](mTrClVA_o5A,122)
 :::
@@ -76,7 +76,7 @@ Check out the main documentation for a [step-by-step guide](/using-wasabi/Downlo
 
 Verify the signature of the package with `gpg --verify Wasabi-${currentVersion}.tar.gz.asc` and ensure the software was signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi with `sudo tar -pxzf Wasabi-${currentVersion}.tar.gz`, and run it with `./wassabee`.
-Check out the main documentation for a [step-by-step guide](/using-wasabi/Download&Install.md#other-linux).
+Check out the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#other-linux).
 :::
 
 :::details
@@ -92,7 +92,7 @@ The Wasabi package is signed and automatically verified on Windows upon installa
 
 Optionally, you can still verify the PGP signature of the package by `right-clicking on the signature file > More GpgEX options > Verify` and ensure the software was signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi by double-clicking the `.msi` file.
-Check out the main documentation for a [step-by-step guide](/using-wasabi/Download&Install.md#windows).
+Check out the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#windows).
 :::
 
 :::details
@@ -106,7 +106,7 @@ The Wasabi package is signed and automatically verified on macOS upon installati
 
 Optionally, you can still verify the PGP signature of the package with `sudo gpg2 --verify Wasabi-${currentVersion}.dmg.asc` and ensure that the software has been signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi by double-clicking the `.dmg` file.
-Check out the main documentation for a [step-by-step guide](/using-wasabi/Download&Install.md#mac).
+Check out the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#mac).
 
 @[youtube](_Zmc54XYzBA)
 :::
@@ -148,7 +148,7 @@ It will also be announced on [Twitter](https://twitter.com/wasabiwallet) and [Re
 
 You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
 Make sure you also download the signatures of the build and verify them with [zkSNACKs' PGP public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
-For step-by-step instructions, follow [this guide](/using-wasabi/Download&Install.md) or [see this video](https://youtu.be/DUc9A76rwX4).
+For step-by-step instructions, follow [this guide](/using-wasabi/InstallPackage.md) or [see this video](https://youtu.be/DUc9A76rwX4).
 :::
 
 :::details

--- a/docs/using-wasabi/ELI5.md
+++ b/docs/using-wasabi/ELI5.md
@@ -29,7 +29,7 @@ Installing Wasabi is super-easy.
 Go to the official website [wasabiwallet.io](https://wasabiwallet.io) and download the version for your operating system.
 You can then install Wasabi as you would do any other software on your computer.
 
-See [this chapter](/using-wasabi/Download&Install.md) for a detailed step-by-step tutorial for all operating systems, and also how to verify the PGP signature.
+See [this chapter](/using-wasabi/InstallPackage.md) for a detailed step-by-step tutorial for all operating systems, and also how to verify the PGP signature.
 
 ## Generating a Wallet
 

--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -1,11 +1,11 @@
 ---
 {
-  "title": "Download & Install",
+  "title": "Install-package",
   "description": "A step by step guide on how to securely download, verify and install the software packages of Wasabi for Linux, Windows and Mac. This is the Wasabi documentation, an archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop."
 }
 ---
 
-# Download & Install
+# Install package
 
 [[toc]]
 

--- a/docs/using-wasabi/README.md
+++ b/docs/using-wasabi/README.md
@@ -19,7 +19,7 @@ Further tutorials about the different parts of the wallet, for newbies and power
 - [Explain Wasabi like I'm 5](/using-wasabi/ELI5.md)
 
 ### Installing Wasabi
-- [Download & Install](/using-wasabi/Download&Install.md)
+- [Install package](/using-wasabi/InstallPackage.md)
 - [Build from source code](/using-wasabi/BuildSource.md)
 
 ### Using Wasabi

--- a/docs/using-wasabi/WasabiSetupVM.md
+++ b/docs/using-wasabi/WasabiSetupVM.md
@@ -136,7 +136,7 @@ There are no additional dependencies required, so the App VM can be based on `te
 [user@dom0 ~]$ qvm-run -a package-wasabi gnome-terminal
 ```
 
-[Download, verify and install](/using-wasabi/Download&Install.md#debian-and-ubuntu) the latest `Wasabi-${currentVersion}.deb` package in `package-wasabi`, then start Wasabi.
+[Download, verify and install](/using-wasabi/InstallPackage.md#debian-and-ubuntu) the latest `Wasabi-${currentVersion}.deb` package in `package-wasabi`, then start Wasabi.
 
 ```sh
 [user@package-wasabi ~]$ wassabee
@@ -259,6 +259,6 @@ Alternatively, you can also install the package in a new VM.
 This is a stable version suitable to use on mainnet and is separated from the development VM.
 There are no additional dependencies required to run this version.
 
-[Download, verify and install](/using-wasabi/Download&Install.md) the latest `Wasabi-${currentVersion}` package in your VM, then start Wasabi.
+[Download, verify and install](/using-wasabi/InstallPackage.md) the latest `Wasabi-${currentVersion}` package in your VM, then start Wasabi.
 
 __Have fun, and please consider contributing to the Wasabi project!__


### PR DESCRIPTION
This reverts the changes in #1269 #1272 #1278 to not break external links like the guide in our website https://wasabiwallet.io/index.html#download

I will coordinate with @adamPetho to merge this, then merge https://github.com/zkSNACKs/WalletWasabi/pull/9290 and then deploy.