### PR TITLE
FAQInstall: rename upgrade to update

### DIFF
--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -165,10 +165,10 @@ The "Other Linux" option is just a generic install method not targeted to Debian
 There's no difference in the code, the same binaries are being delivered in different formats.
 :::
 
-## Upgrade Wasabi
+## Update Wasabi
 
 :::details
-### Why should I upgrade Wasabi?
+### Why should I update Wasabi?
 
 Wasabi is cutting edge software and is being worked on by the developers on a daily basis.
 Once in a while (+- every month) all the changes/improvements are being released in a new Wasabi version.


### PR DESCRIPTION
update seems better fit
also to match the GUI: "Update available"

as this is a new section it doesn't break any links, 
except for _How do I securly upgrade Wasabi?_, so I didn't touch that one