### PR TITLE
Fix message when silicon chip uses intel package

### DIFF
--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -123,7 +123,7 @@ With the architecture that Wasabi uses, these two different processors need thei
 :::details
 ### What happens when I install the wrong package for macOS?
 
-Wasabi won't start or it will crash on startup.
+Wasabi will crash on startup or run significantly slower than it should.
 This will not harm your computer.
 :::
 


### PR DESCRIPTION
Currently, it's wrong.
If I install the Intel package on my m2 it does not crash. It's just slower and uses more ressources because of Rosetta.

Also, can someone tries to run the Wasabi m1 package on an intel mac? Because from what I understand about macOs packages, and according to [this](https://www.maketecheasier.com/run-m1-mac-app-as-intel-app/), it should work as normal.