### PR TITLE
[Trivial] Remove outdated line about system-wide tor

### DIFF
--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -132,7 +132,6 @@ This will not harm your computer.
 
 No, because Wasabi has Tor built into the software.
 All Wasabi network traffic goes via Tor by default - no need to set up Tor yourself.
-If you do already have Tor, and it is running, then Wasabi will try to use that first.
 
 You can turn off Tor in the Settings.
 Be careful, as this will compromise your privacy.


### PR DESCRIPTION
WW2 can't use system-wide Tor.

The exact behavior that is happening on WW2 is: 
`We use a non-standard SOCKS5 port and non-standard Tor control port, so it's not possible to use pre-installed system-wide Tor (by chance)`
and
`Tor bundled with Wasabi Wallet is running  (it was not shut down last time), then we use that instance.`
But these are technicalities, removing the line would do the job.
*Thanks Kimi for the explanation*

FTR, having no info is better than having incorrect info. We should push similar fixes (delete) for outdated infos in the docs that are now incorrect.
