### PR TITLE
update wallet creation workflow

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -47,9 +47,8 @@ There are 4 options:
 Select _Create a new wallet_.
 
 Now follow the next few steps/dialogs: 
-- Give the wallet a name.
 - Write down the recovery words. (do not share these with anyone!)
-- Add a password. (do not forget it and also write it down on a separate place from the recovery words, without your password you cannot send your bitcoin!)
+- Add a password. (do not forget it and also write it down on a separate place from the recovery words, without your password you cannot open your wallet and send your bitcoin!)
 - Select the coinjoin strategy: we select the default one `Maximize Speed`.
 
 :::danger
@@ -60,10 +59,6 @@ The Recovery words can never be shown again.
 The password cannot be changed later on.
 If you lose your password you lose your bitcoin.
 :::
-
-## Open Wallet
-
-Now open the wallet by entering the password.
 
 ## Receive bitcoin
 

--- a/docs/using-wasabi/WalletGeneration.md
+++ b/docs/using-wasabi/WalletGeneration.md
@@ -26,6 +26,7 @@ The very first time you run the software the `Add Wallet` dialog will be open au
 
 3. Give the wallet a name.
 This name is not shared with anyone, it is only stored locally on your computer.
+(If there are no wallets then this step is skipped and the new wallet will automatically be named _Wallet_)
 Click `Continue`.
 
 ![Add Wallet Wallet Name](/AddWalletWalletName.png "Add Wallet Wallet Name")


### PR DESCRIPTION
closes https://github.com/zkSNACKs/WasabiDoc/issues/1651

removed _Give the wallet a name_ & _Open wallet_ in the `Getting Started` guide, as this is aimed for first time usage.
at other places, like wallet generation in Use FAQ, I kept it.

put a small note at `Wallet Generation`