### PR TITLE
daemon: Remove params from daemon executable

### DIFF
--- a/docs/using-wasabi/Daemon.md
+++ b/docs/using-wasabi/Daemon.md
@@ -51,7 +51,7 @@ wassabeed
 
 ### If building from source code
 
-Open the terminal, navigate to the WalletWasabi.Daemon directory (inside the cloned repository) and execute the desired commands.
+Open the terminal, navigate to the _WalletWasabi.Daemon_ directory (inside the cloned repository) and execute the desired commands.
 
 ```bash
 $ dotnet run

--- a/docs/using-wasabi/Daemon.md
+++ b/docs/using-wasabi/Daemon.md
@@ -32,21 +32,21 @@ Depending on your operating system, open the command line and execute:
 #### Linux
 
 ```bash
-wassabeed --wallet=WalletName --jsonrpcserverenabled=true
+wassabeed
 ```
 
 #### macOS
 
 ```bash
 cd /Applications/Wasabi\ Wallet.app/Contents/MacOs
-./wassabeed --wallet=WalletName --jsonrpcserverenabled=true
+./wassabeed
 ```
 
 #### Windows
 
 ```bash
 cd C:\Program Files\WasabiWallet
-wassabeed --wallet=WalletName --jsonrpcserverenabled=true
+wassabeed
 ```
 
 ### If building from source code
@@ -54,7 +54,7 @@ wassabeed --wallet=WalletName --jsonrpcserverenabled=true
 Open the terminal, navigate to the WalletWasabi.Daemon directory (inside the cloned repository) and execute the desired commands.
 
 ```bash
-$ dotnet run --wallet=WalletName --jsonrpcserverenabled=true
+$ dotnet run
 ```
 
 ## Examples


### PR DESCRIPTION
some people think that these params are mandatory to run the daemon.
so remove them, to prevent confusion. better to have only the minimal executable there.

having some params at the examples is good enough.