### PR TITLE
Rename HardwareWallet back to ColdWasabi

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -179,7 +179,7 @@ module.exports = {
             "/using-wasabi/Receive.md",
             "/using-wasabi/CoinJoin.md",
             "/using-wasabi/Send.md",
-            "/using-wasabi/HardwareWallet.md",
+            "/using-wasabi/ColdWasabi.md",
             "/using-wasabi/BitcoinFullNode.md"
           ]
         },

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1103,7 +1103,7 @@ It’s part of [BIP 39](https://github.com/bitcoin/bips/blob/master/bip-0039.med
 
 On the ColdCard you go to `> Advanced > MicroSD Card > Wasabi Wallet` and it will save a skeleton json-file to the MicroSD card in the hardware wallet.
 
-Read more [here](/using-wasabi/HardwareWallet.md).
+Read more [here](/using-wasabi/ColdWasabi.md).
 :::
 
 :::details
@@ -1112,7 +1112,7 @@ Read more [here](/using-wasabi/HardwareWallet.md).
 Take the MicroSD card from the ColdCard and plug it in the computer with the Wasabi Wallet software.
 In Wasabi Wallet go to the Wallet Manager, select Hardware Wallet option and in the bottom right corner click `Import Coldcard`.
 Now select the Wasabi skeleton json-file from the MicroSD card, if this fails you can manually enter the file location in Wasabi Wallet window and load the file.
-Read more [here](/using-wasabi/HardwareWallet.md#connecting-via-sd-card).
+Read more [here](/using-wasabi/ColdWasabi.md#connecting-via-sd-card).
 :::
 
 :::details
@@ -1120,7 +1120,7 @@ Read more [here](/using-wasabi/HardwareWallet.md#connecting-via-sd-card).
 
 In Wasabi Wallet you load your previously imported wallet (from Wasabi skeleton, or USB detection) and go to the `Receive` tab, here you enter a label for the observers of the incoming transaction and click `Generate Receive Address`.
 In the tab below the newly generated receive address can be viewed / copied.
-Read more [here](/using-wasabi/HardwareWallet.md).
+Read more [here](/using-wasabi/ColdWasabi.md).
 :::
 
 :::details
@@ -1129,7 +1129,7 @@ Read more [here](/using-wasabi/HardwareWallet.md).
 To send a transaction you will need to connect your hardware wallet and unlock the device (using PIN or password).
 Then go to the `Send` tab where you can specify the address to send to, the amount of bitcoin to spend and which coins to use as inputs.
 After filling in all transaction details you click `Send Transaction` to sign it with the connected hardware wallet and broadcast to the network.
-Read more [here](/using-wasabi/HardwareWallet.md#connecting-via-usb)
+Read more [here](/using-wasabi/ColdWasabi.md#connecting-via-usb)
 :::
 
 :::details
@@ -1139,7 +1139,7 @@ In the Wallet Explorer on the right side of the GUI, select `YourWallet>Advanced
 This brings up the `Build Transaction` tab where you can specify the address, amount of bitcoin and coins to use.
 Then by clicking `Build Transaction` a new tab will open containing the raw transaction data, here you click `Export Binary PSBT` to save the partially signed bitcoin transaction (PSBT) to a file.
 This file should be moved to the MicroSD card that you can then insert in the ColdCard for manual verification and signing.
-Read more [here](/using-wasabi/HardwareWallet.md#connecting-via-sd-card).
+Read more [here](/using-wasabi/ColdWasabi.md#connecting-via-sd-card).
 :::
 
 :::details
@@ -1148,7 +1148,7 @@ Read more [here](/using-wasabi/HardwareWallet.md#connecting-via-sd-card).
 On the ColdCard (Mk2, firmware 2.1.1 and up) you enter the PIN code to unlock the hardware wallet and press `> Ready To Sign` with the MicroSD card containing the previously generated transaction or PSBT-file.
 Verify the address and amount and the ColdCard will then create a signed.psbt and final.txn file on the MicroSD card.
 The finalized transaction (`xxx-final.txn`) can now be broadcast by Wasabi Wallet with the `Broadcast Transaction` tool, or even a radio or satellite dish if someone is listening!
-Read more [here](/using-wasabi/HardwareWallet.md#connecting-via-sd-card).
+Read more [here](/using-wasabi/ColdWasabi.md#connecting-via-sd-card).
 :::
 
 :::details
@@ -1157,7 +1157,7 @@ Read more [here](/using-wasabi/HardwareWallet.md#connecting-via-sd-card).
 In the top menu bar, go to `Tools > Broadcast Transaction` and in this tab click `Import Transaction`, now you can select the previously finalized (and signed) transaction file from the MicroSD card.
 If this fails you can manually type the path to this file in Wasabi Wallet to load the transaction.
 Now click `Broadcast Transaction` to send it off over Tor to a random Bitcoin node so it can flood over to the miners for confirmation in a block.
-Read more [here](/using-wasabi/HardwareWallet.md#connecting-via-sd-card).
+Read more [here](/using-wasabi/ColdWasabi.md#connecting-via-sd-card).
 :::
 
 :::details
@@ -1166,7 +1166,7 @@ Read more [here](/using-wasabi/HardwareWallet.md#connecting-via-sd-card).
 No, that is currently not possible.
 A coinjoin is a multi round interactive process, and requires fast signing by the participants, thus the keys need to be on a hot computer.
 Thus currently you have to send the bitcoins from your hardware wallet to a `hot` Wasabi Wallet, do the coinjoin and then send them back to a new address on the Hardware wallet for cold-storage.
-Read more [here](/using-wasabi/HardwareWallet.md#cold-wasabi-protocol)
+Read more [here](/using-wasabi/ColdWasabi.md#cold-wasabi-protocol)
 :::
 
 :::details

--- a/docs/glossary/Glossary-GeneralBitcoin.md
+++ b/docs/glossary/Glossary-GeneralBitcoin.md
@@ -96,7 +96,7 @@ Refers to keeping a reserve of important Bitcoin secrets offline.
 Cold storage is achieved when Bitcoin private keys are created and stored in a secure offline environment.
 Cold storage is important for anyone with bitcoin holdings.
 Online computers are vulnerable to hackers and should not be used to store a significant amount of bitcoin.
-Read more: [Cold Wasabi Protocol](/using-wasabi/HardwareWallet.md)
+Read more: [Cold Wasabi Protocol](/using-wasabi/ColdWasabi.md)
 :::
 
 :::details

--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -5,7 +5,7 @@
 }
 ---
 
-# Hardware Wallet
+# Cold-Wasabi Hardware Wallet Mode
 
 [[toc]]
 
@@ -18,7 +18,7 @@ Alternatively, you can import a Coldcard skeleton file via SD card.
 2. The `Hardware Wallet` tab will open, and there you can search all connected hardware wallets.
 3. Click `Load Wallet`, then you can [receive](/using-wasabi/Receive.md) bitcoin to addresses controlled by the hardware wallet.
 4. You can [spend](/using-wasabi/Send.md) these coins in the `Send` tab, though the hardware wallet must be connected via USB to confirm before signing the transaction.
-Alternatively, you can [build a PSBT](/using-wasabi/HardwareWallet.md#connecting-coldcard-via-sd-card), export this via SD card to your Coldcard wallet for signing, then import the final transaction to Wasabi for broadcasting.
+Alternatively, you can [build a PSBT](/using-wasabi/ColdWasabi.md#connecting-coldcard-via-sd-card), export this via SD card to your Coldcard wallet for signing, then import the final transaction to Wasabi for broadcasting.
 
 :::warning No CoinJoin
 Unfortunately, as of now, you cannot [CoinJoin](/using-wasabi/CoinJoin.md) with just the private keys on your hardware wallet.

--- a/docs/using-wasabi/README.md
+++ b/docs/using-wasabi/README.md
@@ -28,7 +28,7 @@ Further tutorials about the different parts of the wallet, for newbies and power
 - [Receive](/using-wasabi/Receive.md)
 - [CoinJoin](/using-wasabi/CoinJoin.md)
 - [Send](/using-wasabi/Send.md)
-- [Hardware Wallet](/using-wasabi/HardwareWallet.md)
+- [Hardware Wallet](/using-wasabi/ColdWasabi.md)
 - [Bitcoin Full Node](/using-wasabi/BitcoinFullNode.md)
 
 ### Best Practices


### PR DESCRIPTION
This reverts #1257 to not break external links like https://walletsrecovery.org/
