### PR TITLE
Rewrite entry for mininal requirements and add one for supported OS

### DIFF
--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -202,5 +202,5 @@ For the complete list of all the officially supported operating systems, click [
 As long as your operating system is [supported](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-operating-systems), Wasabi should be able to run on your hardware.
 The more transactions a wallet has made, the more resources Wasabi will consume, particularly RAM.
 The software can also consume a significant amount of CPU for specific tasks, such as coinjoins or wallet loading.
-Approximately 3 GB of disk space are also, mainly to store the [block filters](/FAQ/FAQ-UseWasabi.md#what-are-bip-158-block-filters).
+Approximately 3 GB of disk space are also needed, mainly to store the [block filters](/FAQ/FAQ-UseWasabi.md#what-are-bip-158-block-filters).
 If you are running the wallet on a system with scarce resources, consider using the [daemon](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Daemon) instead of the GUI application.

--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -192,7 +192,15 @@ However WabiSabi defines its own mixing technique: [WabiSabi coinjoin](/using-wa
 
 For more info please see [WabiSabi](https://github.com/zksnacks/wabisabi).
 
-### What are the minimal requirements to run Wasabi?
+### What are the supported operating systems?
 
 Wasabi runs in most operating systems with 64-bit architecture.
 For the complete list of all the officially supported operating systems, click [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-operating-systems).
+
+### What are the minimal requirements to run Wasabi?
+
+As long as your operating system is [supported](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-operating-systems), Wasabi should be able to run on your hardware.
+The more transactions a wallet has made, the more resources Wasabi will consume, particularly RAM.
+The software can also consume a significant amount of CPU for specific tasks, such as coinjoins or wallet loading.
+Approximately 3 GB of disk space are also required to store the [block filters](/FAQ/FAQ-UseWasabi.md#what-are-bip-158-block-filters).
+If you are running the wallet on a system with scarce resources, consider using the [daemon](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Daemon) instead of the GUI application.

--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -202,5 +202,5 @@ For the complete list of all the officially supported operating systems, click [
 As long as your operating system is [supported](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-operating-systems), Wasabi should be able to run on your hardware.
 The more transactions a wallet has made, the more resources Wasabi will consume, particularly RAM.
 The software can also consume a significant amount of CPU for specific tasks, such as coinjoins or wallet loading.
-Approximately 3 GB of disk space are also required to store the [block filters](/FAQ/FAQ-UseWasabi.md#what-are-bip-158-block-filters).
+Approximately 3 GB of disk space are also, mainly to store the [block filters](/FAQ/FAQ-UseWasabi.md#what-are-bip-158-block-filters).
 If you are running the wallet on a system with scarce resources, consider using the [daemon](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Daemon) instead of the GUI application.


### PR DESCRIPTION
The reason for this change is that minimal requirements implies OS + hardware, but with.the wording and considering that the searchbar ONLY searches for the title I was always having a hard time to find this [document](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-operating-systems) from the doc. 

So basically this PR is useful to find information about this by searching for "minimal requirements" and "supported operating systems" from the searchbar.