### PR TITLE
add FAQ headless daemon

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -323,6 +323,10 @@ If you are doing a re-synchronization because you expect some missing funds, but
 No.
 Wasabi client doesn't work with pruned nodes.
 
+### Can I run a Wasabi headless daemon?
+
+No, currently that is not posssible.
+
 ## Receive
 
 ### Why is it bad to re-use addresses?


### PR DESCRIPTION
I put it at _synchronization_, I think that's the best place.
_General_ section is already pretty cluttered