### PR TITLE
update FAQ mac processor types

### DIFF
--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -113,9 +113,9 @@ Check out the main documentation for a [step-by-step guide](/using-wasabi/Instal
 :::
 
 :::details
-### Why are there two different packages for macOS (intel and M1)?
+### Why are there two different packages for macOS (intel and Apple Silicon)?
 
-Intel and M1 are two different processors that Apple uses for their computers.
+Intel and Apple Silicon are two different processors types that Apple uses for their computers.
 These processors work a bit differently from each other. 
 With the architecture that Wasabi uses, these two different processors need their own specific code binary in order to make it work.
 :::


### PR DESCRIPTION
breaks links,
but title should still be changed
link damage should be limited as it's a (relatively) new FAQ