### PR TITLE
add warning to speeding up tx which has unconfirmed cj outputs

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -691,6 +691,10 @@ Read more [here](/using-wasabi/Send.md#speed-up-or-cancel-transaction).
 
 > The _Speed Up Transaction_ tool is not available for coinjoins, or when using a hardware wallet.
 
+:::warning
+Wasabi currently doesn't take into account if the transaction contains unconfirmed coinjoin outputs and that the speeding up will have little to no effect.
+:::
+
 ### How can I cancel a pending/unconfirmed transaction?
 
 A pending (unconfirmed) transaction can be cancelled by using the _Cancel Transaction_ feature which will send a new transaction with a higher fee rate to replace the current one.


### PR DESCRIPTION
it's a bit of a bug, and we have to mention it all the time in support

so good to mention it here.

suggestions on how to improve the text welcome,
don't want to scare people either, like saying they are wasting/burning their speed up fees in this case