### PR TITLE
change to apt

### DIFF
--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -61,7 +61,7 @@ For an in-depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.md#de
 
 Verify the signature of the package with `gpg --verify Wasabi-${currentVersion}.deb` and ensure the software was signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
 
-Now install Wasabi with `sudo dpkg -i Wasabi-${currentVersion}.deb`, and run it with `wassabee`.
+Now install Wasabi with `sudo apt install ./Wasabi-${currentVersion}.deb`, and run it with `wassabee`.
 Check out the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#debian-and-ubuntu).
 
 @[youtube](mTrClVA_o5A,122)

--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -75,7 +75,7 @@ If the message returned says `Good signature from zkSNACKs` and that it was sign
 	:::
 
 4. [GUI] Install by double-clicking and follow the GUI Instruction. </br>
-   [CLI] In the Download repository, execute the command `sudo dpkg -i Wasabi-${currentVersion}.deb` to install Wasabi and after that run Wasabi by executing `wassabee`.
+   [CLI] In the Download repository, execute the command `sudo apt install ./Wasabi-${currentVersion}.deb` to install Wasabi and after that run Wasabi by executing `wassabee`.
 
 After the first run, a [data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
 Among others, here is where your wallet files and your logs reside.


### PR DESCRIPTION
`dpkg` is the "wrong" command for installing the package, it does not consider dependency downloads.

`apt` uses `dpkg` but also downloads remote packages.

see https://github.com/zkSNACKs/WalletWasabi/pull/9149 change to apt