### PR TITLE
add hyperlink to walletsrecovery website

### DIFF
--- a/docs/using-wasabi/ExternalRestore.md
+++ b/docs/using-wasabi/ExternalRestore.md
@@ -29,7 +29,7 @@ Here are major wallets you can use to recover a Wasabi Wallet for Segwit address
 - Sparrow
 - Specter Desktop
 
-For a complete list of compatible wallets, see here: https://walletsrecovery.org
+For a complete list of compatible wallets, see here: [https://walletsrecovery.org](https://walletsrecovery.org).
 
 ## Compatibility List for Taproot Addresses (bc1p)
 


### PR DESCRIPTION
Having it without a hyperlink seems like a mistake.

---

<img width="741" height="237" alt="image" src="https://github.com/user-attachments/assets/c09b747f-6514-4b32-8d6d-255df6a676a3" />

