### PR TITLE
update coin list FAQ

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -599,25 +599,6 @@ At the transaction fee slider dialog, click on `Advanced` and manually type the 
 
 ![Wasabi Wallet custom fee rate](/SendCustomFee.png "Wasabi Wallet custom fee rate")
 
-### How do I select coins for spending?
-
-In the normal send workflow, Wasabi automatically selects which coins to send.
-
-To send a specific coin, the user can use the `Wallet Coins` dialog (a.k.a coinlist).
-The coinlist can be brought up by pressing the keyboard combination `CTRL` + `C` + `D` simultaneously on the main view or via the search bar.
-
-:::warning This is for advanced usage only
-Users should stick to the default send workflow.
-Misusing the coinlist for sending can result in critical privacy risks.
-:::
-
-![Wallet Coins Send Selected Coins](/WalletCoinsSendSelectedCoins.png "Wallet Coins Send Selected Coins")
-
-:::warning This is not coin control
-You can only send coins in full.
-There is no possiblity to enter a bitcoin amount or receive change.
-:::
-
 ### How does Wasabi select which coins to send?
 
 If the user has coins with the same label as the recipient of the outgoing transaction (coins received in the past from the same recipient), then Wasabi automatically selects these coins.

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1410,6 +1410,24 @@ Do NOT use the manual coin control if you do not know what you are doing.
 Misusing it can have seriously bad privacy consequences.
 :::
 
+### How can I see my wallet's coins?
+
+The `Wallet Coins` dialog (a.k.a coinlist) can be brought up by pressing the keyboard combination `CTRL` + `C` + `D` simultaneously on the main view or via the search bar.
+
+At the coinlist it is possible to select and send specific coins.
+
+:::warning Sending coins via the coinlist is for advanced usage only
+Users should stick to the default send workflow.
+Misusing the coinlist for sending can result in critical privacy risks.
+:::
+
+![Wallet Coins Send Selected Coins](/WalletCoinsSendSelectedCoins.png "Wallet Coins Send Selected Coins")
+
+:::warning This is not coin control
+You can only send coins in full.
+There is no possiblity to enter a bitcoin amount or receive change.
+:::
+
 ### Can I consolidate anonset coins?
 
 It is advisable to limit the recombining of mixed coins because it can only decrease the privacy of these coins.


### PR DESCRIPTION
- remove it from `Send` section (it was added there when there was no coin control yet)
- rephrase the question from `how select coins for sending` to `How can I see my wallet's coins`
- kept the image there and mentioning of using it for sending, as that for some cases can still be handy