### PR TITLE
RPC: listcoins remove old error

### DIFF
--- a/docs/using-wasabi/RPC.md
+++ b/docs/using-wasabi/RPC.md
@@ -272,19 +272,6 @@ curl -s --data-binary '{"jsonrpc":"2.0","id":"1","method":"listcoins"}' http://1
 }
 ```
 
-In case there is no wallet open it will return:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "error": {
-    "code": -32603,
-    "message": "There is no wallet loaded."
-  },
-  "id": "1"
-}
-```
-
 ### listunspentcoins
 
 Returns the list of confirmed and unconfirmed coins that are unspent.


### PR DESCRIPTION
in that case it returns 
```
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32603,
    "message": "Wallet name is invalid or not allowed."
  },
  "id": "1"
}
```

which is self explanatory, as the wallet name should be specified with every call (which was not previously, years ago)