### PR TITLE
fix external link icon color darkmode

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -77,6 +77,9 @@ html.dark {
     -webkit-backdrop-filter: saturate(180%) blur(20px);
     backdrop-filter: saturate(180%) blur(20px);
 	}
+	.external-link-icon {
+		--external-link-icon-color: none;
+	}
 }
 html:not(.dark){
 	--c-text-light: var(--c-text) !important;


### PR DESCRIPTION
it's not really visible
make it black aswell

![image](https://github.com/zkSNACKs/WasabiDoc/assets/93143998/3de7524c-6273-48e8-872d-d8d0d52c1488)
