### PR TITLE
docs: add Coldcard Mk3 seed-entropy warning to ColdWasabi

### DIFF
--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -9,7 +9,7 @@
 
 [[toc]]
 
-:::warning Coldcard seed-entropy advisory (July 2026)
+:::danger Coldcard seed-entropy advisory (July 2026)
 Coinkite disclosed a firmware flaw that reduced generated seed entropy on **Coldcard Mk3** (firmware 4.0.1–5.0.3) and pre-fix **Mk4/Q**.
 Seeds generated without extra dice rolls may be brute-forceable.
 Update to fixed firmware, generate a new seed and move your funds.

--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -9,6 +9,10 @@
 
 [[toc]]
 
+:::warning Coldcard seed-entropy advisory (July 2026)
+Coinkite disclosed a firmware flaw that reduced generated-seed entropy on **Coldcard Mk3** (firmware 4.0.1–5.0.3) and pre-fix **Mk4/Q**. Seeds generated on-device without extra dice rolls may be brute-forceable. Update to fixed firmware, generate a new seed and move your funds. See the [Coinkite advisory](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/).
+:::
+
 ## Using hardware wallet step-by-step
 
 1. Start your Wasabi Wallet and go to `Add Wallet`.

--- a/docs/using-wasabi/ColdWasabi.md
+++ b/docs/using-wasabi/ColdWasabi.md
@@ -10,7 +10,10 @@
 [[toc]]
 
 :::warning Coldcard seed-entropy advisory (July 2026)
-Coinkite disclosed a firmware flaw that reduced generated-seed entropy on **Coldcard Mk3** (firmware 4.0.1–5.0.3) and pre-fix **Mk4/Q**. Seeds generated on-device without extra dice rolls may be brute-forceable. Update to fixed firmware, generate a new seed and move your funds. See the [Coinkite advisory](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/).
+Coinkite disclosed a firmware flaw that reduced generated seed entropy on **Coldcard Mk3** (firmware 4.0.1–5.0.3) and pre-fix **Mk4/Q**.
+Seeds generated without extra dice rolls may be brute-forceable.
+Update to fixed firmware, generate a new seed and move your funds.
+See the [Coinkite advisory](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/).
 :::
 
 ## Using hardware wallet step-by-step


### PR DESCRIPTION
## Summary

Adds a `:::warning` box near the top of `docs/using-wasabi/ColdWasabi.md`.

In July 2026 Coinkite [disclosed](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/) a firmware build error that reduced generated-seed entropy on **Coldcard Mk3** (firmware 4.0.1–5.0.3) and pre-fix **Mk4/Q**. The existing security notes on this page cover privacy and address verification but not seed entropy. This adds a sourced warning linking the advisory. Docs-only change; not asking to remove Coldcard support.

Refs #2112.
